### PR TITLE
#27: Unify connection handshake for all commands

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"github.com/seungpyoson/waggle/internal/protocol"
 	"github.com/spf13/cobra"
 )
 
@@ -19,28 +18,14 @@ var connectCmd = &cobra.Command{
 	Use:   "connect",
 	Short: "Connect to the broker",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c, err := connectToBroker()
+		c, err := connectToBroker(connectName)
 		if err != nil {
 			printErr("BROKER_NOT_RUNNING", err.Error())
 			return nil
 		}
 		defer c.Close()
 
-		resp, err := c.Send(protocol.Request{
-			Cmd:  protocol.CmdConnect,
-			Name: connectName,
-		})
-		if err != nil {
-			printErr("INTERNAL_ERROR", err.Error())
-			return nil
-		}
-
-		if !resp.OK {
-			printErr(resp.Code, resp.Error)
-			return nil
-		}
-
-		printJSON(resp)
+		printJSON(map[string]any{"ok": true, "data": map[string]string{"name": connectName}})
 		return nil
 	},
 }

--- a/cmd/events.go
+++ b/cmd/events.go
@@ -29,7 +29,7 @@ var subscribeCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		topic := args[0]
 
-		c, err := connectToBroker()
+		c, err := connectToBroker("")
 		if err != nil {
 			printErr("BROKER_NOT_RUNNING", err.Error())
 			return nil
@@ -94,7 +94,7 @@ var publishCmd = &cobra.Command{
 		topic := args[0]
 		message := args[1]
 
-		c, err := connectToBroker()
+		c, err := connectToBroker("")
 		if err != nil {
 			printErr("BROKER_NOT_RUNNING", err.Error())
 			return nil

--- a/cmd/lock.go
+++ b/cmd/lock.go
@@ -18,7 +18,7 @@ var lockCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		resource := args[0]
 
-		c, err := connectToBroker()
+		c, err := connectToBroker("")
 		if err != nil {
 			printErr("BROKER_NOT_RUNNING", err.Error())
 			return nil
@@ -53,7 +53,7 @@ var unlockCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		resource := args[0]
 
-		c, err := connectToBroker()
+		c, err := connectToBroker("")
 		if err != nil {
 			printErr("BROKER_NOT_RUNNING", err.Error())
 			return nil
@@ -85,7 +85,7 @@ var locksCmd = &cobra.Command{
 	Use:   "locks",
 	Short: "List all locks",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c, err := connectToBroker()
+		c, err := connectToBroker("")
 		if err != nil {
 			printErr("BROKER_NOT_RUNNING", err.Error())
 			return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -111,23 +111,12 @@ func printErr(code, message string) {
 	os.Exit(1)
 }
 
-// connectToBroker establishes a connection to the broker
-func connectToBroker() (*client.Client, error) {
-	return client.Connect(paths.Socket)
-}
-
-// getUniqueSessionName generates a unique session name for CLI commands
-// Uses cli-{pid} to ensure each CLI process has a unique session
-// This prevents session conflicts when multiple CLI commands run simultaneously
-func getUniqueSessionName() string {
-	return "cli-" + strconv.Itoa(os.Getpid())
-}
-
-// connectWithSession establishes a connection and creates a session
-// If name is empty, generates a unique session name
-func connectWithSession(name string) (*client.Client, error) {
+// connectToBroker establishes a connection with session handshake.
+// If name is empty, generates a unique session name (cli-{pid}).
+// This is the ONLY way to connect — every command needs a session.
+func connectToBroker(name string) (*client.Client, error) {
 	if name == "" {
-		name = getUniqueSessionName()
+		name = "cli-" + strconv.Itoa(os.Getpid())
 	}
 
 	c, err := client.Connect(paths.Socket)
@@ -135,7 +124,6 @@ func connectWithSession(name string) (*client.Client, error) {
 		return nil, err
 	}
 
-	// Send connect request to establish session
 	resp, err := c.Send(protocol.Request{
 		Cmd:  protocol.CmdConnect,
 		Name: name,

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -13,7 +13,7 @@ var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Check broker status",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c, err := connectToBroker()
+		c, err := connectToBroker("")
 		if err != nil {
 			printErr("BROKER_NOT_RUNNING", err.Error())
 			return nil

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -13,7 +13,7 @@ var stopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop the broker daemon",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c, err := connectToBroker()
+		c, err := connectToBroker("")
 		if err != nil {
 			printErr("BROKER_NOT_RUNNING", err.Error())
 			return nil

--- a/cmd/task_cancel.go
+++ b/cmd/task_cancel.go
@@ -16,7 +16,7 @@ var taskCancelCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		taskID := args[0]
 
-		c, err := connectWithSession("")
+		c, err := connectToBroker("")
 		if err != nil {
 			printErr("BROKER_NOT_RUNNING", err.Error())
 			return nil

--- a/cmd/task_claim.go
+++ b/cmd/task_claim.go
@@ -20,7 +20,7 @@ var taskClaimCmd = &cobra.Command{
 	Use:   "claim",
 	Short: "Claim the next eligible task",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c, err := connectWithSession("")
+		c, err := connectToBroker("")
 		if err != nil {
 			printErr("BROKER_NOT_RUNNING", err.Error())
 			return nil

--- a/cmd/task_complete.go
+++ b/cmd/task_complete.go
@@ -25,7 +25,7 @@ var taskCompleteCmd = &cobra.Command{
 		taskID := args[0]
 		result := args[1]
 
-		c, err := connectWithSession("")
+		c, err := connectToBroker("")
 		if err != nil {
 			printErr("BROKER_NOT_RUNNING", err.Error())
 			return nil

--- a/cmd/task_create.go
+++ b/cmd/task_create.go
@@ -35,7 +35,7 @@ var taskCreateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		payload := args[0]
 
-		c, err := connectWithSession("")
+		c, err := connectToBroker("")
 		if err != nil {
 			printErr("BROKER_NOT_RUNNING", err.Error())
 			return nil

--- a/cmd/task_fail.go
+++ b/cmd/task_fail.go
@@ -23,7 +23,7 @@ var taskFailCmd = &cobra.Command{
 		taskID := args[0]
 		reason := args[1]
 
-		c, err := connectWithSession("")
+		c, err := connectToBroker("")
 		if err != nil {
 			printErr("BROKER_NOT_RUNNING", err.Error())
 			return nil

--- a/cmd/task_get.go
+++ b/cmd/task_get.go
@@ -16,7 +16,7 @@ var taskGetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		taskID := args[0]
 
-		c, err := connectWithSession("")
+		c, err := connectToBroker("")
 		if err != nil {
 			printErr("BROKER_NOT_RUNNING", err.Error())
 			return nil

--- a/cmd/task_heartbeat.go
+++ b/cmd/task_heartbeat.go
@@ -22,7 +22,7 @@ var taskHeartbeatCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		taskID := args[0]
 
-		c, err := connectWithSession("")
+		c, err := connectToBroker("")
 		if err != nil {
 			printErr("BROKER_NOT_RUNNING", err.Error())
 			return nil

--- a/cmd/task_list.go
+++ b/cmd/task_list.go
@@ -22,7 +22,7 @@ var taskListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List tasks",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c, err := connectWithSession("")
+		c, err := connectToBroker("")
 		if err != nil {
 			printErr("BROKER_NOT_RUNNING", err.Error())
 			return nil

--- a/internal/broker/router.go
+++ b/internal/broker/router.go
@@ -10,8 +10,21 @@ import (
 	"github.com/seungpyoson/waggle/internal/tasks"
 )
 
-// route dispatches a request to the appropriate handler
+// Commands that work without a session handshake.
+// Everything else requires connect first.
+var noSessionRequired = map[string]bool{
+	protocol.CmdConnect: true,
+	protocol.CmdStatus:  true,
+	protocol.CmdStop:    true,
+}
+
+// route dispatches a request to the appropriate handler.
+// Session check is enforced here once — individual handlers do not check.
 func route(s *Session, req protocol.Request) protocol.Response {
+	if !noSessionRequired[req.Cmd] && s.name == "" {
+		return protocol.ErrResponse(protocol.ErrNotConnected, "not connected")
+	}
+
 	switch req.Cmd {
 	case protocol.CmdConnect:
 		return handleConnect(s, req)
@@ -85,9 +98,6 @@ func handleSubscribe(s *Session, req protocol.Request) protocol.Response {
 	if req.Topic == "" {
 		return protocol.ErrResponse(protocol.ErrInvalidRequest, "topic required")
 	}
-	if s.name == "" {
-		return protocol.ErrResponse(protocol.ErrNotConnected, "not connected")
-	}
 
 	ch := s.broker.hub.Subscribe(req.Topic, s.name)
 
@@ -108,9 +118,6 @@ func handleSubscribe(s *Session, req protocol.Request) protocol.Response {
 }
 
 func handleTaskCreate(s *Session, req protocol.Request) protocol.Response {
-	if s.name == "" {
-		return protocol.ErrResponse(protocol.ErrNotConnected, "not connected")
-	}
 
 	// Parse tags
 	var tags []string
@@ -152,9 +159,6 @@ func handleTaskCreate(s *Session, req protocol.Request) protocol.Response {
 }
 
 func handleTaskList(s *Session, req protocol.Request) protocol.Response {
-	if s.name == "" {
-		return protocol.ErrResponse(protocol.ErrNotConnected, "not connected")
-	}
 
 	taskList, err := s.broker.store.List(tasks.ListFilter{
 		State: req.State,
@@ -170,9 +174,6 @@ func handleTaskList(s *Session, req protocol.Request) protocol.Response {
 }
 
 func handleTaskClaim(s *Session, req protocol.Request) protocol.Response {
-	if s.name == "" {
-		return protocol.ErrResponse(protocol.ErrNotConnected, "not connected")
-	}
 
 	var tags []string
 	if req.Tags != "" {
@@ -198,9 +199,6 @@ func handleTaskClaim(s *Session, req protocol.Request) protocol.Response {
 }
 
 func handleTaskComplete(s *Session, req protocol.Request) protocol.Response {
-	if s.name == "" {
-		return protocol.ErrResponse(protocol.ErrNotConnected, "not connected")
-	}
 
 	taskID, err := strconv.ParseInt(req.TaskID, 10, 64)
 	if err != nil {
@@ -233,9 +231,6 @@ func handleTaskComplete(s *Session, req protocol.Request) protocol.Response {
 }
 
 func handleTaskFail(s *Session, req protocol.Request) protocol.Response {
-	if s.name == "" {
-		return protocol.ErrResponse(protocol.ErrNotConnected, "not connected")
-	}
 
 	taskID, err := strconv.ParseInt(req.TaskID, 10, 64)
 	if err != nil {
@@ -268,9 +263,6 @@ func handleTaskFail(s *Session, req protocol.Request) protocol.Response {
 }
 
 func handleTaskHeartbeat(s *Session, req protocol.Request) protocol.Response {
-	if s.name == "" {
-		return protocol.ErrResponse(protocol.ErrNotConnected, "not connected")
-	}
 
 	taskID, err := strconv.ParseInt(req.TaskID, 10, 64)
 	if err != nil {
@@ -292,9 +284,6 @@ func handleTaskHeartbeat(s *Session, req protocol.Request) protocol.Response {
 }
 
 func handleTaskCancel(s *Session, req protocol.Request) protocol.Response {
-	if s.name == "" {
-		return protocol.ErrResponse(protocol.ErrNotConnected, "not connected")
-	}
 
 	taskID, err := strconv.ParseInt(req.TaskID, 10, 64)
 	if err != nil {
@@ -317,9 +306,6 @@ func handleTaskCancel(s *Session, req protocol.Request) protocol.Response {
 }
 
 func handleTaskGet(s *Session, req protocol.Request) protocol.Response {
-	if s.name == "" {
-		return protocol.ErrResponse(protocol.ErrNotConnected, "not connected")
-	}
 
 	taskID, err := strconv.ParseInt(req.TaskID, 10, 64)
 	if err != nil {
@@ -336,9 +322,6 @@ func handleTaskGet(s *Session, req protocol.Request) protocol.Response {
 }
 
 func handleLock(s *Session, req protocol.Request) protocol.Response {
-	if s.name == "" {
-		return protocol.ErrResponse(protocol.ErrNotConnected, "not connected")
-	}
 	if req.Resource == "" {
 		return protocol.ErrResponse(protocol.ErrInvalidRequest, "resource required")
 	}
@@ -352,9 +335,6 @@ func handleLock(s *Session, req protocol.Request) protocol.Response {
 }
 
 func handleUnlock(s *Session, req protocol.Request) protocol.Response {
-	if s.name == "" {
-		return protocol.ErrResponse(protocol.ErrNotConnected, "not connected")
-	}
 	if req.Resource == "" {
 		return protocol.ErrResponse(protocol.ErrInvalidRequest, "resource required")
 	}
@@ -364,9 +344,6 @@ func handleUnlock(s *Session, req protocol.Request) protocol.Response {
 }
 
 func handleLocks(s *Session) protocol.Response {
-	if s.name == "" {
-		return protocol.ErrResponse(protocol.ErrNotConnected, "not connected")
-	}
 
 	locks := s.broker.lockMgr.List()
 	data, _ := json.Marshal(locks)


### PR DESCRIPTION
## Summary
- Root fix for lock/events/connect commands returning NOT_CONNECTED
- Router: session check moved to top-level allowlist (connect, status, stop exempt)
- CLI: single `connectToBroker(name)` function replaces dual-path `connectToBroker()`/`connectWithSession()`
- Removed 13 duplicated per-handler session checks
- Fixed connect command double-handshake bug

## Evidence
- `go test ./... -race -count=1 -timeout=120s` — 9 packages, 0 failures
- `go vet ./...` — clean
- Live smoke test: 10/10 commands pass including lock/unlock/locks
- Net -50 lines (36 added, 86 removed)

Closes #27