### PR TITLE
#8: Client library

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/seungpyoson/waggle/internal/config"
 	"github.com/seungpyoson/waggle/internal/protocol"
 )
 
@@ -23,8 +24,9 @@ func Connect(socketPath string) (*Client, error) {
 	}
 
 	scanner := bufio.NewScanner(conn)
-	// Set 1MB buffer to handle large payloads (default is 64KB)
-	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	// Use configurable buffer size for large payloads (default 1MB, vs 64KB default)
+	bufSize := int(config.Defaults.MaxMessageSize)
+	scanner.Buffer(make([]byte, bufSize), bufSize)
 
 	return &Client{
 		conn:    conn,

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -22,14 +22,27 @@ func TestClient_SendAndReceive(t *testing.T) {
 	defer ln.Close()
 
 	go func() {
-		conn, _ := ln.Accept()
+		conn, err := ln.Accept()
+		if err != nil {
+			t.Errorf("mock server accept: %v", err)
+			return
+		}
 		defer conn.Close()
 		buf := make([]byte, 4096)
-		conn.Read(buf)
+		if _, err := conn.Read(buf); err != nil {
+			t.Errorf("mock server read: %v", err)
+			return
+		}
 		resp := protocol.OKResponse(json.RawMessage(`{"id":1}`))
-		data, _ := json.Marshal(resp)
+		data, err := json.Marshal(resp)
+		if err != nil {
+			t.Errorf("mock server marshal: %v", err)
+			return
+		}
 		data = append(data, '\n')
-		conn.Write(data)
+		if _, err := conn.Write(data); err != nil {
+			t.Errorf("mock server write: %v", err)
+		}
 	}()
 
 	c, err := Connect(sockPath)
@@ -64,7 +77,11 @@ func TestClient_ReadStream(t *testing.T) {
 	defer ln.Close()
 
 	go func() {
-		conn, _ := ln.Accept()
+		conn, err := ln.Accept()
+		if err != nil {
+			t.Errorf("mock server accept: %v", err)
+			return
+		}
 		defer conn.Close()
 		// Send 3 events
 		for i := 1; i <= 3; i++ {
@@ -74,9 +91,16 @@ func TestClient_ReadStream(t *testing.T) {
 				Data:  json.RawMessage(fmt.Sprintf(`{"num":%d}`, i)),
 				TS:    "2024-01-01T00:00:00Z",
 			}
-			data, _ := json.Marshal(event)
+			data, err := json.Marshal(event)
+			if err != nil {
+				t.Errorf("mock server marshal event %d: %v", i, err)
+				return
+			}
 			data = append(data, '\n')
-			conn.Write(data)
+			if _, err := conn.Write(data); err != nil {
+				t.Errorf("mock server write event %d: %v", i, err)
+				return
+			}
 		}
 	}()
 
@@ -121,19 +145,34 @@ func TestClient_LargePayload(t *testing.T) {
 	largeData := strings.Repeat("x", 100*1024) // 100KB
 
 	go func() {
-		conn, _ := ln.Accept()
+		conn, err := ln.Accept()
+		if err != nil {
+			t.Errorf("mock server accept: %v", err)
+			return
+		}
 		defer conn.Close()
-		
+
 		// Read request
 		scanner := bufio.NewScanner(conn)
 		scanner.Buffer(make([]byte, 1024*1024), 1024*1024) // 1MB buffer
-		scanner.Scan()
-		
+		if !scanner.Scan() {
+			if err := scanner.Err(); err != nil {
+				t.Errorf("mock server scan: %v", err)
+			}
+			return
+		}
+
 		// Send large response
 		resp := protocol.OKResponse(json.RawMessage(fmt.Sprintf(`{"data":"%s"}`, largeData)))
-		data, _ := json.Marshal(resp)
+		data, err := json.Marshal(resp)
+		if err != nil {
+			t.Errorf("mock server marshal: %v", err)
+			return
+		}
 		data = append(data, '\n')
-		conn.Write(data)
+		if _, err := conn.Write(data); err != nil {
+			t.Errorf("mock server write: %v", err)
+		}
 	}()
 
 	c, err := Connect(sockPath)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ var Defaults = struct {
 	ShutdownTimeout time.Duration
 	PollInterval    time.Duration
 	MaxLogSize      int64
+	MaxMessageSize  int64
 	LeaseDuration   time.Duration
 	MaxRetries      int
 }{
@@ -32,6 +33,7 @@ var Defaults = struct {
 	ShutdownTimeout: 5 * time.Second,
 	PollInterval:    500 * time.Millisecond,
 	MaxLogSize:      10 * 1024 * 1024,
+	MaxMessageSize:  1024 * 1024, // 1MB buffer for large AI agent payloads
 	LeaseDuration:   5 * time.Minute,
 	MaxRetries:      3,
 }


### PR DESCRIPTION
## Summary

Implements client library for connecting to broker socket and sending/receiving messages.

## Changes

### Protocol Types (Task 2 dependency)
- `internal/protocol/codes.go` — Command and error code constants
- `internal/protocol/message.go` — Request, Response, Event types with JSON serialization

### Client Library
- `internal/client/client.go` — Client struct with methods:
  - `Connect(socketPath)` — Connect to Unix domain socket
  - `Send(req)` — Send request and read response
  - `Receive()` — Read one response
  - `ReadStream()` — Stream events (for subscribe)
  - `Close()` — Close connection
- `internal/client/client_test.go` — 4 comprehensive tests

## Test Results

```
=== RUN   TestClient_SendAndReceive
--- PASS: TestClient_SendAndReceive (0.00s)
=== RUN   TestClient_ConnectFail
--- PASS: TestClient_ConnectFail (0.00s)
=== RUN   TestClient_ReadStream
--- PASS: TestClient_ReadStream (0.00s)
=== RUN   TestClient_LargePayload
--- PASS: TestClient_LargePayload (0.00s)
PASS
ok      github.com/seungpyoson/waggle/internal/client   0.760s
```

## Verification

- ✅ All 4 tests pass
- ✅ `go vet ./internal/client/` — zero warnings
- ✅ Large payload test (>64KB) passes
- ✅ bufio.Scanner buffer set to 1MB
- ✅ Race detector clean

## Key Implementation Details

- **Large payload support:** Set `bufio.Scanner` buffer to 1MB (default is 64KB) to handle AI agent payloads
- **NDJSON protocol:** All messages are newline-delimited JSON
- **Stream support:** `ReadStream()` returns a channel for event streaming
- **Error handling:** Proper error wrapping with context

Closes #8

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author