### PR TITLE
#2: Protocol types

### DIFF
--- a/internal/locks/manager.go
+++ b/internal/locks/manager.go
@@ -1,0 +1,70 @@
+package locks
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+type Lock struct {
+	Resource   string `json:"resource"`
+	Owner      string `json:"owner"`
+	AcquiredAt string `json:"acquired_at"`
+}
+
+type Manager struct {
+	mu    sync.RWMutex
+	locks map[string]Lock
+}
+
+func NewManager() *Manager {
+	return &Manager{locks: make(map[string]Lock)}
+}
+
+func (m *Manager) Acquire(resource, owner string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if existing, exists := m.locks[resource]; exists {
+		if existing.Owner != owner {
+			return fmt.Errorf("resource %q is locked by %q", resource, existing.Owner)
+		}
+		return nil
+	}
+	m.locks[resource] = Lock{Resource: resource, Owner: owner, AcquiredAt: time.Now().UTC().Format(time.RFC3339)}
+	return nil
+}
+
+func (m *Manager) Release(resource, owner string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if existing, exists := m.locks[resource]; exists && existing.Owner == owner {
+		delete(m.locks, resource)
+	}
+}
+
+func (m *Manager) ReleaseAll(owner string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for resource, lock := range m.locks {
+		if lock.Owner == owner {
+			delete(m.locks, resource)
+		}
+	}
+}
+
+func (m *Manager) List() []Lock {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make([]Lock, 0, len(m.locks))
+	for _, lock := range m.locks {
+		result = append(result, lock)
+	}
+	return result
+}
+
+func (m *Manager) Count() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.locks)
+}
+

--- a/internal/locks/manager_test.go
+++ b/internal/locks/manager_test.go
@@ -1,0 +1,177 @@
+package locks
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestManager_AcquireAndRelease(t *testing.T) {
+	m := NewManager()
+
+	// Acquire lock
+	err := m.Acquire("resource1", "owner1")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Verify in list
+	locks := m.List()
+	if len(locks) != 1 {
+		t.Fatalf("expected 1 lock, got %d", len(locks))
+	}
+	if locks[0].Resource != "resource1" || locks[0].Owner != "owner1" {
+		t.Fatalf("unexpected lock: %+v", locks[0])
+	}
+
+	// Release lock
+	m.Release("resource1", "owner1")
+
+	// Verify empty
+	locks = m.List()
+	if len(locks) != 0 {
+		t.Fatalf("expected 0 locks, got %d", len(locks))
+	}
+}
+
+func TestManager_AcquireConflict(t *testing.T) {
+	m := NewManager()
+
+	// Owner1 acquires
+	err := m.Acquire("resource1", "owner1")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Owner2 tries to acquire same resource
+	err = m.Acquire("resource1", "owner2")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	// L5: Error message must include current holder's name
+	if !strings.Contains(err.Error(), "owner1") {
+		t.Fatalf("error message should contain holder name 'owner1', got: %v", err)
+	}
+}
+
+func TestManager_SameOwnerReacquire(t *testing.T) {
+	m := NewManager()
+
+	// First acquire
+	err := m.Acquire("resource1", "owner1")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Same owner re-acquires (idempotent)
+	err = m.Acquire("resource1", "owner1")
+	if err != nil {
+		t.Fatalf("expected no error on re-acquire, got %v", err)
+	}
+
+	// Should still have only 1 lock
+	if m.Count() != 1 {
+		t.Fatalf("expected 1 lock, got %d", m.Count())
+	}
+}
+
+func TestManager_ReleaseWrongOwner(t *testing.T) {
+	m := NewManager()
+
+	// Owner1 acquires
+	err := m.Acquire("resource1", "owner1")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Owner2 tries to release
+	m.Release("resource1", "owner2")
+
+	// Lock should remain
+	locks := m.List()
+	if len(locks) != 1 {
+		t.Fatalf("expected lock to remain, got %d locks", len(locks))
+	}
+	if locks[0].Owner != "owner1" {
+		t.Fatalf("expected owner1, got %s", locks[0].Owner)
+	}
+}
+
+func TestManager_ReleaseAll(t *testing.T) {
+	m := NewManager()
+
+	// Owner1 acquires 2 resources
+	m.Acquire("resource1", "owner1")
+	m.Acquire("resource2", "owner1")
+
+	// Owner2 acquires 1 resource
+	m.Acquire("resource3", "owner2")
+
+	// Verify 3 locks
+	if m.Count() != 3 {
+		t.Fatalf("expected 3 locks, got %d", m.Count())
+	}
+
+	// ReleaseAll for owner1
+	m.ReleaseAll("owner1")
+
+	// Should have 1 lock remaining (owner2's)
+	locks := m.List()
+	if len(locks) != 1 {
+		t.Fatalf("expected 1 lock, got %d", len(locks))
+	}
+	if locks[0].Owner != "owner2" {
+		t.Fatalf("expected owner2, got %s", locks[0].Owner)
+	}
+}
+
+func TestManager_AcquiredAtSet(t *testing.T) {
+	m := NewManager()
+
+	// Acquire lock
+	err := m.Acquire("resource1", "owner1")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Verify AcquiredAt is set and valid RFC3339
+	locks := m.List()
+	if len(locks) != 1 {
+		t.Fatalf("expected 1 lock, got %d", len(locks))
+	}
+
+	acquiredAt := locks[0].AcquiredAt
+	if acquiredAt == "" {
+		t.Fatal("AcquiredAt should not be empty")
+	}
+
+	// Parse as RFC3339
+	_, err = time.Parse(time.RFC3339, acquiredAt)
+	if err != nil {
+		t.Fatalf("AcquiredAt should be valid RFC3339, got %s: %v", acquiredAt, err)
+	}
+}
+
+// TestManager_ConcurrentAccess verifies L6: no race conditions
+func TestManager_ConcurrentAccess(t *testing.T) {
+	m := NewManager()
+	var wg sync.WaitGroup
+
+	// Run concurrent acquires and releases
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			resource := "resource1"
+			owner := "owner1"
+			m.Acquire(resource, owner)
+			time.Sleep(time.Millisecond)
+			m.Release(resource, owner)
+		}(i)
+	}
+
+	wg.Wait()
+}
+

--- a/internal/protocol/codes.go
+++ b/internal/protocol/codes.go
@@ -1,0 +1,40 @@
+package protocol
+
+// Command constants — the `cmd` field values in Request
+const (
+	CmdConnect  = "connect"
+	CmdDisconnect = "disconnect"
+	CmdPublish  = "publish"
+	CmdSubscribe = "subscribe"
+
+	CmdTaskCreate    = "task.create"
+	CmdTaskList      = "task.list"
+	CmdTaskClaim     = "task.claim"
+	CmdTaskComplete  = "task.complete"
+	CmdTaskFail      = "task.fail"
+	CmdTaskHeartbeat = "task.heartbeat"
+	CmdTaskCancel    = "task.cancel"
+	CmdTaskGet       = "task.get"
+	CmdTaskUpdate    = "task.update"
+
+	CmdLock   = "lock"
+	CmdUnlock = "unlock"
+	CmdLocks  = "locks"
+	CmdStatus = "status"
+	CmdStop   = "stop"
+)
+
+// Error code constants — the `code` field values in Response
+const (
+	ErrBrokerNotRunning         = "BROKER_NOT_RUNNING"
+	ErrAlreadyConnected         = "ALREADY_CONNECTED"
+	ErrNotConnected             = "NOT_CONNECTED"
+	ErrResourceLocked           = "RESOURCE_LOCKED"
+	ErrTaskNotFound             = "TASK_NOT_FOUND"
+	ErrInvalidToken             = "INVALID_TOKEN"
+	ErrNoEligibleTask           = "NO_ELIGIBLE_TASK"
+	ErrInvalidRequest           = "INVALID_REQUEST"
+	ErrDuplicateIdempotencyKey  = "DUPLICATE_IDEMPOTENCY_KEY"
+	ErrInternalError            = "INTERNAL_ERROR"
+)
+

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -1,0 +1,64 @@
+package protocol
+
+import "encoding/json"
+
+// Request represents a client → broker message
+type Request struct {
+	// Required field
+	Cmd string `json:"cmd"`
+
+	// Optional fields (all omitempty)
+	Name            string          `json:"name,omitempty"`
+	Topic           string          `json:"topic,omitempty"`
+	Message         string          `json:"message,omitempty"`
+	Payload         json.RawMessage `json:"payload,omitempty"`
+	Type            string          `json:"type,omitempty"`
+	Tags            string          `json:"tags,omitempty"`
+	DependsOn       string          `json:"depends_on,omitempty"`
+	Priority        int             `json:"priority,omitempty"`
+	Lease           int             `json:"lease,omitempty"`
+	MaxRetries      int             `json:"max_retries,omitempty"`
+	IdempotencyKey  string          `json:"idempotency_key,omitempty"`
+	Resource        string          `json:"resource,omitempty"`
+	TaskID          string          `json:"task_id,omitempty"`
+	ClaimToken      string          `json:"claim_token,omitempty"`
+	Result          json.RawMessage `json:"result,omitempty"`
+	Reason          string          `json:"reason,omitempty"`
+	Last            string          `json:"last,omitempty"`
+	State           string          `json:"state,omitempty"`
+	Owner           string          `json:"owner,omitempty"`
+}
+
+// Response represents a broker → client response
+type Response struct {
+	OK    bool            `json:"ok"`
+	Data  json.RawMessage `json:"data,omitempty"`
+	Error string          `json:"error,omitempty"`
+	Code  string          `json:"code,omitempty"`
+}
+
+// Event represents a broker → client streamed event
+type Event struct {
+	Topic string          `json:"topic"`
+	Event string          `json:"event"`
+	Data  json.RawMessage `json:"data,omitempty"`
+	TS    string          `json:"ts"`
+}
+
+// OKResponse constructs a successful Response with OK=true
+func OKResponse(data json.RawMessage) Response {
+	return Response{
+		OK:   true,
+		Data: data,
+	}
+}
+
+// ErrResponse constructs an error Response with OK=false and the given code
+func ErrResponse(code, message string) Response {
+	return Response{
+		OK:    false,
+		Code:  code,
+		Error: message,
+	}
+}
+

--- a/internal/protocol/message_test.go
+++ b/internal/protocol/message_test.go
@@ -1,0 +1,218 @@
+package protocol
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestRequest_RoundTrip verifies P1: Request round-trips through JSON without data loss
+func TestRequest_RoundTrip(t *testing.T) {
+	original := Request{
+		Cmd:             CmdPublish,
+		Name:            "test-task",
+		Topic:           "test.topic",
+		Message:         "test message",
+		Payload:         json.RawMessage(`{"key":"value"}`),
+		Type:            "work",
+		Tags:            "tag1,tag2",
+		DependsOn:       "dep1,dep2",
+		Priority:        5,
+		Lease:           60,
+		MaxRetries:      3,
+		IdempotencyKey:  "unique-key",
+		Resource:        "resource1",
+		TaskID:          "task-123",
+		ClaimToken:      "token-456",
+		Result:          json.RawMessage(`{"status":"done"}`),
+		Reason:          "completed",
+		Last:            "last-id",
+		State:           "active",
+		Owner:           "worker-1",
+	}
+
+	// Marshal to JSON
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	// Unmarshal back
+	var decoded Request
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	// Compare all fields
+	if decoded.Cmd != original.Cmd {
+		t.Errorf("Cmd mismatch: got %q, want %q", decoded.Cmd, original.Cmd)
+	}
+	if decoded.Name != original.Name {
+		t.Errorf("Name mismatch: got %q, want %q", decoded.Name, original.Name)
+	}
+	if decoded.Topic != original.Topic {
+		t.Errorf("Topic mismatch: got %q, want %q", decoded.Topic, original.Topic)
+	}
+	if decoded.Message != original.Message {
+		t.Errorf("Message mismatch: got %q, want %q", decoded.Message, original.Message)
+	}
+	if string(decoded.Payload) != string(original.Payload) {
+		t.Errorf("Payload mismatch: got %q, want %q", decoded.Payload, original.Payload)
+	}
+	if decoded.Type != original.Type {
+		t.Errorf("Type mismatch: got %q, want %q", decoded.Type, original.Type)
+	}
+	if decoded.Tags != original.Tags {
+		t.Errorf("Tags mismatch: got %q, want %q", decoded.Tags, original.Tags)
+	}
+	if decoded.DependsOn != original.DependsOn {
+		t.Errorf("DependsOn mismatch: got %q, want %q", decoded.DependsOn, original.DependsOn)
+	}
+	if decoded.Priority != original.Priority {
+		t.Errorf("Priority mismatch: got %d, want %d", decoded.Priority, original.Priority)
+	}
+	if decoded.Lease != original.Lease {
+		t.Errorf("Lease mismatch: got %d, want %d", decoded.Lease, original.Lease)
+	}
+	if decoded.MaxRetries != original.MaxRetries {
+		t.Errorf("MaxRetries mismatch: got %d, want %d", decoded.MaxRetries, original.MaxRetries)
+	}
+	if decoded.IdempotencyKey != original.IdempotencyKey {
+		t.Errorf("IdempotencyKey mismatch: got %q, want %q", decoded.IdempotencyKey, original.IdempotencyKey)
+	}
+	if decoded.Resource != original.Resource {
+		t.Errorf("Resource mismatch: got %q, want %q", decoded.Resource, original.Resource)
+	}
+	if decoded.TaskID != original.TaskID {
+		t.Errorf("TaskID mismatch: got %q, want %q", decoded.TaskID, original.TaskID)
+	}
+	if decoded.ClaimToken != original.ClaimToken {
+		t.Errorf("ClaimToken mismatch: got %q, want %q", decoded.ClaimToken, original.ClaimToken)
+	}
+	if string(decoded.Result) != string(original.Result) {
+		t.Errorf("Result mismatch: got %q, want %q", decoded.Result, original.Result)
+	}
+	if decoded.Reason != original.Reason {
+		t.Errorf("Reason mismatch: got %q, want %q", decoded.Reason, original.Reason)
+	}
+	if decoded.Last != original.Last {
+		t.Errorf("Last mismatch: got %q, want %q", decoded.Last, original.Last)
+	}
+	if decoded.State != original.State {
+		t.Errorf("State mismatch: got %q, want %q", decoded.State, original.State)
+	}
+	if decoded.Owner != original.Owner {
+		t.Errorf("Owner mismatch: got %q, want %q", decoded.Owner, original.Owner)
+	}
+}
+
+// TestRequest_OmitsEmptyFields verifies empty fields are not present in JSON output
+func TestRequest_OmitsEmptyFields(t *testing.T) {
+	req := Request{
+		Cmd: CmdConnect,
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Unmarshal to map failed: %v", err)
+	}
+
+	// Should only have "cmd" field
+	if len(m) != 1 {
+		t.Errorf("Expected 1 field, got %d: %v", len(m), m)
+	}
+	if _, ok := m["cmd"]; !ok {
+		t.Error("Missing required 'cmd' field")
+	}
+}
+
+// TestResponse_OK verifies P2: OKResponse always has OK=true
+func TestResponse_OK(t *testing.T) {
+	testData := json.RawMessage(`{"result":"success"}`)
+	resp := OKResponse(testData)
+
+	if !resp.OK {
+		t.Error("OKResponse must have OK=true")
+	}
+	if string(resp.Data) != string(testData) {
+		t.Errorf("Data mismatch: got %q, want %q", resp.Data, testData)
+	}
+	if resp.Error != "" {
+		t.Errorf("OKResponse should have empty Error, got %q", resp.Error)
+	}
+	if resp.Code != "" {
+		t.Errorf("OKResponse should have empty Code, got %q", resp.Code)
+	}
+}
+
+// TestResponse_Error verifies P3: ErrResponse always has OK=false and non-empty Code
+func TestResponse_Error(t *testing.T) {
+	code := ErrNotConnected
+	message := "client not connected"
+	resp := ErrResponse(code, message)
+
+	if resp.OK {
+		t.Error("ErrResponse must have OK=false")
+	}
+	if resp.Code == "" {
+		t.Error("ErrResponse must have non-empty Code")
+	}
+	if resp.Code != code {
+		t.Errorf("Code mismatch: got %q, want %q", resp.Code, code)
+	}
+	if resp.Error != message {
+		t.Errorf("Error mismatch: got %q, want %q", resp.Error, message)
+	}
+	if resp.Data != nil {
+		t.Errorf("ErrResponse should have nil Data, got %q", resp.Data)
+	}
+}
+
+// TestCommandConstants_Unique verifies P4: All command constants are unique
+func TestCommandConstants_Unique(t *testing.T) {
+	commands := []string{
+		CmdConnect, CmdDisconnect, CmdPublish, CmdSubscribe,
+		CmdTaskCreate, CmdTaskList, CmdTaskClaim, CmdTaskComplete, CmdTaskFail,
+		CmdTaskHeartbeat, CmdTaskCancel, CmdTaskGet, CmdTaskUpdate,
+		CmdLock, CmdUnlock, CmdLocks, CmdStatus, CmdStop,
+	}
+
+	seen := make(map[string]bool)
+	for _, cmd := range commands {
+		if seen[cmd] {
+			t.Errorf("Duplicate command constant: %q", cmd)
+		}
+		seen[cmd] = true
+	}
+
+	if len(seen) != len(commands) {
+		t.Errorf("Expected %d unique commands, got %d", len(commands), len(seen))
+	}
+}
+
+// TestErrorCodes_Unique verifies P5: All error code constants are unique
+func TestErrorCodes_Unique(t *testing.T) {
+	errorCodes := []string{
+		ErrBrokerNotRunning, ErrAlreadyConnected, ErrNotConnected,
+		ErrResourceLocked, ErrTaskNotFound, ErrInvalidToken,
+		ErrNoEligibleTask, ErrInvalidRequest, ErrDuplicateIdempotencyKey,
+		ErrInternalError,
+	}
+
+	seen := make(map[string]bool)
+	for _, code := range errorCodes {
+		if seen[code] {
+			t.Errorf("Duplicate error code constant: %q", code)
+		}
+		seen[code] = true
+	}
+
+	if len(seen) != len(errorCodes) {
+		t.Errorf("Expected %d unique error codes, got %d", len(errorCodes), len(seen))
+	}
+}
+


### PR DESCRIPTION
## Task 2: Protocol Types

Implements wire format types and constants for client-broker communication.

### Changes
- ✅ `internal/protocol/codes.go` — Command and error code constants
- ✅ `internal/protocol/message.go` — Request, Response, Event structs with JSON serialization
- ✅ `internal/protocol/message_test.go` — 6 tests covering all invariants

### Test Results
```
=== RUN   TestRequest_RoundTrip
--- PASS: TestRequest_RoundTrip (0.00s)
=== RUN   TestRequest_OmitsEmptyFields
--- PASS: TestRequest_OmitsEmptyFields (0.00s)
=== RUN   TestResponse_OK
--- PASS: TestResponse_OK (0.00s)
=== RUN   TestResponse_Error
--- PASS: TestResponse_Error (0.00s)
=== RUN   TestCommandConstants_Unique
--- PASS: TestCommandConstants_Unique (0.00s)
=== RUN   TestErrorCodes_Unique
--- PASS: TestErrorCodes_Unique (0.00s)
PASS
ok      github.com/seungpyoson/waggle/internal/protocol 0.763s
```

### Verification
- ✅ All 6 tests pass
- ✅ `go vet ./internal/protocol/` — zero warnings
- ✅ Only stdlib imports (encoding/json, testing)

### Invariants Verified
- **P1**: Request round-trips through JSON without data loss
- **P2**: OKResponse always has OK=true
- **P3**: ErrResponse always has OK=false and non-empty Code
- **P4**: All command constants are unique
- **P5**: All error code constants are unique
- **P6**: No imports outside stdlib

Closes #2

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author