### PR TITLE
#7: Lease checker

### DIFF
--- a/internal/tasks/lease.go
+++ b/internal/tasks/lease.go
@@ -1,0 +1,28 @@
+package tasks
+
+import (
+	"log"
+	"time"
+)
+
+// StartLeaseChecker starts a goroutine that periodically checks for expired leases
+// and re-queues them. It runs until the stop channel is closed.
+func StartLeaseChecker(store *Store, interval time.Duration, stop <-chan struct{}) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			count, err := store.RequeueExpiredLeases()
+			if err != nil {
+				log.Printf("lease checker: error requeuing expired leases: %v", err)
+			} else if count > 0 {
+				log.Printf("lease checker: requeued %d expired leases", count)
+			}
+		}
+	}
+}
+

--- a/internal/tasks/lease_test.go
+++ b/internal/tasks/lease_test.go
@@ -1,0 +1,179 @@
+package tasks
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRequeue_ExpiredLease verifies that expired leases are re-queued
+func TestRequeue_ExpiredLease(t *testing.T) {
+	s := newTestStore(t)
+
+	// Create and claim a task
+	s.Create(CreateParams{Payload: `{"test":"data"}`})
+	claimed, err := s.Claim("worker-1", ClaimFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Manually expire the lease by setting lease_expires_at to the past
+	pastTime := time.Now().Add(-1 * time.Minute).UTC().Format(time.RFC3339)
+	_, err = s.db.Exec(`
+		UPDATE tasks
+		SET lease_expires_at = ?
+		WHERE id = ?
+	`, pastTime, claimed.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Requeue expired leases
+	count, err := s.RequeueExpiredLeases()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 requeued, got %d", count)
+	}
+
+	// Verify task is back to pending
+	task, _ := s.Get(claimed.ID)
+	if task.State != StatePending {
+		t.Errorf("state = %q, want %q", task.State, StatePending)
+	}
+	if task.RetryCount != 1 {
+		t.Errorf("retry_count = %d, want 1", task.RetryCount)
+	}
+}
+
+// TestRequeue_MaxRetriesExceeded verifies that tasks exceeding max retries are marked as failed
+func TestRequeue_MaxRetriesExceeded(t *testing.T) {
+	s := newTestStore(t)
+
+	// Create a task with max_retries=3
+	s.Create(CreateParams{Payload: `{"test":"data"}`, MaxRetries: 3})
+	claimed, _ := s.Claim("worker-1", ClaimFilter{})
+
+	// Set retry_count to 2 (one more retry will exceed max)
+	_, err := s.db.Exec(`
+		UPDATE tasks
+		SET retry_count = 2
+		WHERE id = ?
+	`, claimed.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Expire the lease
+	pastTime := time.Now().Add(-1 * time.Minute).UTC().Format(time.RFC3339)
+	_, err = s.db.Exec(`
+		UPDATE tasks
+		SET lease_expires_at = ?
+		WHERE id = ?
+	`, pastTime, claimed.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Requeue expired leases
+	count, err := s.RequeueExpiredLeases()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 processed, got %d", count)
+	}
+
+	// Verify task is marked as failed
+	task, _ := s.Get(claimed.ID)
+	if task.State != StateFailed {
+		t.Errorf("state = %q, want %q", task.State, StateFailed)
+	}
+	if task.FailureReason != "max_retries_exceeded" {
+		t.Errorf("failure_reason = %q, want %q", task.FailureReason, "max_retries_exceeded")
+	}
+	if task.RetryCount != 3 {
+		t.Errorf("retry_count = %d, want 3", task.RetryCount)
+	}
+}
+
+// TestHeartbeat_ExtendsLease verifies that heartbeat extends the lease
+func TestHeartbeat_ExtendsLease(t *testing.T) {
+	s := newTestStore(t)
+	s.Create(CreateParams{Payload: `{}`})
+	claimed, _ := s.Claim("w", ClaimFilter{})
+
+	// Get initial lease expiry
+	initialStr := claimed.LeaseExpiresAt
+	initial, err := time.Parse(time.RFC3339, initialStr)
+	if err != nil {
+		t.Fatalf("parsing initial lease: %v", err)
+	}
+
+	// Wait to ensure time difference
+	time.Sleep(1100 * time.Millisecond)
+
+	// Heartbeat should extend lease
+	err = s.Heartbeat(claimed.ID, claimed.ClaimToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that lease was extended
+	got, _ := s.Get(claimed.ID)
+	newLease, err := time.Parse(time.RFC3339, got.LeaseExpiresAt)
+	if err != nil {
+		t.Fatalf("parsing new lease: %v", err)
+	}
+
+	if !newLease.After(initial) {
+		t.Errorf("lease was not extended: initial=%s, new=%s", initialStr, got.LeaseExpiresAt)
+	}
+}
+
+// TestHeartbeat_InvalidToken verifies that heartbeat fails with invalid token
+func TestHeartbeat_InvalidToken(t *testing.T) {
+	s := newTestStore(t)
+	s.Create(CreateParams{Payload: `{}`})
+	claimed, _ := s.Claim("w", ClaimFilter{})
+
+	err := s.Heartbeat(claimed.ID, "wrong-token")
+	if err == nil {
+		t.Fatal("expected error for invalid token")
+	}
+}
+
+// TestLeaseChecker_Goroutine verifies that the lease checker goroutine works
+func TestLeaseChecker_Goroutine(t *testing.T) {
+	s := newTestStore(t)
+
+	// Create and claim a task
+	s.Create(CreateParams{Payload: `{"test":"data"}`})
+	claimed, _ := s.Claim("worker-1", ClaimFilter{})
+
+	// Manually expire the lease
+	pastTime := time.Now().Add(-1 * time.Minute).UTC().Format(time.RFC3339)
+	_, err := s.db.Exec(`
+		UPDATE tasks
+		SET lease_expires_at = ?
+		WHERE id = ?
+	`, pastTime, claimed.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Start lease checker with short interval
+	stop := make(chan struct{})
+	defer close(stop)
+	go StartLeaseChecker(s, 100*time.Millisecond, stop)
+
+	// Wait for lease checker to run
+	time.Sleep(300 * time.Millisecond)
+
+	// Verify task was re-queued
+	task, _ := s.Get(claimed.ID)
+	if task.State != StatePending {
+		t.Errorf("state = %q, want %q", task.State, StatePending)
+	}
+}
+

--- a/internal/tasks/store.go
+++ b/internal/tasks/store.go
@@ -602,3 +602,60 @@ func (s *Store) RequeueAllClaimed() (int, error) {
 	return int(rows), nil
 }
 
+// RequeueExpiredLeases finds expired leases and re-queues them or marks them as failed
+func (s *Store) RequeueExpiredLeases() (int, error) {
+	now := time.Now().UTC().Format(time.RFC3339)
+	totalCount := 0
+
+	// First, mark tasks that have exceeded max retries as failed
+	res1, err := s.db.Exec(`
+		UPDATE tasks
+		SET state = 'failed',
+		    failure_reason = 'max_retries_exceeded',
+		    retry_count = retry_count + 1,
+		    claimed_by = NULL,
+		    claim_token = NULL,
+		    claimed_at = NULL,
+		    lease_expires_at = NULL,
+		    updated_at = ?
+		WHERE state = 'claimed'
+		  AND lease_expires_at < ?
+		  AND retry_count + 1 >= max_retries
+	`, now, now)
+	if err != nil {
+		return 0, err
+	}
+
+	rows1, err := res1.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	totalCount += int(rows1)
+
+	// Then, re-queue tasks that haven't exceeded max retries
+	res2, err := s.db.Exec(`
+		UPDATE tasks
+		SET state = 'pending',
+		    retry_count = retry_count + 1,
+		    claimed_by = NULL,
+		    claim_token = NULL,
+		    claimed_at = NULL,
+		    lease_expires_at = NULL,
+		    updated_at = ?
+		WHERE state = 'claimed'
+		  AND lease_expires_at < ?
+		  AND retry_count + 1 < max_retries
+	`, now, now)
+	if err != nil {
+		return 0, err
+	}
+
+	rows2, err := res2.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	totalCount += int(rows2)
+
+	return totalCount, nil
+}
+


### PR DESCRIPTION
## Summary

Implements lease expiry checker with heartbeat renewal and re-queue logic for the Waggle pub/sub broker.

## Changes

- **`internal/tasks/lease.go`** - Lease checker goroutine that periodically checks for expired leases
- **`internal/tasks/lease_test.go`** - 5 comprehensive tests covering all lease checker functionality
- **`internal/tasks/store.go`** - Added `RequeueExpiredLeases()` method

## Test Results

```
=== RUN   TestRequeue_ExpiredLease
--- PASS: TestRequeue_ExpiredLease (0.00s)
=== RUN   TestRequeue_MaxRetriesExceeded
--- PASS: TestRequeue_MaxRetriesExceeded (0.00s)
=== RUN   TestHeartbeat_ExtendsLease
--- PASS: TestHeartbeat_ExtendsLease (1.11s)
=== RUN   TestHeartbeat_InvalidToken
--- PASS: TestHeartbeat_InvalidToken (0.00s)
=== RUN   TestLeaseChecker_Goroutine
--- PASS: TestLeaseChecker_Goroutine (0.30s)
PASS
ok  	github.com/seungpyoson/waggle/internal/tasks	2.224s
```

## Verification

✅ All 5 tests pass
✅ `go vet ./internal/tasks/` - zero warnings
✅ Expired leases re-queued with retry_count incremented
✅ Max retries enforced - tasks marked as failed with reason "max_retries_exceeded"
✅ Pre-commit and pre-push hooks passed

Closes #7

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author