### PR TITLE
Hardening: model runtime status fidelity per watch

### DIFF
--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -251,6 +251,9 @@ func (m *Manager) stopWatch(key watchKey) {
 	m.clearDeliveryStateForWatch(key)
 	m.clearDeliveryError(watchTransportErrorKey(worker.watch))
 	m.clearDeliveryError(watchDeliveryErrorKey(worker.watch.ProjectID, worker.watch.AgentName))
+	if err := m.refreshDeliveryErrorState(worker.watch.ProjectID, worker.watch.AgentName); err != nil {
+		m.captureDeliveryError("delivery-status", fmt.Errorf("refresh delivery status for removed watch %s/%s: %w", worker.watch.ProjectID, worker.watch.AgentName, err))
+	}
 }
 
 func (m *Manager) stopAllWorkers() {
@@ -356,12 +359,14 @@ func (m *Manager) handleDelivery(w Watch, d Delivery) error {
 		if err := m.recordNotificationFailure(currentRecord); err != nil {
 			return err
 		}
-		m.clearDeliveryError(backlogDeliveryErrorKey(w.ProjectID, w.AgentName))
-		m.captureDeliveryError(watchDeliveryErrorKey(w.ProjectID, w.AgentName), fmt.Errorf("notify %s/%s/%d: %w", w.ProjectID, w.AgentName, d.MessageID, err))
+		if err := m.refreshDeliveryErrorState(w.ProjectID, w.AgentName); err != nil {
+			return err
+		}
 		return nil
 	}
-	m.clearDeliveryError(backlogDeliveryErrorKey(w.ProjectID, w.AgentName))
-	m.clearDeliveryError(watchDeliveryErrorKey(w.ProjectID, w.AgentName))
+	if err := m.refreshDeliveryErrorState(w.ProjectID, w.AgentName); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -381,16 +386,17 @@ func (m *Manager) retryPendingNotifications() error {
 		if !ok {
 			continue
 		}
-		errorKey, staleKey := m.deliveryErrorKeys(rec.ProjectID, rec.AgentName)
 		if err := m.notifyRecord(rec.ProjectID, rec.AgentName, rec.MessageID, notificationTitle(Delivery{FromName: rec.FromName}), rec.Body); err != nil {
-			m.clearDeliveryError(staleKey)
-			m.captureDeliveryError(errorKey, fmt.Errorf("notify %s/%s/%d: %w", rec.ProjectID, rec.AgentName, rec.MessageID, err))
 			if recordErr := m.recordNotificationFailure(rec); recordErr != nil && firstErr == nil {
 				firstErr = recordErr
 			}
+			if refreshErr := m.refreshDeliveryErrorState(rec.ProjectID, rec.AgentName); refreshErr != nil && firstErr == nil {
+				firstErr = refreshErr
+			}
 		} else {
-			m.clearDeliveryError(errorKey)
-			m.clearDeliveryError(staleKey)
+			if refreshErr := m.refreshDeliveryErrorState(rec.ProjectID, rec.AgentName); refreshErr != nil && firstErr == nil {
+				firstErr = refreshErr
+			}
 		}
 		release()
 	}
@@ -471,13 +477,37 @@ func backlogDeliveryErrorKey(projectID, agentName string) string {
 	return fmt.Sprintf("backlog-delivery/%s/%s", projectID, agentName)
 }
 
-func (m *Manager) deliveryErrorKeys(projectID, agentName string) (activeKey, staleKey string) {
+func (m *Manager) watchIsActive(projectID, agentName string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.workers[watchKey{projectID: projectID, agentName: agentName}]; ok {
-		return watchDeliveryErrorKey(projectID, agentName), backlogDeliveryErrorKey(projectID, agentName)
+		return true
 	}
-	return backlogDeliveryErrorKey(projectID, agentName), watchDeliveryErrorKey(projectID, agentName)
+	return false
+}
+
+func (m *Manager) refreshDeliveryErrorState(projectID, agentName string) error {
+	hasFailures, err := m.store.HasUnresolvedFailedDeliveries(projectID, agentName)
+	if err != nil {
+		return err
+	}
+	watchKey := watchDeliveryErrorKey(projectID, agentName)
+	backlogKey := backlogDeliveryErrorKey(projectID, agentName)
+	if !hasFailures {
+		m.clearDeliveryError(watchKey)
+		m.clearDeliveryError(backlogKey)
+		return nil
+	}
+
+	errMsg := fmt.Errorf("unresolved delivery failures pending retry for %s/%s", projectID, agentName)
+	if m.watchIsActive(projectID, agentName) {
+		m.clearDeliveryError(backlogKey)
+		m.captureDeliveryError(watchKey, errMsg)
+		return nil
+	}
+	m.clearDeliveryError(watchKey)
+	m.captureDeliveryError(backlogKey, errMsg)
+	return nil
 }
 
 func notificationTitle(d Delivery) string {

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -60,6 +60,7 @@ type Manager struct {
 	wg              sync.WaitGroup
 	started         bool
 	inflight        map[deliveryKey]struct{}
+	pendingFailures map[watchKey]int
 	lastDeliveryErr map[string]error
 	workers         map[watchKey]*watchWorker
 }
@@ -71,6 +72,7 @@ func NewManager(store *Store, factory ListenerFactory, notifier Notifier) *Manag
 		notifier:        notifier,
 		ctx:             context.Background(),
 		inflight:        make(map[deliveryKey]struct{}),
+		pendingFailures: make(map[watchKey]int),
 		lastDeliveryErr: make(map[string]error),
 		workers:         make(map[watchKey]*watchWorker),
 	}
@@ -356,9 +358,12 @@ func (m *Manager) handleDelivery(w Watch, d Delivery) error {
 		}
 	}
 	if err := m.notifyRecord(w.ProjectID, w.AgentName, d.MessageID, notificationTitle(d), d.Body); err != nil {
+		releasePending := m.beginPendingFailure(watchKey{projectID: w.ProjectID, agentName: w.AgentName})
 		if err := m.recordNotificationFailure(currentRecord); err != nil {
+			releasePending()
 			return err
 		}
+		releasePending()
 		if err := m.refreshDeliveryErrorState(w.ProjectID, w.AgentName); err != nil {
 			return err
 		}
@@ -376,29 +381,32 @@ func (m *Manager) retryPendingNotifications() error {
 		return err
 	}
 	var firstErr error
+	affected := make(map[watchKey]struct{})
 	for _, rec := range records {
 		key := deliveryKey{
 			projectID: rec.ProjectID,
 			agentName: rec.AgentName,
 			messageID: rec.MessageID,
 		}
+		watch := watchKey{projectID: rec.ProjectID, agentName: rec.AgentName}
+		affected[watch] = struct{}{}
 		release, ok := m.beginInflight(key)
 		if !ok {
 			continue
 		}
 		if err := m.notifyRecord(rec.ProjectID, rec.AgentName, rec.MessageID, notificationTitle(Delivery{FromName: rec.FromName}), rec.Body); err != nil {
+			releasePending := m.beginPendingFailure(watch)
 			if recordErr := m.recordNotificationFailure(rec); recordErr != nil && firstErr == nil {
 				firstErr = recordErr
 			}
-			if refreshErr := m.refreshDeliveryErrorState(rec.ProjectID, rec.AgentName); refreshErr != nil && firstErr == nil {
-				firstErr = refreshErr
-			}
-		} else {
-			if refreshErr := m.refreshDeliveryErrorState(rec.ProjectID, rec.AgentName); refreshErr != nil && firstErr == nil {
-				firstErr = refreshErr
-			}
+			releasePending()
 		}
 		release()
+	}
+	for watch := range affected {
+		if refreshErr := m.refreshDeliveryErrorState(watch.projectID, watch.agentName); refreshErr != nil && firstErr == nil {
+			firstErr = refreshErr
+		}
 	}
 	if firstErr == nil {
 		m.clearDeliveryError("retry-sweep")
@@ -443,6 +451,7 @@ func (m *Manager) reset() {
 	m.ctx = context.Background()
 	m.started = false
 	m.inflight = make(map[deliveryKey]struct{})
+	m.pendingFailures = make(map[watchKey]int)
 	m.lastDeliveryErr = make(map[string]error)
 	m.workers = make(map[watchKey]*watchWorker)
 }
@@ -491,6 +500,9 @@ func (m *Manager) refreshDeliveryErrorState(projectID, agentName string) error {
 	if err != nil {
 		return err
 	}
+	if !hasFailures && m.hasPendingFailure(watchKey{projectID: projectID, agentName: agentName}) {
+		hasFailures = true
+	}
 	watchKey := watchDeliveryErrorKey(projectID, agentName)
 	backlogKey := backlogDeliveryErrorKey(projectID, agentName)
 	if !hasFailures {
@@ -499,7 +511,7 @@ func (m *Manager) refreshDeliveryErrorState(projectID, agentName string) error {
 		return nil
 	}
 
-	errMsg := fmt.Errorf("unresolved delivery failures pending retry for %s/%s", projectID, agentName)
+	errMsg := fmt.Errorf("unresolved delivery failures for %s/%s", projectID, agentName)
 	if m.watchIsActive(projectID, agentName) {
 		m.clearDeliveryError(backlogKey)
 		m.captureDeliveryError(watchKey, errMsg)
@@ -548,6 +560,7 @@ func (m *Manager) clearDeliveryStateForWatch(key watchKey) {
 			delete(m.inflight, deliveryKey)
 		}
 	}
+	delete(m.pendingFailures, key)
 }
 
 func (m *Manager) recordNotificationFailure(rec DeliveryRecord) error {
@@ -557,6 +570,28 @@ func (m *Manager) recordNotificationFailure(rec DeliveryRecord) error {
 		return m.store.RecordNotificationFailure(rec.ProjectID, rec.AgentName, rec.MessageID, attempts, time.Time{}, now)
 	}
 	return m.store.RecordNotificationFailure(rec.ProjectID, rec.AgentName, rec.MessageID, attempts, now.Add(retryDelayForAttempt(attempts)), time.Time{})
+}
+
+func (m *Manager) beginPendingFailure(key watchKey) func() {
+	m.mu.Lock()
+	m.pendingFailures[key]++
+	m.mu.Unlock()
+
+	return func() {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		if m.pendingFailures[key] <= 1 {
+			delete(m.pendingFailures, key)
+			return
+		}
+		m.pendingFailures[key]--
+	}
+}
+
+func (m *Manager) hasPendingFailure(key watchKey) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.pendingFailures[key] > 0
 }
 
 func retryDelayForAttempt(attempt int) time.Duration {

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -366,14 +366,10 @@ func (m *Manager) handleDelivery(w Watch, d Delivery) error {
 		}
 		m.setDeliveryFailureCause(watchKey{projectID: w.ProjectID, agentName: w.AgentName}, err)
 		releasePending()
-		if err := m.refreshDeliveryErrorState(w.ProjectID, w.AgentName); err != nil {
-			return err
-		}
+		_ = m.refreshWatchDeliveryState(w.ProjectID, w.AgentName)
 		return nil
 	}
-	if err := m.refreshDeliveryErrorState(w.ProjectID, w.AgentName); err != nil {
-		return err
-	}
+	_ = m.refreshWatchDeliveryState(w.ProjectID, w.AgentName)
 	return nil
 }
 
@@ -411,9 +407,7 @@ func (m *Manager) retryPendingNotifications() error {
 		release()
 	}
 	for watch := range affected {
-		if refreshErr := m.refreshDeliveryErrorState(watch.projectID, watch.agentName); refreshErr != nil && firstErr == nil {
-			firstErr = refreshErr
-		}
+		_ = m.refreshWatchDeliveryState(watch.projectID, watch.agentName)
 	}
 	if firstErr == nil {
 		m.clearDeliveryError("retry-sweep")
@@ -579,10 +573,9 @@ func (m *Manager) clearDeliveryStateForWatch(key watchKey) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// stopWatch only owns worker-scoped state. A blocked retry sweep may still hold
-	// an inflight dedupe lock for the same watch/message across remove+re-add, and
-	// clearing it here would allow duplicate concurrent notifications.
-	delete(m.pendingFailures, key)
+	// stopWatch only owns worker-scoped state. Detached retry-sweep state may still
+	// hold inflight dedupe or pending-failure bookkeeping for the same watch/message,
+	// and clearing it here would corrupt state owned by another active path.
 }
 
 func (m *Manager) recordNotificationFailure(rec DeliveryRecord) error {

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -578,11 +578,9 @@ func (m *Manager) clearDeliveryStateForWatch(key watchKey) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	for deliveryKey := range m.inflight {
-		if deliveryKey.projectID == key.projectID && deliveryKey.agentName == key.agentName {
-			delete(m.inflight, deliveryKey)
-		}
-	}
+	// stopWatch only owns worker-scoped state. A blocked retry sweep may still hold
+	// an inflight dedupe lock for the same watch/message across remove+re-add, and
+	// clearing it here would allow duplicate concurrent notifications.
 	delete(m.pendingFailures, key)
 }
 

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -255,6 +255,8 @@ func (m *Manager) stopWatch(key watchKey) {
 	m.clearDeliveryError(watchDeliveryErrorKey(worker.watch.ProjectID, worker.watch.AgentName))
 	if err := m.refreshDeliveryErrorState(worker.watch.ProjectID, worker.watch.AgentName); err != nil {
 		m.captureDeliveryError("delivery-status", fmt.Errorf("refresh delivery status for removed watch %s/%s: %w", worker.watch.ProjectID, worker.watch.AgentName, err))
+	} else {
+		m.clearDeliveryError("delivery-status")
 	}
 }
 
@@ -496,22 +498,22 @@ func (m *Manager) watchIsActive(projectID, agentName string) bool {
 }
 
 func (m *Manager) refreshDeliveryErrorState(projectID, agentName string) error {
-	hasFailures, err := m.store.HasUnresolvedFailedDeliveries(projectID, agentName)
+	summary, err := m.store.DeliveryFailureSummary(projectID, agentName)
 	if err != nil {
 		return err
 	}
-	if !hasFailures && m.hasPendingFailure(watchKey{projectID: projectID, agentName: agentName}) {
-		hasFailures = true
+	if summary.Retrying == 0 && summary.Exhausted == 0 && m.hasPendingFailure(watchKey{projectID: projectID, agentName: agentName}) {
+		summary.Retrying = 1
 	}
 	watchKey := watchDeliveryErrorKey(projectID, agentName)
 	backlogKey := backlogDeliveryErrorKey(projectID, agentName)
-	if !hasFailures {
+	if summary.Retrying == 0 && summary.Exhausted == 0 {
 		m.clearDeliveryError(watchKey)
 		m.clearDeliveryError(backlogKey)
 		return nil
 	}
 
-	errMsg := fmt.Errorf("unresolved delivery failures for %s/%s", projectID, agentName)
+	errMsg := fmt.Errorf("%d unresolved delivery failures for %s/%s (%d retrying, %d exhausted)", summary.Retrying+summary.Exhausted, projectID, agentName, summary.Retrying, summary.Exhausted)
 	if m.watchIsActive(projectID, agentName) {
 		m.clearDeliveryError(backlogKey)
 		m.captureDeliveryError(watchKey, errMsg)

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -359,9 +359,10 @@ func (m *Manager) handleDelivery(w Watch, d Delivery) error {
 	}
 	if err := m.notifyRecord(w.ProjectID, w.AgentName, d.MessageID, notificationTitle(d), d.Body); err != nil {
 		releasePending := m.beginPendingFailure(watchKey{projectID: w.ProjectID, agentName: w.AgentName})
-		if err := m.recordNotificationFailure(currentRecord); err != nil {
+		recordErr := m.recordNotificationFailure(currentRecord)
+		if recordErr != nil {
 			releasePending()
-			return err
+			return recordErr
 		}
 		m.setDeliveryFailureCause(watchKey{projectID: w.ProjectID, agentName: w.AgentName}, err)
 		releasePending()

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -502,6 +502,7 @@ func (m *Manager) refreshDeliveryErrorState(projectID, agentName string) error {
 	if err != nil {
 		return err
 	}
+	m.clearDeliveryError("delivery-status")
 	if summary.Retrying == 0 && summary.Exhausted == 0 && m.hasPendingFailure(watchKey{projectID: projectID, agentName: agentName}) {
 		summary.Retrying = 1
 	}

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -61,6 +61,7 @@ type Manager struct {
 	started         bool
 	inflight        map[deliveryKey]struct{}
 	pendingFailures map[watchKey]int
+	deliveryCauses  map[watchKey]error
 	lastDeliveryErr map[string]error
 	workers         map[watchKey]*watchWorker
 }
@@ -73,6 +74,7 @@ func NewManager(store *Store, factory ListenerFactory, notifier Notifier) *Manag
 		ctx:             context.Background(),
 		inflight:        make(map[deliveryKey]struct{}),
 		pendingFailures: make(map[watchKey]int),
+		deliveryCauses:  make(map[watchKey]error),
 		lastDeliveryErr: make(map[string]error),
 		workers:         make(map[watchKey]*watchWorker),
 	}
@@ -365,6 +367,7 @@ func (m *Manager) handleDelivery(w Watch, d Delivery) error {
 			releasePending()
 			return err
 		}
+		m.setDeliveryFailureCause(watchKey{projectID: w.ProjectID, agentName: w.AgentName}, err)
 		releasePending()
 		if err := m.refreshDeliveryErrorState(w.ProjectID, w.AgentName); err != nil {
 			return err
@@ -398,8 +401,13 @@ func (m *Manager) retryPendingNotifications() error {
 		}
 		if err := m.notifyRecord(rec.ProjectID, rec.AgentName, rec.MessageID, notificationTitle(Delivery{FromName: rec.FromName}), rec.Body); err != nil {
 			releasePending := m.beginPendingFailure(watch)
-			if recordErr := m.recordNotificationFailure(rec); recordErr != nil && firstErr == nil {
-				firstErr = recordErr
+			recordErr := m.recordNotificationFailure(rec)
+			if recordErr != nil {
+				if firstErr == nil {
+					firstErr = recordErr
+				}
+			} else {
+				m.setDeliveryFailureCause(watch, err)
 			}
 			releasePending()
 		}
@@ -454,6 +462,7 @@ func (m *Manager) reset() {
 	m.started = false
 	m.inflight = make(map[deliveryKey]struct{})
 	m.pendingFailures = make(map[watchKey]int)
+	m.deliveryCauses = make(map[watchKey]error)
 	m.lastDeliveryErr = make(map[string]error)
 	m.workers = make(map[watchKey]*watchWorker)
 }
@@ -488,40 +497,41 @@ func backlogDeliveryErrorKey(projectID, agentName string) string {
 	return fmt.Sprintf("backlog-delivery/%s/%s", projectID, agentName)
 }
 
-func (m *Manager) watchIsActive(projectID, agentName string) bool {
+func (m *Manager) refreshDeliveryErrorState(projectID, agentName string) error {
+	key := watchKey{projectID: projectID, agentName: agentName}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if _, ok := m.workers[watchKey{projectID: projectID, agentName: agentName}]; ok {
-		return true
-	}
-	return false
-}
 
-func (m *Manager) refreshDeliveryErrorState(projectID, agentName string) error {
 	summary, err := m.store.DeliveryFailureSummary(projectID, agentName)
 	if err != nil {
 		return err
 	}
-	m.clearDeliveryError("delivery-status")
-	if summary.Retrying == 0 && summary.Exhausted == 0 && m.hasPendingFailure(watchKey{projectID: projectID, agentName: agentName}) {
+	delete(m.lastDeliveryErr, "delivery-status")
+	if summary.Retrying == 0 && summary.Exhausted == 0 && m.pendingFailures[key] > 0 {
 		summary.Retrying = 1
 	}
 	watchKey := watchDeliveryErrorKey(projectID, agentName)
 	backlogKey := backlogDeliveryErrorKey(projectID, agentName)
 	if summary.Retrying == 0 && summary.Exhausted == 0 {
-		m.clearDeliveryError(watchKey)
-		m.clearDeliveryError(backlogKey)
+		delete(m.lastDeliveryErr, watchKey)
+		delete(m.lastDeliveryErr, backlogKey)
+		delete(m.deliveryCauses, key)
 		return nil
 	}
 
-	errMsg := fmt.Errorf("%d unresolved delivery failures for %s/%s (%d retrying, %d exhausted)", summary.Retrying+summary.Exhausted, projectID, agentName, summary.Retrying, summary.Exhausted)
-	if m.watchIsActive(projectID, agentName) {
-		m.clearDeliveryError(backlogKey)
-		m.captureDeliveryError(watchKey, errMsg)
+	errText := fmt.Sprintf("%d unresolved delivery failures for %s/%s (%d retrying, %d exhausted)", summary.Retrying+summary.Exhausted, projectID, agentName, summary.Retrying, summary.Exhausted)
+	if cause := m.deliveryCauses[key]; cause != nil {
+		errText = fmt.Sprintf("%s; last notifier error: %v", errText, cause)
+	}
+	errMsg := fmt.Errorf("%s", errText)
+	if _, active := m.workers[key]; active {
+		delete(m.lastDeliveryErr, backlogKey)
+		m.lastDeliveryErr[watchKey] = errMsg
 		return nil
 	}
-	m.clearDeliveryError(watchKey)
-	m.captureDeliveryError(backlogKey, errMsg)
+	delete(m.lastDeliveryErr, watchKey)
+	m.lastDeliveryErr[backlogKey] = errMsg
 	return nil
 }
 
@@ -591,10 +601,13 @@ func (m *Manager) beginPendingFailure(key watchKey) func() {
 	}
 }
 
-func (m *Manager) hasPendingFailure(key watchKey) bool {
+func (m *Manager) setDeliveryFailureCause(key watchKey, err error) {
+	if err == nil {
+		return
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.pendingFailures[key] > 0
+	m.deliveryCauses[key] = err
 }
 
 func retryDelayForAttempt(attempt int) time.Duration {

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -255,11 +255,7 @@ func (m *Manager) stopWatch(key watchKey) {
 	m.clearDeliveryStateForWatch(key)
 	m.clearDeliveryError(watchTransportErrorKey(worker.watch))
 	m.clearDeliveryError(watchDeliveryErrorKey(worker.watch.ProjectID, worker.watch.AgentName))
-	if err := m.refreshDeliveryErrorState(worker.watch.ProjectID, worker.watch.AgentName); err != nil {
-		m.captureDeliveryError("delivery-status", fmt.Errorf("refresh delivery status for removed watch %s/%s: %w", worker.watch.ProjectID, worker.watch.AgentName, err))
-	} else {
-		m.clearDeliveryError("delivery-status")
-	}
+	_ = m.refreshWatchDeliveryState(worker.watch.ProjectID, worker.watch.AgentName)
 }
 
 func (m *Manager) stopAllWorkers() {
@@ -497,6 +493,10 @@ func backlogDeliveryErrorKey(projectID, agentName string) string {
 	return fmt.Sprintf("backlog-delivery/%s/%s", projectID, agentName)
 }
 
+func refreshDeliveryStatusErrorKey(projectID, agentName string) string {
+	return fmt.Sprintf("delivery-status/%s/%s", projectID, agentName)
+}
+
 func (m *Manager) refreshDeliveryErrorState(projectID, agentName string) error {
 	key := watchKey{projectID: projectID, agentName: agentName}
 
@@ -507,7 +507,6 @@ func (m *Manager) refreshDeliveryErrorState(projectID, agentName string) error {
 	if err != nil {
 		return err
 	}
-	delete(m.lastDeliveryErr, "delivery-status")
 	if summary.Retrying == 0 && summary.Exhausted == 0 && m.pendingFailures[key] > 0 {
 		summary.Retrying = 1
 	}
@@ -532,6 +531,17 @@ func (m *Manager) refreshDeliveryErrorState(projectID, agentName string) error {
 	}
 	delete(m.lastDeliveryErr, watchKey)
 	m.lastDeliveryErr[backlogKey] = errMsg
+	return nil
+}
+
+func (m *Manager) refreshWatchDeliveryState(projectID, agentName string) error {
+	err := m.refreshDeliveryErrorState(projectID, agentName)
+	refreshKey := refreshDeliveryStatusErrorKey(projectID, agentName)
+	if err != nil {
+		m.captureDeliveryError(refreshKey, fmt.Errorf("refresh delivery status for %s/%s: %w", projectID, agentName, err))
+		return err
+	}
+	m.clearDeliveryError(refreshKey)
 	return nil
 }
 
@@ -610,6 +620,51 @@ func (m *Manager) setDeliveryFailureCause(key watchKey, err error) {
 	m.deliveryCauses[key] = err
 }
 
+func (m *Manager) trackedDeliveryStatusWatches() []watchKey {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	seen := make(map[watchKey]struct{})
+	for key := range m.deliveryCauses {
+		seen[key] = struct{}{}
+	}
+	for errKey := range m.lastDeliveryErr {
+		if key, ok := trackedDeliveryStatusWatch(errKey); ok {
+			seen[key] = struct{}{}
+		}
+	}
+
+	watches := make([]watchKey, 0, len(seen))
+	for key := range seen {
+		watches = append(watches, key)
+	}
+	return watches
+}
+
+func trackedDeliveryStatusWatch(errKey string) (watchKey, bool) {
+	for _, prefix := range []string{"watch-delivery/", "backlog-delivery/", "delivery-status/"} {
+		if !strings.HasPrefix(errKey, prefix) {
+			continue
+		}
+		parts := strings.SplitN(strings.TrimPrefix(errKey, prefix), "/", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return watchKey{}, false
+		}
+		return watchKey{projectID: parts[0], agentName: parts[1]}, true
+	}
+	return watchKey{}, false
+}
+
+func (m *Manager) refreshTrackedDeliveryStates() error {
+	var firstErr error
+	for _, key := range m.trackedDeliveryStatusWatches() {
+		if err := m.refreshWatchDeliveryState(key.projectID, key.agentName); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
 func retryDelayForAttempt(attempt int) time.Duration {
 	if attempt <= 0 {
 		return config.Defaults.PollInterval
@@ -660,6 +715,10 @@ func (m *Manager) runMaintenanceLoop(ctx context.Context) {
 			if _, err := m.store.PruneDeliveryRecords(now.Add(-config.Defaults.RuntimeDeliveryRetention)); err != nil {
 				hadErr = true
 				m.captureDeliveryError("maintenance", fmt.Errorf("prune delivery records: %w", err))
+			}
+			if err := m.refreshTrackedDeliveryStates(); err != nil {
+				hadErr = true
+				m.captureDeliveryError("maintenance", fmt.Errorf("refresh tracked delivery states: %w", err))
 			}
 			if !hadErr {
 				m.clearDeliveryError("maintenance")

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -405,7 +405,7 @@ func TestManager_StartReconcilesWatchesRemovedAfterStartup(t *testing.T) {
 	})
 }
 
-func TestManager_StopWatchClearsWorkerErrorsAndPendingState(t *testing.T) {
+func TestManager_StopWatchClearsWorkerErrorsButPreservesDetachedInflightState(t *testing.T) {
 	store := newTestStore(t)
 	watch := Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}
 	if err := store.UpsertWatch(watch); err != nil {
@@ -426,7 +426,6 @@ func TestManager_StopWatchClearsWorkerErrorsAndPendingState(t *testing.T) {
 	key := deliveryKey{projectID: "proj-a", agentName: "agent-1", messageID: 99}
 	manager.mu.Lock()
 	manager.inflight[key] = struct{}{}
-	manager.pendingFailures[watchKey{projectID: watch.ProjectID, agentName: watch.AgentName}] = 1
 	manager.mu.Unlock()
 	manager.captureDeliveryError(watchTransportErrorKey(watch), errors.New("transport error"))
 	manager.captureDeliveryError(watchDeliveryErrorKey(watch.ProjectID, watch.AgentName), errors.New("delivery error"))
@@ -440,11 +439,10 @@ func TestManager_StopWatchClearsWorkerErrorsAndPendingState(t *testing.T) {
 		manager.mu.Lock()
 		defer manager.mu.Unlock()
 		_, inflightExists := manager.inflight[key]
-		_, pendingExists := manager.pendingFailures[watchKey{projectID: watch.ProjectID, agentName: watch.AgentName}]
 		_, transportExists := manager.lastDeliveryErr[watchTransportErrorKey(watch)]
 		_, deliveryExists := manager.lastDeliveryErr[watchDeliveryErrorKey(watch.ProjectID, watch.AgentName)]
 		_, statusExists := manager.lastDeliveryErr[refreshDeliveryStatusErrorKey(watch.ProjectID, watch.AgentName)]
-		return len(manager.workers) == 0 && inflightExists && !pendingExists && !transportExists && !deliveryExists && !statusExists
+		return len(manager.workers) == 0 && inflightExists && !transportExists && !deliveryExists && !statusExists
 	})
 }
 

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -429,7 +429,7 @@ func TestManager_StopWatchClearsInflightState(t *testing.T) {
 	manager.mu.Unlock()
 	manager.captureDeliveryError(watchTransportErrorKey(watch), errors.New("transport error"))
 	manager.captureDeliveryError(watchDeliveryErrorKey(watch.ProjectID, watch.AgentName), errors.New("delivery error"))
-	manager.captureDeliveryError("delivery-status", errors.New("status refresh error"))
+	manager.captureDeliveryError(refreshDeliveryStatusErrorKey(watch.ProjectID, watch.AgentName), errors.New("status refresh error"))
 
 	if err := store.RemoveWatch(watch.ProjectID, watch.AgentName); err != nil {
 		t.Fatal(err)
@@ -441,7 +441,7 @@ func TestManager_StopWatchClearsInflightState(t *testing.T) {
 		_, inflightExists := manager.inflight[key]
 		_, transportExists := manager.lastDeliveryErr[watchTransportErrorKey(watch)]
 		_, deliveryExists := manager.lastDeliveryErr[watchDeliveryErrorKey(watch.ProjectID, watch.AgentName)]
-		_, statusExists := manager.lastDeliveryErr["delivery-status"]
+		_, statusExists := manager.lastDeliveryErr[refreshDeliveryStatusErrorKey(watch.ProjectID, watch.AgentName)]
 		return len(manager.workers) == 0 && !inflightExists && !transportExists && !deliveryExists && !statusExists
 	})
 }
@@ -692,6 +692,44 @@ func TestManager_BacklogRetrySuccessClearsBacklogErrorKey(t *testing.T) {
 	}
 }
 
+func TestManager_MaintenanceClearsRemovedWatchBacklogErrorAfterDismiss(t *testing.T) {
+	store := newTestStore(t)
+	exhausted := DeliveryRecord{
+		ProjectID:        "proj-a",
+		AgentName:        "agent-1",
+		MessageID:        506,
+		FromName:         "planner",
+		Body:             "dismissed after watch removal",
+		SentAt:           time.Unix(112, 0).UTC(),
+		ReceivedAt:       time.Unix(113, 0).UTC(),
+		RetryAttempts:    config.Defaults.RuntimeNotificationRetryLimit,
+		RetryExhaustedAt: time.Now().UTC(),
+	}
+	if err := store.AddRecord(exhausted); err != nil {
+		t.Fatal(err)
+	}
+
+	manager := NewManager(store, newFakeListenerFactory(), &fakeNotifier{})
+	setTTLCheckPeriodForTest(t, 10*time.Millisecond)
+	manager.captureDeliveryError(backlogDeliveryErrorKey("proj-a", "agent-1"), errors.New("stale backlog error"))
+	manager.setDeliveryFailureCause(watchKey{projectID: "proj-a", agentName: "agent-1"}, errors.New("stale notifier cause"))
+
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Stop()
+
+	dismissed := exhausted
+	dismissed.DismissedAt = time.Now().UTC()
+	if err := store.AddRecord(dismissed); err != nil {
+		t.Fatal(err)
+	}
+
+	waitFor(t, "dismissed backlog error cleared", func() bool {
+		return manager.LastDeliveryError() == nil
+	})
+}
+
 func TestManager_RefreshDeliveryErrorStateKeepsActiveErrorWhileFailureInFlight(t *testing.T) {
 	store := newTestStore(t)
 	watch := Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}
@@ -730,14 +768,51 @@ func TestManager_RefreshDeliveryErrorStateClearsDeliveryStatusOnSuccess(t *testi
 	store := newTestStore(t)
 	manager := NewManager(store, newFakeListenerFactory(), &fakeNotifier{})
 
-	manager.captureDeliveryError("delivery-status", errors.New("stale refresh error"))
-	if err := manager.refreshDeliveryErrorState("proj-a", "agent-1"); err != nil {
+	manager.captureDeliveryError(refreshDeliveryStatusErrorKey("proj-a", "agent-1"), errors.New("stale refresh error"))
+	if err := manager.refreshWatchDeliveryState("proj-a", "agent-1"); err != nil {
 		t.Fatal(err)
 	}
 
 	if err := manager.LastDeliveryError(); err != nil {
 		t.Fatalf("LastDeliveryError() = %v, want nil after successful refresh", err)
 	}
+}
+
+func TestManager_StopWatchRefreshErrorKeyDoesNotClearSiblingRefreshError(t *testing.T) {
+	store := newTestStore(t)
+	watchA := Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}
+	watchB := Watch{ProjectID: "proj-b", AgentName: "agent-2", Source: "hook"}
+	if err := store.UpsertWatch(watchA); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertWatch(watchB); err != nil {
+		t.Fatal(err)
+	}
+
+	factory := newFakeListenerFactory()
+	manager := NewManager(store, factory, &fakeNotifier{})
+	setRuntimeReconcileIntervalForTest(t, 10*time.Millisecond)
+
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Stop()
+
+	_ = factory.waitForListener(t, watchA)
+	_ = factory.waitForListener(t, watchB)
+
+	manager.captureDeliveryError(refreshDeliveryStatusErrorKey(watchA.ProjectID, watchA.AgentName), errors.New("watch a refresh failed"))
+
+	if err := store.RemoveWatch(watchB.ProjectID, watchB.AgentName); err != nil {
+		t.Fatal(err)
+	}
+
+	waitFor(t, "watch b removed without clearing watch a refresh error", func() bool {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		_, exists := manager.lastDeliveryErr[refreshDeliveryStatusErrorKey(watchA.ProjectID, watchA.AgentName)]
+		return len(manager.workers) == 1 && exists
+	})
 }
 
 func TestManager_SameWatchSuccessDoesNotClearSiblingFailure(t *testing.T) {
@@ -1747,5 +1822,15 @@ func setRuntimeRetrySweepIntervalForTest(t *testing.T, d time.Duration) {
 	config.Defaults.RuntimeNotificationRetrySweepInterval = d
 	t.Cleanup(func() {
 		config.Defaults.RuntimeNotificationRetrySweepInterval = orig
+	})
+}
+
+func setTTLCheckPeriodForTest(t *testing.T, d time.Duration) {
+	t.Helper()
+
+	orig := config.Defaults.TTLCheckPeriod
+	config.Defaults.TTLCheckPeriod = d
+	t.Cleanup(func() {
+		config.Defaults.TTLCheckPeriod = orig
 	})
 }

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -501,6 +501,76 @@ func TestManager_RetryPendingNotificationsUsesBacklogErrorKeyAfterWatchRemoval(t
 	}
 }
 
+func TestManager_RetryPendingNotificationsClassifiesBlockedFailureAfterConcurrentWatchRemoval(t *testing.T) {
+	store := newTestStore(t)
+	watch := Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}
+	if err := store.UpsertWatch(watch); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AddRecordIfAbsent(DeliveryRecord{
+		ProjectID:     "proj-a",
+		AgentName:     "agent-1",
+		MessageID:     406,
+		FromName:      "planner",
+		Body:          "retry while watch is removed",
+		SentAt:        time.Unix(102, 0).UTC(),
+		ReceivedAt:    time.Unix(103, 0).UTC(),
+		RetryAttempts: 1,
+		RetryNextAt:   time.Now().UTC().Add(-time.Millisecond),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	factory := newFakeListenerFactory()
+	notifier := &blockingResultNotifier{
+		started: make(chan struct{}, 1),
+		release: make(chan error, 1),
+	}
+	manager := NewManager(store, factory, notifier)
+	setRuntimeReconcileIntervalForTest(t, 10*time.Millisecond)
+
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Stop()
+
+	_ = factory.waitForListener(t, watch)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- manager.retryPendingNotifications()
+	}()
+
+	<-notifier.started
+
+	if err := store.RemoveWatch(watch.ProjectID, watch.AgentName); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "watch removed during retry notify", func() bool {
+		return manager.WatchCount() == 0
+	})
+
+	notifier.release <- errors.New("blocked retry notify failed")
+
+	if err := <-done; err != nil {
+		t.Fatalf("retryPendingNotifications returned unexpected error: %v", err)
+	}
+
+	err := manager.LastDeliveryError()
+	if err == nil {
+		t.Fatal("LastDeliveryError() = nil, want backlog delivery error after concurrent watch removal")
+	}
+	if strings.Contains(err.Error(), watchDeliveryErrorKey("proj-a", "agent-1")) {
+		t.Fatalf("LastDeliveryError() = %v, want no watch-delivery key after concurrent watch removal", err)
+	}
+	if !strings.Contains(err.Error(), backlogDeliveryErrorKey("proj-a", "agent-1")) {
+		t.Fatalf("LastDeliveryError() = %v, want backlog-delivery key after concurrent watch removal", err)
+	}
+	if !strings.Contains(err.Error(), "blocked retry notify failed") {
+		t.Fatalf("LastDeliveryError() = %v, want blocked notifier failure detail", err)
+	}
+}
+
 func TestManager_BacklogRetrySuccessClearsBacklogErrorKey(t *testing.T) {
 	store := newTestStore(t)
 	if _, err := store.AddRecordIfAbsent(DeliveryRecord{
@@ -883,6 +953,69 @@ func TestManager_PendingRetryAndLiveDeliveryDoNotDoubleNotifySameRecord(t *testi
 	}
 }
 
+func TestManager_HandleDeliveryClassifiesBlockedFailureAfterConcurrentWatchRemoval(t *testing.T) {
+	store := newTestStore(t)
+	watch := Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}
+	if err := store.UpsertWatch(watch); err != nil {
+		t.Fatal(err)
+	}
+
+	factory := newFakeListenerFactory()
+	notifier := &blockingResultNotifier{
+		started: make(chan struct{}, 1),
+		release: make(chan error, 1),
+	}
+	manager := NewManager(store, factory, notifier)
+	setRuntimeReconcileIntervalForTest(t, 10*time.Millisecond)
+
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Stop()
+
+	listener := factory.waitForListener(t, watch)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- listener.emit(Delivery{
+			MessageID:  778,
+			FromName:   "planner",
+			Body:       "live delivery while watch is removed",
+			SentAt:     time.Unix(104, 0).UTC(),
+			ReceivedAt: time.Unix(105, 0).UTC(),
+		})
+	}()
+
+	<-notifier.started
+
+	if err := store.RemoveWatch(watch.ProjectID, watch.AgentName); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "watch removed during live notify", func() bool {
+		return manager.WatchCount() == 0
+	})
+
+	notifier.release <- errors.New("blocked live notify failed")
+
+	if err := <-done; err != nil {
+		t.Fatalf("listener emit returned unexpected error: %v", err)
+	}
+
+	err := manager.LastDeliveryError()
+	if err == nil {
+		t.Fatal("LastDeliveryError() = nil, want backlog delivery error after concurrent watch removal")
+	}
+	if strings.Contains(err.Error(), watchDeliveryErrorKey("proj-a", "agent-1")) {
+		t.Fatalf("LastDeliveryError() = %v, want no watch-delivery key after concurrent watch removal", err)
+	}
+	if !strings.Contains(err.Error(), backlogDeliveryErrorKey("proj-a", "agent-1")) {
+		t.Fatalf("LastDeliveryError() = %v, want backlog-delivery key after concurrent watch removal", err)
+	}
+	if !strings.Contains(err.Error(), "blocked live notify failed") {
+		t.Fatalf("LastDeliveryError() = %v, want blocked notifier failure detail", err)
+	}
+}
+
 func TestManager_RestartsWatchAfterCleanListenerExit(t *testing.T) {
 	store := newTestStore(t)
 	if err := store.UpsertWatch(Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}); err != nil {
@@ -1134,6 +1267,13 @@ type blockingNotifier struct {
 	release chan struct{}
 }
 
+type blockingResultNotifier struct {
+	mu      sync.Mutex
+	calls   int
+	started chan struct{}
+	release chan error
+}
+
 func (n *blockingNotifier) Notify(_ context.Context, _, _ string) error {
 	n.mu.Lock()
 	n.calls++
@@ -1150,6 +1290,22 @@ func (n *blockingNotifier) callCount() int {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	return n.calls
+}
+
+func (n *blockingResultNotifier) Notify(ctx context.Context, _, _ string) error {
+	n.mu.Lock()
+	n.calls++
+	n.mu.Unlock()
+	select {
+	case n.started <- struct{}{}:
+	default:
+	}
+	select {
+	case err := <-n.release:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 type notifyCall struct {

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -571,6 +571,84 @@ func TestManager_RetryPendingNotificationsClassifiesBlockedFailureAfterConcurren
 	}
 }
 
+func TestManager_RetryPendingNotificationsClassifiesBlockedFailureAfterConcurrentWatchReAdd(t *testing.T) {
+	store := newTestStore(t)
+	watch := Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}
+	if err := store.UpsertWatch(watch); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AddRecordIfAbsent(DeliveryRecord{
+		ProjectID:     "proj-a",
+		AgentName:     "agent-1",
+		MessageID:     407,
+		FromName:      "planner",
+		Body:          "retry while watch is re-added",
+		SentAt:        time.Unix(104, 0).UTC(),
+		ReceivedAt:    time.Unix(105, 0).UTC(),
+		RetryAttempts: 1,
+		RetryNextAt:   time.Now().UTC().Add(-time.Millisecond),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	factory := newFakeListenerFactory()
+	notifier := &blockingResultNotifier{
+		started: make(chan struct{}, 1),
+		release: make(chan error, 1),
+	}
+	manager := NewManager(store, factory, notifier)
+	setRuntimeReconcileIntervalForTest(t, 10*time.Millisecond)
+
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Stop()
+
+	originalListener := factory.waitForListener(t, watch)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- manager.retryPendingNotifications()
+	}()
+
+	<-notifier.started
+
+	if err := store.RemoveWatch(watch.ProjectID, watch.AgentName); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "watch removed during retry notify before re-add", func() bool {
+		return manager.WatchCount() == 0
+	})
+
+	if err := store.UpsertWatch(watch); err != nil {
+		t.Fatal(err)
+	}
+	waitForNewListener(t, factory, watch, originalListener)
+	waitFor(t, "watch re-added during retry notify", func() bool {
+		return manager.WatchCount() == 1
+	})
+
+	notifier.release <- errors.New("blocked retry notify failed after re-add")
+
+	if err := <-done; err != nil {
+		t.Fatalf("retryPendingNotifications returned unexpected error: %v", err)
+	}
+
+	err := manager.LastDeliveryError()
+	if err == nil {
+		t.Fatal("LastDeliveryError() = nil, want watch delivery error after concurrent watch re-add")
+	}
+	if strings.Contains(err.Error(), backlogDeliveryErrorKey("proj-a", "agent-1")) {
+		t.Fatalf("LastDeliveryError() = %v, want no backlog-delivery key after concurrent watch re-add", err)
+	}
+	if !strings.Contains(err.Error(), watchDeliveryErrorKey("proj-a", "agent-1")) {
+		t.Fatalf("LastDeliveryError() = %v, want watch-delivery key after concurrent watch re-add", err)
+	}
+	if !strings.Contains(err.Error(), "blocked retry notify failed after re-add") {
+		t.Fatalf("LastDeliveryError() = %v, want blocked notifier failure detail", err)
+	}
+}
+
 func TestManager_BacklogRetrySuccessClearsBacklogErrorKey(t *testing.T) {
 	store := newTestStore(t)
 	if _, err := store.AddRecordIfAbsent(DeliveryRecord{
@@ -1016,6 +1094,81 @@ func TestManager_HandleDeliveryClassifiesBlockedFailureAfterConcurrentWatchRemov
 	}
 }
 
+func TestManager_HandleDeliveryClassifiesBlockedFailureAfterConcurrentWatchReAdd(t *testing.T) {
+	store := newTestStore(t)
+	watch := Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}
+	if err := store.UpsertWatch(watch); err != nil {
+		t.Fatal(err)
+	}
+
+	factory := newFakeListenerFactory()
+	notifier := &blockingResultNotifier{
+		started: make(chan struct{}, 1),
+		release: make(chan error, 1),
+	}
+	manager := NewManager(store, factory, notifier)
+	setRuntimeReconcileIntervalForTest(t, 10*time.Millisecond)
+
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Stop()
+
+	_ = factory.waitForListener(t, watch)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- manager.handleDelivery(watch, Delivery{
+			MessageID:  779,
+			FromName:   "planner",
+			Body:       "live delivery while watch is re-added",
+			SentAt:     time.Unix(106, 0).UTC(),
+			ReceivedAt: time.Unix(107, 0).UTC(),
+		})
+	}()
+
+	<-notifier.started
+
+	if err := store.RemoveWatch(watch.ProjectID, watch.AgentName); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "watch removed during live notify before re-add", func() bool {
+		return manager.WatchCount() == 0
+	})
+
+	if err := store.UpsertWatch(watch); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "watch listener present after re-add", func() bool {
+		factory.mu.Lock()
+		defer factory.mu.Unlock()
+		return factory.listeners[watchKey{projectID: watch.ProjectID, agentName: watch.AgentName}] != nil
+	})
+	waitFor(t, "watch re-added during live notify", func() bool {
+		return manager.WatchCount() == 1
+	})
+
+	notifier.release <- errors.New("blocked live notify failed after re-add")
+
+	if err := <-done; err != nil {
+		t.Fatalf("listener emit returned unexpected error: %v", err)
+	}
+
+	err := manager.LastDeliveryError()
+	if err == nil {
+		t.Fatal("LastDeliveryError() = nil, want watch delivery error after concurrent watch re-add")
+	}
+	if strings.Contains(err.Error(), backlogDeliveryErrorKey("proj-a", "agent-1")) {
+		t.Fatalf("LastDeliveryError() = %v, want no backlog-delivery key after concurrent watch re-add", err)
+	}
+	if !strings.Contains(err.Error(), watchDeliveryErrorKey("proj-a", "agent-1")) {
+		t.Fatalf("LastDeliveryError() = %v, want watch-delivery key after concurrent watch re-add", err)
+	}
+	if !strings.Contains(err.Error(), "blocked live notify failed after re-add") {
+		t.Fatalf("LastDeliveryError() = %v, want blocked notifier failure detail", err)
+	}
+}
+
 func TestManager_RestartsWatchAfterCleanListenerExit(t *testing.T) {
 	store := newTestStore(t)
 	if err := store.UpsertWatch(Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}); err != nil {
@@ -1381,6 +1534,19 @@ func (f *fakeListenerFactory) waitForListener(t *testing.T, watch Watch) *fakeLi
 			t.Fatalf("listener for %+v was not created", watch)
 		}
 	}
+}
+
+func waitForNewListener(t *testing.T, f *fakeListenerFactory, watch Watch, prior *fakeListener) *fakeListener {
+	t.Helper()
+
+	var next *fakeListener
+	waitFor(t, "replacement listener", func() bool {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		next = f.listeners[watchKey{projectID: watch.ProjectID, agentName: watch.AgentName}]
+		return next != nil && next != prior
+	})
+	return next
 }
 
 type fakeListener struct {

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -575,6 +575,20 @@ func TestManager_RefreshDeliveryErrorStateKeepsActiveErrorWhileFailureInFlight(t
 	}
 }
 
+func TestManager_RefreshDeliveryErrorStateClearsDeliveryStatusOnSuccess(t *testing.T) {
+	store := newTestStore(t)
+	manager := NewManager(store, newFakeListenerFactory(), &fakeNotifier{})
+
+	manager.captureDeliveryError("delivery-status", errors.New("stale refresh error"))
+	if err := manager.refreshDeliveryErrorState("proj-a", "agent-1"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := manager.LastDeliveryError(); err != nil {
+		t.Fatalf("LastDeliveryError() = %v, want nil after successful refresh", err)
+	}
+}
+
 func TestManager_SameWatchSuccessDoesNotClearSiblingFailure(t *testing.T) {
 	store := newTestStore(t)
 	watch := Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -539,6 +539,80 @@ func TestManager_BacklogRetrySuccessClearsBacklogErrorKey(t *testing.T) {
 	}
 }
 
+func TestManager_SameWatchSuccessDoesNotClearSiblingFailure(t *testing.T) {
+	store := newTestStore(t)
+	watch := Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}
+	if err := store.UpsertWatch(watch); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, rec := range []DeliveryRecord{
+		{
+			ProjectID:     "proj-a",
+			AgentName:     "agent-1",
+			MessageID:     601,
+			FromName:      "planner",
+			Body:          "first fails",
+			SentAt:        time.Unix(120, 0).UTC(),
+			ReceivedAt:    time.Unix(121, 0).UTC(),
+			RetryAttempts: 1,
+			RetryNextAt:   time.Now().UTC().Add(-time.Millisecond),
+		},
+		{
+			ProjectID:     "proj-a",
+			AgentName:     "agent-1",
+			MessageID:     602,
+			FromName:      "planner",
+			Body:          "second succeeds",
+			SentAt:        time.Unix(122, 0).UTC(),
+			ReceivedAt:    time.Unix(123, 0).UTC(),
+			RetryAttempts: 1,
+			RetryNextAt:   time.Now().UTC().Add(-time.Millisecond),
+		},
+	} {
+		if _, err := store.AddRecordIfAbsent(rec); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	manager := NewManager(store, newFakeListenerFactory(), &fakeNotifier{
+		errs: []error{errors.New("first still failing"), nil},
+	})
+	setRuntimeReconcileIntervalForTest(t, 10*time.Millisecond)
+
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Stop()
+
+	if err := manager.retryPendingNotifications(); err != nil {
+		t.Fatalf("retryPendingNotifications returned unexpected error: %v", err)
+	}
+
+	err := manager.LastDeliveryError()
+	if err == nil {
+		t.Fatal("LastDeliveryError() = nil, want active watch-delivery error")
+	}
+	if !strings.Contains(err.Error(), watchDeliveryErrorKey("proj-a", "agent-1")) {
+		t.Fatalf("LastDeliveryError() = %v, want watch-delivery key to remain while sibling failure exists", err)
+	}
+
+	failed, err := store.GetRecord("proj-a", "agent-1", 601)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failed.NotifiedAt.IsZero() && failed.RetryAttempts == 0 {
+		t.Fatalf("failed record = %+v, want unresolved failed retry state", failed)
+	}
+	succeeded, err := store.GetRecord("proj-a", "agent-1", 602)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if succeeded.NotifiedAt.IsZero() {
+		t.Fatalf("successful record = %+v, want notified", succeeded)
+	}
+}
+
 func TestManager_RestartsWatchAfterListenerError(t *testing.T) {
 	store := newTestStore(t)
 	if err := store.UpsertWatch(Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}); err != nil {

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -429,6 +429,7 @@ func TestManager_StopWatchClearsInflightState(t *testing.T) {
 	manager.mu.Unlock()
 	manager.captureDeliveryError(watchTransportErrorKey(watch), errors.New("transport error"))
 	manager.captureDeliveryError(watchDeliveryErrorKey(watch.ProjectID, watch.AgentName), errors.New("delivery error"))
+	manager.captureDeliveryError("delivery-status", errors.New("status refresh error"))
 
 	if err := store.RemoveWatch(watch.ProjectID, watch.AgentName); err != nil {
 		t.Fatal(err)
@@ -440,7 +441,8 @@ func TestManager_StopWatchClearsInflightState(t *testing.T) {
 		_, inflightExists := manager.inflight[key]
 		_, transportExists := manager.lastDeliveryErr[watchTransportErrorKey(watch)]
 		_, deliveryExists := manager.lastDeliveryErr[watchDeliveryErrorKey(watch.ProjectID, watch.AgentName)]
-		return len(manager.workers) == 0 && !inflightExists && !transportExists && !deliveryExists
+		_, statusExists := manager.lastDeliveryErr["delivery-status"]
+		return len(manager.workers) == 0 && !inflightExists && !transportExists && !deliveryExists && !statusExists
 	})
 }
 

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -496,6 +496,9 @@ func TestManager_RetryPendingNotificationsUsesBacklogErrorKeyAfterWatchRemoval(t
 	if !strings.Contains(err.Error(), backlogDeliveryErrorKey("proj-a", "agent-1")) {
 		t.Fatalf("LastDeliveryError() = %v, want backlog-delivery key", err)
 	}
+	if !strings.Contains(err.Error(), "notify failed") {
+		t.Fatalf("LastDeliveryError() = %v, want preserved notifier failure detail", err)
+	}
 }
 
 func TestManager_BacklogRetrySuccessClearsBacklogErrorKey(t *testing.T) {
@@ -645,6 +648,9 @@ func TestManager_SameWatchSuccessDoesNotClearSiblingFailure(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), watchDeliveryErrorKey("proj-a", "agent-1")) {
 		t.Fatalf("LastDeliveryError() = %v, want watch-delivery key to remain while sibling failure exists", err)
+	}
+	if !strings.Contains(err.Error(), "first still failing") {
+		t.Fatalf("LastDeliveryError() = %v, want preserved notifier failure detail", err)
 	}
 
 	failed, err := store.GetRecord("proj-a", "agent-1", 601)

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -405,7 +405,7 @@ func TestManager_StartReconcilesWatchesRemovedAfterStartup(t *testing.T) {
 	})
 }
 
-func TestManager_StopWatchClearsInflightState(t *testing.T) {
+func TestManager_StopWatchClearsWorkerErrorsAndPendingState(t *testing.T) {
 	store := newTestStore(t)
 	watch := Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}
 	if err := store.UpsertWatch(watch); err != nil {
@@ -426,6 +426,7 @@ func TestManager_StopWatchClearsInflightState(t *testing.T) {
 	key := deliveryKey{projectID: "proj-a", agentName: "agent-1", messageID: 99}
 	manager.mu.Lock()
 	manager.inflight[key] = struct{}{}
+	manager.pendingFailures[watchKey{projectID: watch.ProjectID, agentName: watch.AgentName}] = 1
 	manager.mu.Unlock()
 	manager.captureDeliveryError(watchTransportErrorKey(watch), errors.New("transport error"))
 	manager.captureDeliveryError(watchDeliveryErrorKey(watch.ProjectID, watch.AgentName), errors.New("delivery error"))
@@ -439,10 +440,11 @@ func TestManager_StopWatchClearsInflightState(t *testing.T) {
 		manager.mu.Lock()
 		defer manager.mu.Unlock()
 		_, inflightExists := manager.inflight[key]
+		_, pendingExists := manager.pendingFailures[watchKey{projectID: watch.ProjectID, agentName: watch.AgentName}]
 		_, transportExists := manager.lastDeliveryErr[watchTransportErrorKey(watch)]
 		_, deliveryExists := manager.lastDeliveryErr[watchDeliveryErrorKey(watch.ProjectID, watch.AgentName)]
 		_, statusExists := manager.lastDeliveryErr[refreshDeliveryStatusErrorKey(watch.ProjectID, watch.AgentName)]
-		return len(manager.workers) == 0 && !inflightExists && !transportExists && !deliveryExists && !statusExists
+		return len(manager.workers) == 0 && inflightExists && !pendingExists && !transportExists && !deliveryExists && !statusExists
 	})
 }
 
@@ -1103,6 +1105,87 @@ func TestManager_PendingRetryAndLiveDeliveryDoNotDoubleNotifySameRecord(t *testi
 	}
 	if notifier.callCount() != 1 {
 		t.Fatalf("notify count = %d, want 1", notifier.callCount())
+	}
+}
+
+func TestManager_PendingRetryPreservesInflightAcrossWatchRemoveAndReAdd(t *testing.T) {
+	store := newTestStore(t)
+	watch := Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}
+	if err := store.UpsertWatch(watch); err != nil {
+		t.Fatal(err)
+	}
+
+	notifier := &blockingNotifier{
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	factory := newFakeListenerFactory()
+	manager := NewManager(store, factory, notifier)
+	setRuntimeReconcileIntervalForTest(t, 10*time.Millisecond)
+
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Stop()
+
+	originalListener := factory.waitForListener(t, watch)
+	record := DeliveryRecord{
+		ProjectID:  watch.ProjectID,
+		AgentName:  watch.AgentName,
+		MessageID:  780,
+		FromName:   "planner",
+		Body:       "same message across watch re-add",
+		SentAt:     time.Unix(108, 0).UTC(),
+		ReceivedAt: time.Unix(109, 0).UTC(),
+	}
+	if _, err := store.AddRecordIfAbsent(record); err != nil {
+		t.Fatal(err)
+	}
+
+	retryDone := make(chan error, 1)
+	go func() {
+		retryDone <- manager.retryPendingNotifications()
+	}()
+
+	<-notifier.started
+
+	if err := store.RemoveWatch(watch.ProjectID, watch.AgentName); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "watch removed during blocked retry", func() bool {
+		return manager.WatchCount() == 0
+	})
+
+	if err := store.UpsertWatch(watch); err != nil {
+		t.Fatal(err)
+	}
+	replacementListener := waitForNewListener(t, factory, watch, originalListener)
+	waitFor(t, "watch re-added during blocked retry", func() bool {
+		return manager.WatchCount() == 1
+	})
+
+	liveDone := make(chan error, 1)
+	go func() {
+		liveDone <- replacementListener.emit(Delivery{
+			MessageID:  record.MessageID,
+			FromName:   record.FromName,
+			Body:       record.Body,
+			SentAt:     record.SentAt,
+			ReceivedAt: record.ReceivedAt,
+		})
+	}()
+
+	if err := <-liveDone; err != nil {
+		t.Fatalf("replacement listener emit returned unexpected error: %v", err)
+	}
+
+	close(notifier.release)
+
+	if err := <-retryDone; err != nil {
+		t.Fatalf("retryPendingNotifications returned unexpected error: %v", err)
+	}
+	if notifier.callCount() != 1 {
+		t.Fatalf("notify count = %d, want 1 with inflight dedupe preserved across re-add", notifier.callCount())
 	}
 }
 

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -539,6 +539,40 @@ func TestManager_BacklogRetrySuccessClearsBacklogErrorKey(t *testing.T) {
 	}
 }
 
+func TestManager_RefreshDeliveryErrorStateKeepsActiveErrorWhileFailureInFlight(t *testing.T) {
+	store := newTestStore(t)
+	watch := Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}
+	if err := store.UpsertWatch(watch); err != nil {
+		t.Fatal(err)
+	}
+
+	factory := newFakeListenerFactory()
+	manager := NewManager(store, factory, &fakeNotifier{})
+	setRuntimeReconcileIntervalForTest(t, 10*time.Millisecond)
+
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Stop()
+
+	_ = factory.waitForListener(t, watch)
+
+	releasePending := manager.beginPendingFailure(watchKey{projectID: "proj-a", agentName: "agent-1"})
+	defer releasePending()
+
+	if err := manager.refreshDeliveryErrorState("proj-a", "agent-1"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := manager.LastDeliveryError()
+	if err == nil {
+		t.Fatal("LastDeliveryError() = nil, want active watch-delivery error while failure is in flight")
+	}
+	if !strings.Contains(err.Error(), watchDeliveryErrorKey("proj-a", "agent-1")) {
+		t.Fatalf("LastDeliveryError() = %v, want watch-delivery key", err)
+	}
+}
+
 func TestManager_SameWatchSuccessDoesNotClearSiblingFailure(t *testing.T) {
 	store := newTestStore(t)
 	watch := Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}

--- a/internal/runtime/store.go
+++ b/internal/runtime/store.go
@@ -497,23 +497,29 @@ func (s *Store) RecordNotificationFailure(projectID, agentName string, messageID
 	return nil
 }
 
-func (s *Store) HasUnresolvedFailedDeliveries(projectID, agentName string) (bool, error) {
+type DeliveryFailureSummary struct {
+	Retrying  int
+	Exhausted int
+}
+
+func (s *Store) DeliveryFailureSummary(projectID, agentName string) (DeliveryFailureSummary, error) {
 	if projectID == "" || agentName == "" {
-		return false, fmt.Errorf("project_id and agent_name required")
+		return DeliveryFailureSummary{}, fmt.Errorf("project_id and agent_name required")
 	}
 
-	var count int
+	var summary DeliveryFailureSummary
 	if err := s.db.QueryRow(`
-		SELECT COUNT(*)
+		SELECT
+			COALESCE(SUM(CASE WHEN retry_attempts > 0 AND retry_exhausted_at = '' THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN retry_exhausted_at != '' THEN 1 ELSE 0 END), 0)
 		FROM delivery_records
 		WHERE project_id = ? AND agent_name = ?
 		  AND notified_at = ''
 		  AND dismissed_at IS NULL
-		  AND retry_attempts > 0
-	`, projectID, agentName).Scan(&count); err != nil {
-		return false, fmt.Errorf("query unresolved failed deliveries: %w", err)
+	`, projectID, agentName).Scan(&summary.Retrying, &summary.Exhausted); err != nil {
+		return DeliveryFailureSummary{}, fmt.Errorf("query unresolved failed deliveries: %w", err)
 	}
-	return count > 0, nil
+	return summary, nil
 }
 
 // MarkSurfaced marks a delivery record as surfaced to the agent.

--- a/internal/runtime/store.go
+++ b/internal/runtime/store.go
@@ -516,6 +516,7 @@ func (s *Store) DeliveryFailureSummary(projectID, agentName string) (DeliveryFai
 		WHERE project_id = ? AND agent_name = ?
 		  AND notified_at = ''
 		  AND dismissed_at IS NULL
+		  AND (retry_attempts > 0 OR retry_exhausted_at != '')
 	`, projectID, agentName).Scan(&summary.Retrying, &summary.Exhausted); err != nil {
 		return DeliveryFailureSummary{}, fmt.Errorf("query unresolved failed deliveries: %w", err)
 	}

--- a/internal/runtime/store.go
+++ b/internal/runtime/store.go
@@ -497,6 +497,25 @@ func (s *Store) RecordNotificationFailure(projectID, agentName string, messageID
 	return nil
 }
 
+func (s *Store) HasUnresolvedFailedDeliveries(projectID, agentName string) (bool, error) {
+	if projectID == "" || agentName == "" {
+		return false, fmt.Errorf("project_id and agent_name required")
+	}
+
+	var count int
+	if err := s.db.QueryRow(`
+		SELECT COUNT(*)
+		FROM delivery_records
+		WHERE project_id = ? AND agent_name = ?
+		  AND notified_at = ''
+		  AND dismissed_at IS NULL
+		  AND retry_attempts > 0
+	`, projectID, agentName).Scan(&count); err != nil {
+		return false, fmt.Errorf("query unresolved failed deliveries: %w", err)
+	}
+	return count > 0, nil
+}
+
 // MarkSurfaced marks a delivery record as surfaced to the agent.
 func (s *Store) MarkSurfaced(projectID, agentName string, messageID int64) error {
 	if projectID == "" || agentName == "" {
@@ -559,12 +578,6 @@ func (s *Store) MarkSurfacedBatch(projectID, agentName string, messageIDs []int6
 	defer func() {
 		_ = tx.Rollback()
 	}()
-
-	args := make([]any, 0, 2+len(ids))
-	args = append(args, projectID, agentName)
-	for _, id := range ids {
-		args = append(args, id)
-	}
 
 	updateArgs := make([]any, 0, 3+len(ids))
 	updateArgs = append(updateArgs, time.Now().UTC().Format(time.RFC3339Nano), projectID, agentName)

--- a/internal/runtime/store_test.go
+++ b/internal/runtime/store_test.go
@@ -652,7 +652,7 @@ func TestStore_PendingNotificationsBatchSkipsDeferredAndExhaustedRecords(t *test
 	}
 }
 
-func TestStore_PendingNotificationsBatchTreatsExactSecondRetryAsEligible(t *testing.T) {
+func TestStore_PendingNotificationsBatchUsesJuliandayForRetryEligibility(t *testing.T) {
 	store := newTestStore(t)
 
 	rec := DeliveryRecord{
@@ -660,7 +660,7 @@ func TestStore_PendingNotificationsBatchTreatsExactSecondRetryAsEligible(t *test
 		AgentName:  "agent-1",
 		MessageID:  99,
 		FromName:   "planner",
-		Body:       "exact-second retry",
+		Body:       "retry eligibility uses julianday",
 		SentAt:     time.Unix(10, 0).UTC(),
 		ReceivedAt: time.Unix(11, 0).UTC(),
 	}


### PR DESCRIPTION
## Summary
This PR is a focused post-merge hardening slice after the Wave 1 integration work.

It addresses the remaining status-fidelity class of problems in the runtime:
- operator-facing watch delivery status should reflect active unresolved failures for that watch
- backlog retry failures should not pollute active watch health
- status should be derived from a more systematic model than last-write-wins event clearing

## Scope
- runtime/operator status fidelity only
- no new product scope
- no adapter feature changes

## What changed
- model unresolved delivery status per watch more systematically
- tighten the runtime error/status behavior so a successful record does not incorrectly clear another unresolved failure for the same watch

## Verification
Run locally in low-overhead single-process mode:

```bash
GOCACHE=/tmp/go-build-cache GOMAXPROCS=1 go test ./internal/runtime/... -count=1 -p=1
GOCACHE=/tmp/go-build-cache GOMAXPROCS=1 go test ./... -count=1 -p=1
GOCACHE=/tmp/go-build-cache GOMAXPROCS=1 go build ./...
```

## Review focus
Please review specifically for:
- whether per-watch delivery status now reflects unresolved failure state correctly
- whether the model avoids reintroducing cross-subsystem masking or zombie watch errors
- whether this hardening stayed narrow and merge-safe