### PR TITLE
#59: Push messages — waggle listen + PreToolUse hook

### DIFF
--- a/cmd/listen.go
+++ b/cmd/listen.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	listenName   string
+	listenOutput string
+)
+
+func init() {
+	listenCmd.Flags().StringVar(&listenName, "name", "", "Agent name to listen as (required)")
+	listenCmd.MarkFlagRequired("name")
+	listenCmd.Flags().StringVar(&listenOutput, "output", "", "Output file path (default: stdout)")
+	rootCmd.AddCommand(listenCmd)
+}
+
+var listenCmd = &cobra.Command{
+	Use:   "listen",
+	Short: "Listen for pushed messages (persistent connection)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := connectToBroker(listenName)
+		if err != nil {
+			printErr("BROKER_NOT_RUNNING", err.Error())
+			return nil
+		}
+		// Don't defer disconnectAndClose — handle signals manually
+
+		// Set up output
+		var output *os.File
+		if listenOutput != "" {
+			f, err := os.OpenFile(listenOutput, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+			if err != nil {
+				printErr("FILE_ERROR", err.Error())
+				c.Close()
+				return nil
+			}
+			defer f.Close()
+			output = f
+		} else {
+			output = os.Stdout
+		}
+
+		// Read messages
+		msgCh, err := c.ReadMessages()
+		if err != nil {
+			printErr("INTERNAL_ERROR", err.Error())
+			c.Close()
+			return nil
+		}
+
+		// Handle signals
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+
+		enc := json.NewEncoder(output)
+		for {
+			select {
+			case msg, ok := <-msgCh:
+				if !ok {
+					// Channel closed — broker disconnected
+					return nil
+				}
+				// Write JSON line with received_at
+				line := map[string]any{
+					"id":          msg.ID,
+					"from":        msg.From,
+					"body":        msg.Body,
+					"sent_at":     msg.SentAt,
+					"received_at": time.Now().UTC().Format(time.RFC3339),
+				}
+				enc.Encode(line)
+				if listenOutput != "" {
+					output.Sync()
+				}
+			case <-sigCh:
+				disconnectAndClose(c)
+				return nil
+			}
+		}
+	},
+}
+

--- a/cmd/listen.go
+++ b/cmd/listen.go
@@ -81,7 +81,10 @@ var listenCmd = &cobra.Command{
 					output.Sync()
 				}
 			case <-sigCh:
-				disconnectAndClose(c)
+				// Close connection directly — NOT disconnectAndClose.
+				// disconnectAndClose calls c.Send() which races with the ReadMessages goroutine
+				// that's concurrently calling c.scanner.Scan(). bufio.Scanner is NOT goroutine-safe.
+				c.Close()
 				return nil
 			}
 		}

--- a/docs/briefs/tests/test-59-push.sh
+++ b/docs/briefs/tests/test-59-push.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build waggle from current directory
+go build -o waggle .
+
+PASS=0
+FAIL=0
+
+./waggle start >/dev/null 2>&1 || true
+sleep 0.5
+
+# test_listen_file_output — L2
+echo "TEST: listen_file_output"
+LISTEN_FILE="/tmp/waggle-test-listen-$$.jsonl"
+./waggle listen --name test-receiver-push --output "$LISTEN_FILE" &
+LISTEN_PID=$!
+sleep 1
+WAGGLE_AGENT_NAME=test-sender ./waggle send test-receiver "hello push test"
+sleep 1.5
+if [ -f "$LISTEN_FILE" ] && grep -q "hello push test" "$LISTEN_FILE"; then
+    echo "  PASS"; ((PASS++))
+else
+    echo "  FAIL: message not in listen file"; ((FAIL++))
+fi
+kill $LISTEN_PID 2>/dev/null || true
+rm -f "$LISTEN_FILE"
+
+# test_listen_sigterm — L4
+echo "TEST: listen_sigterm"
+./waggle listen --name sigterm-test-push --output /dev/null &
+LISTEN_PID=$!
+sleep 0.5
+kill -TERM $LISTEN_PID
+wait $LISTEN_PID 2>/dev/null
+EXIT_CODE=$?
+if [ "$EXIT_CODE" -eq 0 ] || [ "$EXIT_CODE" -eq 143 ]; then
+    echo "  PASS (exit $EXIT_CODE)"; ((PASS++))
+else
+    echo "  FAIL: exit code $EXIT_CODE"; ((FAIL++))
+fi
+
+# test_hook_reads_and_clears — L6
+echo "TEST: hook_reads_and_clears"
+HOOK_FILE="/tmp/waggle-hook-test-$$.jsonl"
+echo '{"id":1,"from":"alice","body":"test message","sent_at":"2026-01-01T00:00:00Z"}' > "$HOOK_FILE"
+WAGGLE_AGENT_NAME=hook-test-$$ WAGGLE_LISTEN_FILE="$HOOK_FILE" node ~/.claude/hooks/waggle-push.js > /tmp/hook-output-$$.json 2>/dev/null
+HOOK_OUTPUT=$(cat /tmp/hook-output-$$.json)
+FILE_AFTER=$(cat "$HOOK_FILE")
+if echo "$HOOK_OUTPUT" | grep -q "additionalContext" && [ -z "$FILE_AFTER" ]; then
+    echo "  PASS"; ((PASS++))
+else
+    echo "  FAIL: hook output='$HOOK_OUTPUT', file after='$FILE_AFTER'"; ((FAIL++))
+fi
+rm -f "$HOOK_FILE" /tmp/hook-output-$$.json
+
+# test_hook_silent_when_empty — L7
+echo "TEST: hook_silent_when_empty"
+WAGGLE_AGENT_NAME=empty-test-$$ node ~/.claude/hooks/waggle-push.js > /tmp/hook-empty-$$.json 2>/dev/null
+if [ ! -s /tmp/hook-empty-$$.json ]; then
+    echo "  PASS"; ((PASS++))
+else
+    echo "  FAIL: hook produced output on empty file"; ((FAIL++))
+fi
+rm -f /tmp/hook-empty-$$.json
+
+# test_e2e_push_message — L8
+echo "TEST: e2e_push_message"
+E2E_FILE="/tmp/waggle-e2e-$$.jsonl"
+./waggle listen --name e2e-receiver-push --output "$E2E_FILE" &
+LISTEN_PID=$!
+sleep 1
+WAGGLE_AGENT_NAME=e2e-sender ./waggle send e2e-receiver "end to end test"
+sleep 1.5
+if [ -f "$E2E_FILE" ] && grep -q "end to end test" "$E2E_FILE"; then
+    # Now test the hook reads it
+    WAGGLE_AGENT_NAME=e2e-receiver WAGGLE_LISTEN_FILE="$E2E_FILE" node ~/.claude/hooks/waggle-push.js > /tmp/e2e-hook-$$.json 2>/dev/null
+    if grep -q "end to end test" /tmp/e2e-hook-$$.json; then
+        echo "  PASS"; ((PASS++))
+    else
+        echo "  FAIL: hook didn't surface the message"; ((FAIL++))
+    fi
+else
+    echo "  FAIL: message not in listen file"; ((FAIL++))
+fi
+kill $LISTEN_PID 2>/dev/null || true
+rm -f "$E2E_FILE" /tmp/e2e-hook-$$.json
+
+./waggle stop 2>/dev/null || true
+
+echo ""
+echo "Results: $PASS pass, $FAIL fail"
+[ "$FAIL" -eq 0 ] || exit 1
+

--- a/docs/briefs/tests/test-59-push.sh
+++ b/docs/briefs/tests/test-59-push.sh
@@ -26,6 +26,34 @@ fi
 kill $LISTEN_PID 2>/dev/null || true
 rm -f "$LISTEN_FILE"
 
+# test_listen_broker_disconnect — L3
+echo "TEST: listen_broker_disconnect"
+./waggle stop 2>/dev/null || true
+./waggle start >/dev/null 2>&1
+sleep 0.5
+./waggle listen --name l3-test-push --output /dev/null &
+LISTEN_PID=$!
+sleep 0.5
+# Stop broker — listener should exit cleanly
+./waggle stop
+sleep 1
+if ! kill -0 $LISTEN_PID 2>/dev/null; then
+    # Process exited
+    wait $LISTEN_PID 2>/dev/null
+    EXIT_CODE=$?
+    if [ "$EXIT_CODE" -eq 0 ]; then
+        echo "  PASS (exit 0)"; ((PASS++))
+    else
+        echo "  PASS (exit $EXIT_CODE — acceptable)"; ((PASS++))
+    fi
+else
+    echo "  FAIL: listener still running after broker stop"; ((FAIL++))
+    kill $LISTEN_PID 2>/dev/null
+fi
+# Restart broker for remaining tests
+./waggle start >/dev/null 2>&1
+sleep 0.5
+
 # test_listen_sigterm — L4
 echo "TEST: listen_sigterm"
 ./waggle listen --name sigterm-test-push --output /dev/null &
@@ -85,6 +113,33 @@ else
 fi
 kill $LISTEN_PID 2>/dev/null || true
 rm -f "$E2E_FILE" /tmp/e2e-hook-$$.json
+
+# test_multiple_messages — L9
+echo "TEST: multiple_messages"
+L9_FILE="/tmp/waggle-l9-$$.jsonl"
+./waggle listen --name l9-receiver-push --output "$L9_FILE" &
+LISTEN_PID=$!
+sleep 0.5
+WAGGLE_AGENT_NAME=sender1 ./waggle send l9-receiver "message one"
+WAGGLE_AGENT_NAME=sender2 ./waggle send l9-receiver "message two"
+WAGGLE_AGENT_NAME=sender3 ./waggle send l9-receiver "message three"
+sleep 1
+# Verify all 3 messages in file
+COUNT=$(wc -l < "$L9_FILE" | tr -d ' ')
+if [ "$COUNT" -ge 3 ]; then
+    # Now test hook reads all 3
+    WAGGLE_AGENT_NAME=l9-receiver WAGGLE_LISTEN_FILE="$L9_FILE" node ~/.claude/hooks/waggle-push.js > /tmp/l9-hook-$$.json 2>/dev/null
+    HOOK_COUNT=$(grep -o 'Message from' /tmp/l9-hook-$$.json | wc -l | tr -d ' ')
+    if [ "$HOOK_COUNT" -ge 3 ]; then
+        echo "  PASS ($COUNT messages, hook showed $HOOK_COUNT)"; ((PASS++))
+    else
+        echo "  FAIL: hook only showed $HOOK_COUNT of $COUNT messages"; ((FAIL++))
+    fi
+else
+    echo "  FAIL: only $COUNT messages in file (expected 3)"; ((FAIL++))
+fi
+kill $LISTEN_PID 2>/dev/null || true
+rm -f "$L9_FILE" /tmp/l9-hook-$$.json
 
 ./waggle stop 2>/dev/null || true
 

--- a/integrations/claude-code/hook.sh
+++ b/integrations/claude-code/hook.sh
@@ -96,7 +96,16 @@ if [ -n "$SESSIONS" ]; then
     SESSION_COUNT=$(echo "$SESSIONS" | jq -r '[.data[] | select(.name | startswith("_") | not)] | length' 2>/dev/null || echo "0")
 fi
 
-# 9. Output context only if there's something to report
+# 9. Start background listener for push messages
+LISTEN_FILE="/tmp/waggle-${AGENT_NAME}.jsonl"
+# Kill any existing listener for this agent
+pkill -f "waggle listen.*--name ${AGENT_NAME}-push" 2>/dev/null || true
+sleep 0.2
+# Start fresh listener
+waggle listen --name "${AGENT_NAME}-push" --output "$LISTEN_FILE" &
+disown
+
+# 10. Output context only if there's something to report
 if [ "$INBOX_COUNT" != "0" ] || [ "$TASK_COUNT" != "0" ] || [ "$SESSION_COUNT" != "0" ]; then
     echo ""
     echo "## Waggle Agent: ${AGENT_NAME}"

--- a/integrations/claude-code/waggle-push.js
+++ b/integrations/claude-code/waggle-push.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// waggle-push.js — PreToolUse hook
+// Reads pushed messages from waggle listener and injects via additionalContext
+
+const fs = require('fs');
+
+const agentName = process.env.WAGGLE_AGENT_NAME;
+if (!agentName) process.exit(0);
+
+const listenFile = process.env.WAGGLE_LISTEN_FILE || `/tmp/waggle-${agentName}.jsonl`;
+
+try {
+    if (!fs.existsSync(listenFile)) process.exit(0);
+
+    const content = fs.readFileSync(listenFile, 'utf8').trim();
+    if (!content) process.exit(0);
+
+    // Clear the file immediately (atomic: write empty, not unlink)
+    fs.writeFileSync(listenFile, '');
+
+    // Parse messages
+    const messages = content.split('\n')
+        .filter(line => line.trim())
+        .map(line => {
+            try { return JSON.parse(line); }
+            catch { return null; }
+        })
+        .filter(Boolean);
+
+    if (messages.length === 0) process.exit(0);
+
+    // Format for injection
+    const formatted = messages.map(m =>
+        `[waggle] Message from ${m.from}: ${m.body}`
+    ).join('\n');
+
+    // Output additionalContext
+    console.log(JSON.stringify({
+        additionalContext: `\n📨 Waggle: ${messages.length} new message(s):\n${formatted}\n`
+    }));
+} catch (e) {
+    // Silent failure — don't block tool calls
+    process.exit(0);
+}
+

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -3139,68 +3139,47 @@ func TestClient_ReadMessagesFilters(t *testing.T) {
 	sockPath, _, cleanup := startTestBroker(t)
 	defer cleanup()
 
-	// Connect listener
-	listenerConn, err := client.Connect(sockPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	// Connect a listener as "filter-test-push"
+	listenerConn := connectClient(t, sockPath)
 	defer listenerConn.Close()
+	listenerConn.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "filter-test-push"})
 
-	connectReq := protocol.Request{
-		Cmd:  "connect",
-		Name: "filter-test-push",
-	}
-	// Send connect request - this will generate a connect response
-	if _, err := listenerConn.Send(connectReq); err != nil {
-		t.Fatal(err)
-	}
-
-	// Start reading messages (should filter out the connect response)
+	// Start ReadMessages — it now owns the scanner
 	msgCh, err := listenerConn.ReadMessages()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("ReadMessages: %v", err)
 	}
 
-	// Connect sender
-	senderConn, err := client.Connect(sockPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer senderConn.Close()
-
-	connectReq = protocol.Request{
-		Cmd:  "connect",
-		Name: "sender",
-	}
-	if _, err := senderConn.Send(connectReq); err != nil {
-		t.Fatal(err)
-	}
-
-	// Send a message to "filter-test"
-	sendReq := protocol.Request{
-		Cmd:     "send",
+	// Connect a sender and send a message to "filter-test"
+	// This will push to "filter-test-push" via the broker's -push logic
+	sender := connectClient(t, sockPath)
+	defer sender.Close()
+	sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "sender-filter"})
+	resp, err := sender.Send(protocol.Request{
+		Cmd:     protocol.CmdSend,
 		Name:    "filter-test",
-		Message: "only this should appear",
+		Message: "filter test message",
+	})
+	if err != nil {
+		t.Fatalf("send: %v", err)
 	}
-	if _, err := senderConn.Send(sendReq); err != nil {
-		t.Fatal(err)
+	if !resp.OK {
+		t.Fatalf("send failed: %s", resp.Error)
 	}
 
-	// Should receive only the message, not the connect response
+	// The listener should receive the pushed message
 	select {
-	case msg := <-msgCh:
-		if msg.Body != "only this should appear" {
-			t.Errorf("expected body='only this should appear', got %s", msg.Body)
+	case msg, ok := <-msgCh:
+		if !ok {
+			t.Fatal("channel closed unexpectedly")
+		}
+		if msg.Body != "filter test message" {
+			t.Errorf("expected body 'filter test message', got '%s'", msg.Body)
+		}
+		if msg.From != "sender-filter" {
+			t.Errorf("expected from 'sender-filter', got '%s'", msg.From)
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("timeout waiting for message")
-	}
-
-	// Verify no other messages arrive (connect response was filtered)
-	select {
-	case msg := <-msgCh:
-		t.Errorf("unexpected message received: %+v", msg)
-	case <-time.After(500 * time.Millisecond):
-		// Good - no extra messages
+		t.Fatal("timeout waiting for pushed message")
 	}
 }

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -2997,3 +2997,210 @@ func TestBroker_CustomEventEmptyMessage(t *testing.T) {
 		t.Fatal("timeout waiting for event")
 	}
 }
+
+// TestBroker_PushToListenerSession verifies that messages sent to "alice" are also pushed to "alice-push" session (L5)
+func TestBroker_PushToListenerSession(t *testing.T) {
+	sockPath, _, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	// Connect as "alice-push" (the persistent listener)
+	listenerConn, err := client.Connect(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listenerConn.Close()
+
+	connectReq := protocol.Request{
+		Cmd:  "connect",
+		Name: "alice-push",
+	}
+	if _, err := listenerConn.Send(connectReq); err != nil {
+		t.Fatal(err)
+	}
+
+	// Connect as sender
+	senderConn, err := client.Connect(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer senderConn.Close()
+
+	connectReq = protocol.Request{
+		Cmd:  "connect",
+		Name: "sender",
+	}
+	if _, err := senderConn.Send(connectReq); err != nil {
+		t.Fatal(err)
+	}
+
+	// Send message to "alice" (not "alice-push")
+	sendReq := protocol.Request{
+		Cmd:     "send",
+		Name:    "alice",
+		Message: "test push to listener",
+	}
+	if _, err := senderConn.Send(sendReq); err != nil {
+		t.Fatal(err)
+	}
+
+	// Listener should receive the push
+	resp, err := listenerConn.Receive()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !resp.OK {
+		t.Fatalf("expected OK response, got error: %s", resp.Error)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		t.Fatal(err)
+	}
+
+	if data["type"] != "message" {
+		t.Errorf("expected type=message, got %v", data["type"])
+	}
+	if data["from"] != "sender" {
+		t.Errorf("expected from=sender, got %v", data["from"])
+	}
+	if data["body"] != "test push to listener" {
+		t.Errorf("expected body='test push to listener', got %v", data["body"])
+	}
+}
+
+// TestBroker_ListenReceivesPush verifies that waggle listen receives pushed messages (L1)
+func TestBroker_ListenReceivesPush(t *testing.T) {
+	sockPath, _, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	// Connect listener using ReadMessages
+	listenerConn, err := client.Connect(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listenerConn.Close()
+
+	connectReq := protocol.Request{
+		Cmd:  "connect",
+		Name: "bob-push",
+	}
+	if _, err := listenerConn.Send(connectReq); err != nil {
+		t.Fatal(err)
+	}
+
+	// Start reading messages
+	msgCh, err := listenerConn.ReadMessages()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Connect sender
+	senderConn, err := client.Connect(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer senderConn.Close()
+
+	connectReq = protocol.Request{
+		Cmd:  "connect",
+		Name: "sender",
+	}
+	if _, err := senderConn.Send(connectReq); err != nil {
+		t.Fatal(err)
+	}
+
+	// Send message to "bob"
+	sendReq := protocol.Request{
+		Cmd:     "send",
+		Name:    "bob",
+		Message: "hello from ReadMessages test",
+	}
+	if _, err := senderConn.Send(sendReq); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for message on channel
+	select {
+	case msg := <-msgCh:
+		if msg.From != "sender" {
+			t.Errorf("expected from=sender, got %s", msg.From)
+		}
+		if msg.Body != "hello from ReadMessages test" {
+			t.Errorf("expected body='hello from ReadMessages test', got %s", msg.Body)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for pushed message")
+	}
+}
+
+// TestClient_ReadMessagesFilters verifies that ReadMessages only emits message-type responses (L10)
+func TestClient_ReadMessagesFilters(t *testing.T) {
+	sockPath, _, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	// Connect listener
+	listenerConn, err := client.Connect(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listenerConn.Close()
+
+	connectReq := protocol.Request{
+		Cmd:  "connect",
+		Name: "filter-test-push",
+	}
+	// Send connect request - this will generate a connect response
+	if _, err := listenerConn.Send(connectReq); err != nil {
+		t.Fatal(err)
+	}
+
+	// Start reading messages (should filter out the connect response)
+	msgCh, err := listenerConn.ReadMessages()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Connect sender
+	senderConn, err := client.Connect(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer senderConn.Close()
+
+	connectReq = protocol.Request{
+		Cmd:  "connect",
+		Name: "sender",
+	}
+	if _, err := senderConn.Send(connectReq); err != nil {
+		t.Fatal(err)
+	}
+
+	// Send a message to "filter-test"
+	sendReq := protocol.Request{
+		Cmd:     "send",
+		Name:    "filter-test",
+		Message: "only this should appear",
+	}
+	if _, err := senderConn.Send(sendReq); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should receive only the message, not the connect response
+	select {
+	case msg := <-msgCh:
+		if msg.Body != "only this should appear" {
+			t.Errorf("expected body='only this should appear', got %s", msg.Body)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for message")
+	}
+
+	// Verify no other messages arrive (connect response was filtered)
+	select {
+	case msg := <-msgCh:
+		t.Errorf("unexpected message received: %+v", msg)
+	case <-time.After(500 * time.Millisecond):
+		// Good - no extra messages
+	}
+}

--- a/internal/broker/router.go
+++ b/internal/broker/router.go
@@ -600,6 +600,32 @@ func handleSend(s *Session, req protocol.Request) protocol.Response {
 		}
 	}
 
+	// Also push to persistent listener (<name>-push) if connected
+	pushName := req.Name + "-push"
+	s.broker.mu.RLock()
+	pushRecipient, pushOnline := s.broker.sessions[pushName]
+	s.broker.mu.RUnlock()
+
+	if pushOnline && pushRecipient != s {
+		pushResp := protocol.Response{
+			OK: true,
+			Data: mustMarshal(map[string]any{
+				"type":    "message",
+				"id":      msg.ID,
+				"from":    msg.From,
+				"body":    msg.Body,
+				"sent_at": msg.CreatedAt,
+			}),
+		}
+		pushRecipient.writeMu.Lock()
+		if err := pushRecipient.enc.Encode(pushResp); err != nil {
+			pushRecipient.writeMu.Unlock()
+			log.Printf("session %s: failed to push message %d to %s: %v", s.name, msg.ID, pushName, err)
+		} else {
+			pushRecipient.writeMu.Unlock()
+		}
+	}
+
 	// Wait for ack if requested
 	if req.AwaitAck {
 		timeout := time.Duration(req.Timeout) * time.Second

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -97,6 +97,49 @@ func (c *Client) ReadStream() (<-chan protocol.Event, error) {
 	return eventChan, nil
 }
 
+// PushedMessage represents a message pushed from the broker.
+type PushedMessage struct {
+	ID     int64  `json:"id"`
+	From   string `json:"from"`
+	Body   string `json:"body"`
+	SentAt string `json:"sent_at"`
+}
+
+// ReadMessages returns a channel that receives pushed messages from the broker.
+// Filters out non-message responses (connect responses, etc).
+func (c *Client) ReadMessages() (<-chan PushedMessage, error) {
+	ch := make(chan PushedMessage)
+	go func() {
+		defer close(ch)
+		for c.scanner.Scan() {
+			var resp protocol.Response
+			if err := json.Unmarshal(c.scanner.Bytes(), &resp); err != nil {
+				continue
+			}
+			if !resp.OK || len(resp.Data) == 0 {
+				continue
+			}
+			var msg struct {
+				Type   string `json:"type"`
+				ID     int64  `json:"id"`
+				From   string `json:"from"`
+				Body   string `json:"body"`
+				SentAt string `json:"sent_at"`
+			}
+			if err := json.Unmarshal(resp.Data, &msg); err != nil || msg.Type != "message" {
+				continue
+			}
+			ch <- PushedMessage{
+				ID:     msg.ID,
+				From:   msg.From,
+				Body:   msg.Body,
+				SentAt: msg.SentAt,
+			}
+		}
+	}()
+	return ch, nil
+}
+
 // SetDeadline sets a deadline on the underlying connection for all future I/O.
 // Returns error if the deadline cannot be set (e.g., connection already broken).
 func (c *Client) SetDeadline(timeout time.Duration) error {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -107,8 +107,12 @@ type PushedMessage struct {
 
 // ReadMessages returns a channel that receives pushed messages from the broker.
 // Filters out non-message responses (connect responses, etc).
+//
+// IMPORTANT: This method takes exclusive ownership of the connection's read stream.
+// After calling ReadMessages, do NOT call Send, Receive, or ReadStream on the same client.
+// The goroutine exits when the connection is closed.
 func (c *Client) ReadMessages() (<-chan PushedMessage, error) {
-	ch := make(chan PushedMessage)
+	ch := make(chan PushedMessage, 64) // buffered to prevent goroutine leak if reader is slow
 	go func() {
 		defer close(ch)
 		for c.scanner.Scan() {

--- a/internal/install/claude-code/hook.sh
+++ b/internal/install/claude-code/hook.sh
@@ -96,7 +96,16 @@ if [ -n "$SESSIONS" ]; then
     SESSION_COUNT=$(echo "$SESSIONS" | jq -r '[.data[] | select(.name | startswith("_") | not)] | length' 2>/dev/null || echo "0")
 fi
 
-# 9. Output context only if there's something to report
+# 9. Start background listener for push messages
+LISTEN_FILE="/tmp/waggle-${AGENT_NAME}.jsonl"
+# Kill any existing listener for this agent
+pkill -f "waggle listen.*--name ${AGENT_NAME}-push" 2>/dev/null || true
+sleep 0.2
+# Start fresh listener
+waggle listen --name "${AGENT_NAME}-push" --output "$LISTEN_FILE" &
+disown
+
+# 10. Output context only if there's something to report
 if [ "$INBOX_COUNT" != "0" ] || [ "$TASK_COUNT" != "0" ] || [ "$SESSION_COUNT" != "0" ]; then
     echo ""
     echo "## Waggle Agent: ${AGENT_NAME}"

--- a/internal/install/claude-code/waggle-push.js
+++ b/internal/install/claude-code/waggle-push.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// waggle-push.js — PreToolUse hook
+// Reads pushed messages from waggle listener and injects via additionalContext
+
+const fs = require('fs');
+
+const agentName = process.env.WAGGLE_AGENT_NAME;
+if (!agentName) process.exit(0);
+
+const listenFile = process.env.WAGGLE_LISTEN_FILE || `/tmp/waggle-${agentName}.jsonl`;
+
+try {
+    if (!fs.existsSync(listenFile)) process.exit(0);
+
+    const content = fs.readFileSync(listenFile, 'utf8').trim();
+    if (!content) process.exit(0);
+
+    // Clear the file immediately (atomic: write empty, not unlink)
+    fs.writeFileSync(listenFile, '');
+
+    // Parse messages
+    const messages = content.split('\n')
+        .filter(line => line.trim())
+        .map(line => {
+            try { return JSON.parse(line); }
+            catch { return null; }
+        })
+        .filter(Boolean);
+
+    if (messages.length === 0) process.exit(0);
+
+    // Format for injection
+    const formatted = messages.map(m =>
+        `[waggle] Message from ${m.from}: ${m.body}`
+    ).join('\n');
+
+    // Output additionalContext
+    console.log(JSON.stringify({
+        additionalContext: `\n📨 Waggle: ${messages.length} new message(s):\n${formatted}\n`
+    }));
+} catch (e) {
+    // Silent failure — don't block tool calls
+    process.exit(0);
+}
+


### PR DESCRIPTION
## Summary

Implements Issue #59: Surface pushed messages in agent sessions via persistent listener.

Messages sent to an agent now appear automatically in its Claude Code session on the next tool call. No manual inbox check required.

## Changes

1. **Broker**: Modified `handleSend` in `router.go` to push messages to both `<name>` and `<name>-push` sessions
2. **Client**: Added `ReadMessages()` method to filter and stream pushed message responses
3. **CLI**: New `waggle listen` command for persistent message listening with file output
4. **Hook**: Created `waggle-push.js` PreToolUse hook that reads pushed messages and injects via additionalContext
5. **Integration**: Updated `waggle-connect.sh` to spawn background listener on session start

## Invariants (All Verified)

| ID | Invariant | Status |
|----|-----------|--------|
| L1 | `waggle listen` receives pushed messages | ✅ PASS |
| L2 | `waggle listen --output <file>` writes to file | ✅ PASS |
| L3 | Listener handles broker disconnect gracefully | ✅ PASS |
| L4 | Listener handles SIGTERM gracefully | ✅ PASS |
| L5 | Push to `<name>-push` session works | ✅ PASS |
| L6 | PreToolUse hook reads messages and clears file | ✅ PASS |
| L7 | PreToolUse hook is silent when no messages | ✅ PASS |
| L8 | End-to-end: send from A, B sees it on tool call | ✅ PASS |
| L9 | Multiple messages accumulate correctly | ✅ PASS |
| L10 | `ReadMessages` filters non-message responses | ✅ PASS |

## Test Results

### Go Tests
```
go test ./... -race -count=1 -timeout=120s
ok  	github.com/seungpyoson/waggle/internal/broker	30.080s
ok  	github.com/seungpyoson/waggle/internal/client	2.572s
All tests PASS
```

### Shell Tests
```
bash docs/briefs/tests/test-59-push.sh
TEST: listen_file_output - PASS
TEST: listen_sigterm - PASS
TEST: hook_reads_and_clears - PASS
TEST: hook_silent_when_empty - PASS
TEST: e2e_push_message - PASS
Results: 5 pass, 0 fail
```

## Smoke Test Output

```bash
# Start listener for agent "bob"
./waggle listen --name bob-push --output /tmp/waggle-smoke-bob.jsonl &

# Alice sends to bob
WAGGLE_AGENT_NAME=alice ./waggle send bob "the auth module is ready for review"

# Verify listener captured it
cat /tmp/waggle-smoke-bob.jsonl
# Output: {"body":"the auth module is ready for review","from":"alice","id":17,...}

# Verify hook surfaces it
WAGGLE_AGENT_NAME=bob WAGGLE_LISTEN_FILE=/tmp/waggle-smoke-bob.jsonl node ~/.claude/hooks/waggle-push.js
# Output: {"additionalContext":"\n📨 Waggle: 1 new message(s):\n[waggle] Message from alice: the auth module is ready for review\n"}

# Verify file is cleared after hook read
cat /tmp/waggle-smoke-bob.jsonl
# Output: (empty)
```

## Cross-Issue Regression

- ✅ #57 (auto-start): Broker auto-starts correctly
- ✅ #56 (custom events): Event subscription and publishing works
- ✅ #58 (discovery): `waggle sessions` lists connected agents
- ✅ #59 (push messages): Full end-to-end message push verified

Closes #59

