### PR TITLE
#6: Task dependencies

### DIFF
--- a/internal/tasks/deps.go
+++ b/internal/tasks/deps.go
@@ -1,0 +1,191 @@
+package tasks
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// ValidateDeps validates that dependencies exist and don't create cycles
+// selfID is the task being updated (0 for new tasks)
+func ValidateDeps(s *Store, dependsOn []int64, selfID int64) error {
+	// Verify all dependencies exist
+	for _, depID := range dependsOn {
+		_, err := s.Get(depID)
+		if err != nil {
+			return fmt.Errorf("dependency task %d not found", depID)
+		}
+	}
+	
+	// Skip cycle check for new tasks (selfID == 0)
+	if selfID == 0 {
+		return nil
+	}
+	
+	// Check for cycles using DFS
+	visited := make(map[int64]bool)
+	for _, depID := range dependsOn {
+		if hasCycle(s, depID, selfID, visited) {
+			return fmt.Errorf("dependency cycle detected")
+		}
+	}
+	
+	return nil
+}
+
+// hasCycle performs DFS to detect if target appears in the dependency chain of start
+func hasCycle(s *Store, start, target int64, visited map[int64]bool) bool {
+	if start == target {
+		return true
+	}
+	
+	if visited[start] {
+		return false
+	}
+	visited[start] = true
+	
+	// Get the task and check its dependencies
+	task, err := s.Get(start)
+	if err != nil {
+		return false
+	}
+	
+	for _, depID := range task.DependsOn {
+		if hasCycle(s, depID, target, visited) {
+			return true
+		}
+	}
+	
+	return false
+}
+
+// ResolveDeps finds and unblocks tasks that were waiting on completedID
+// Returns the list of task IDs that were unblocked
+func ResolveDeps(s *Store, completedID int64) ([]int64, error) {
+	// Find all blocked tasks that depend on completedID
+	// Use json_each() to properly query the JSON array
+	query := `
+		SELECT DISTINCT t.id, t.depends_on
+		FROM tasks t, json_each(t.depends_on) j
+		WHERE t.state = 'pending' AND t.blocked = 1 AND j.value = ?
+	`
+
+	rows, err := s.db.Query(query, completedID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Collect all candidates first (avoid nested queries)
+	type candidate struct {
+		taskID    int64
+		dependsOn []int64
+	}
+	var candidates []candidate
+
+	for rows.Next() {
+		var taskID int64
+		var dependsOnJSON string
+
+		if err := rows.Scan(&taskID, &dependsOnJSON); err != nil {
+			rows.Close()
+			return nil, err
+		}
+
+		// Parse the depends_on array
+		var dependsOn []int64
+		if err := json.Unmarshal([]byte(dependsOnJSON), &dependsOn); err != nil {
+			rows.Close()
+			return nil, err
+		}
+
+		candidates = append(candidates, candidate{taskID: taskID, dependsOn: dependsOn})
+	}
+	rows.Close()
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Now check each candidate
+	var unblocked []int64
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	for _, c := range candidates {
+		// Check if all dependencies are completed
+		allCompleted := true
+		for _, depID := range c.dependsOn {
+			dep, err := s.Get(depID)
+			if err != nil {
+				return nil, err
+			}
+			if dep.State != StateCompleted {
+				allCompleted = false
+				break
+			}
+		}
+
+		// If all dependencies are completed, unblock the task
+		if allCompleted {
+			_, err := s.db.Exec(`
+				UPDATE tasks
+				SET blocked = 0, updated_at = ?
+				WHERE id = ?
+			`, now, c.taskID)
+			if err != nil {
+				return nil, err
+			}
+			unblocked = append(unblocked, c.taskID)
+		}
+	}
+
+	return unblocked, nil
+}
+
+// FailDependents finds and fails all tasks that depend on failedID
+// Returns the list of task IDs that were failed
+func FailDependents(s *Store, failedID int64) ([]int64, error) {
+	// Find all blocked tasks that depend on failedID
+	// Use json_each() to properly query the JSON array
+	query := `
+		SELECT DISTINCT t.id
+		FROM tasks t, json_each(t.depends_on) j
+		WHERE t.state = 'pending' AND t.blocked = 1 AND j.value = ?
+	`
+
+	rows, err := s.db.Query(query, failedID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Collect all task IDs first (avoid nested queries)
+	var taskIDs []int64
+	for rows.Next() {
+		var taskID int64
+		if err := rows.Scan(&taskID); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		taskIDs = append(taskIDs, taskID)
+	}
+	rows.Close()
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Now update all the tasks
+	now := time.Now().UTC().Format(time.RFC3339)
+	for _, taskID := range taskIDs {
+		_, err := s.db.Exec(`
+			UPDATE tasks
+			SET state = 'failed', failure_reason = 'dependency_failed', updated_at = ?
+			WHERE id = ?
+		`, now, taskID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return taskIDs, nil
+}
+

--- a/internal/tasks/deps_test.go
+++ b/internal/tasks/deps_test.go
@@ -1,0 +1,282 @@
+package tasks
+
+import "testing"
+
+// TestDeps_AddDependency verifies that tasks with dependencies start blocked
+func TestDeps_AddDependency(t *testing.T) {
+	s := newTestStore(t)
+	
+	// Create a dependency task
+	dep, err := s.Create(CreateParams{Payload: `{"dep":true}`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	
+	// Create a task that depends on it
+	child, err := s.Create(CreateParams{
+		Payload:   `{"child":true}`,
+		DependsOn: []int64{dep.ID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	
+	// Verify child is blocked
+	if !child.Blocked {
+		t.Error("child should be blocked when it has dependencies")
+	}
+	if child.State != StatePending {
+		t.Errorf("state = %q, want %q", child.State, StatePending)
+	}
+	if len(child.DependsOn) != 1 || child.DependsOn[0] != dep.ID {
+		t.Errorf("depends_on = %v, want [%d]", child.DependsOn, dep.ID)
+	}
+}
+
+// TestDeps_DirectCycle verifies that direct cycles are detected
+func TestDeps_DirectCycle(t *testing.T) {
+	s := newTestStore(t)
+	
+	a, err := s.Create(CreateParams{Payload: `{}`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	
+	// B depends on A — fine
+	b, err := s.Create(CreateParams{
+		Payload:   `{}`,
+		DependsOn: []int64{a.ID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	
+	// Try to make A depend on B — should fail (cycle: A -> B -> A)
+	err = ValidateDeps(s, []int64{b.ID}, a.ID)
+	if err == nil {
+		t.Fatal("expected cycle detection error")
+	}
+}
+
+// TestDeps_IndirectCycle verifies that indirect cycles are detected
+func TestDeps_IndirectCycle(t *testing.T) {
+	s := newTestStore(t)
+	
+	a, err := s.Create(CreateParams{Payload: `{}`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	
+	b, err := s.Create(CreateParams{
+		Payload:   `{}`,
+		DependsOn: []int64{a.ID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	
+	c, err := s.Create(CreateParams{
+		Payload:   `{}`,
+		DependsOn: []int64{b.ID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	
+	// Try to make A depend on C — should fail (cycle: A -> B -> C -> A)
+	err = ValidateDeps(s, []int64{c.ID}, a.ID)
+	if err == nil {
+		t.Fatal("expected cycle detection error for indirect cycle")
+	}
+}
+
+// TestDeps_BlockedTaskNotClaimed verifies that blocked tasks cannot be claimed
+func TestDeps_BlockedTaskNotClaimed(t *testing.T) {
+	s := newTestStore(t)
+	
+	dep, err := s.Create(CreateParams{Payload: `{}`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	
+	child, err := s.Create(CreateParams{
+		Payload:   `{}`,
+		DependsOn: []int64{dep.ID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	
+	// Verify child is blocked
+	if !child.Blocked {
+		t.Fatal("child should be blocked")
+	}
+	
+	// Try to claim — should get the dep, not the child
+	claimed, err := s.Claim("worker", ClaimFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	
+	if claimed.ID == child.ID {
+		t.Error("blocked task should not be claimable")
+	}
+	if claimed.ID != dep.ID {
+		t.Errorf("claimed task ID = %d, want %d (the dependency)", claimed.ID, dep.ID)
+	}
+}
+
+// TestDeps_UnblockOnComplete verifies that completing a dependency unblocks waiting tasks
+func TestDeps_UnblockOnComplete(t *testing.T) {
+	s := newTestStore(t)
+	
+	dep, err := s.Create(CreateParams{Payload: `{"dep":true}`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	
+	child, err := s.Create(CreateParams{
+		Payload:   `{"child":true}`,
+		DependsOn: []int64{dep.ID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	
+	// Verify child is blocked
+	got, err := s.Get(child.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Blocked {
+		t.Fatal("child should be blocked")
+	}
+	
+	// Claim and complete the dependency
+	claimed, err := s.Claim("worker", ClaimFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = s.Complete(claimed.ID, claimed.ClaimToken, `{}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Resolve dependencies
+	unblocked, err := ResolveDeps(s, dep.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(unblocked) != 1 || unblocked[0] != child.ID {
+		t.Errorf("unblocked = %v, want [%d]", unblocked, child.ID)
+	}
+
+	// Verify child is now unblocked
+	got, err = s.Get(child.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Blocked {
+		t.Error("child should be unblocked after dependency completes")
+	}
+}
+
+// TestDeps_UnblockOnFail verifies that failing a dependency fails waiting tasks
+func TestDeps_UnblockOnFail(t *testing.T) {
+	s := newTestStore(t)
+
+	dep, err := s.Create(CreateParams{Payload: `{}`})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	child, err := s.Create(CreateParams{
+		Payload:   `{}`,
+		DependsOn: []int64{dep.ID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Claim and fail the dependency
+	claimed, err := s.Claim("worker", ClaimFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = s.Fail(claimed.ID, claimed.ClaimToken, "error")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Fail dependents
+	failed, err := FailDependents(s, dep.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(failed) != 1 || failed[0] != child.ID {
+		t.Errorf("failed = %v, want [%d]", failed, child.ID)
+	}
+
+	// Verify child is now failed
+	got, err := s.Get(child.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != StateFailed {
+		t.Errorf("state = %q, want %q", got.State, StateFailed)
+	}
+	if got.FailureReason != "dependency_failed" {
+		t.Errorf("failure_reason = %q, want %q", got.FailureReason, "dependency_failed")
+	}
+}
+
+// TestDeps_UnblockOnCancel verifies that canceling a dependency fails waiting tasks
+func TestDeps_UnblockOnCancel(t *testing.T) {
+	s := newTestStore(t)
+
+	dep, err := s.Create(CreateParams{Payload: `{}`})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	child, err := s.Create(CreateParams{
+		Payload:   `{}`,
+		DependsOn: []int64{dep.ID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Cancel the dependency
+	err = s.Cancel(dep.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Fail dependents
+	failed, err := FailDependents(s, dep.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(failed) != 1 || failed[0] != child.ID {
+		t.Errorf("failed = %v, want [%d]", failed, child.ID)
+	}
+
+	// Verify child is now failed
+	got, err := s.Get(child.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != StateFailed {
+		t.Errorf("state = %q, want %q", got.State, StateFailed)
+	}
+	if got.FailureReason != "dependency_failed" {
+		t.Errorf("failure_reason = %q, want %q", got.FailureReason, "dependency_failed")
+	}
+}
+


### PR DESCRIPTION
## Summary

Implements task dependency resolution with cycle detection and block/unblock logic.

## Changes

- **deps.go**: Dependency graph operations
  - `ValidateDeps()` - Cycle detection using DFS (direct and indirect cycles)
  - `ResolveDeps()` - Unblock tasks when all dependencies complete
  - `FailDependents()` - Fail tasks when dependencies fail/cancel

- **deps_test.go**: All 7 required tests
  - TestDeps_AddDependency
  - TestDeps_DirectCycle
  - TestDeps_IndirectCycle
  - TestDeps_BlockedTaskNotClaimed
  - TestDeps_UnblockOnComplete
  - TestDeps_UnblockOnFail
  - TestDeps_UnblockOnCancel

## Implementation Details

- Uses `json_each()` for dependency queries (not LIKE) to avoid false matches
- Blocked tasks cannot be claimed (verified in tests)
- Tasks with dependencies start blocked automatically
- Completing a dependency unblocks waiting tasks only when ALL deps are complete
- Failing/canceling a dependency fails all waiting tasks with reason `dependency_failed`

## Test Results

```
=== RUN   TestDeps_AddDependency
--- PASS: TestDeps_AddDependency (0.00s)
=== RUN   TestDeps_DirectCycle
--- PASS: TestDeps_DirectCycle (0.00s)
=== RUN   TestDeps_IndirectCycle
--- PASS: TestDeps_IndirectCycle (0.00s)
=== RUN   TestDeps_BlockedTaskNotClaimed
--- PASS: TestDeps_BlockedTaskNotClaimed (0.00s)
=== RUN   TestDeps_UnblockOnComplete
--- PASS: TestDeps_UnblockOnComplete (0.00s)
=== RUN   TestDeps_UnblockOnFail
--- PASS: TestDeps_UnblockOnFail (0.00s)
=== RUN   TestDeps_UnblockOnCancel
--- PASS: TestDeps_UnblockOnCancel (0.00s)
PASS
ok  	github.com/seungpyoson/waggle/internal/tasks	0.682s
```

## Verification

- ✅ All 7 tests pass
- ✅ `go vet ./internal/tasks/` - zero warnings
- ✅ Full regression passes with race detector
- ✅ Cycle detection works for both direct and indirect cycles

Closes #6

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author