### PR TITLE
fix: harden reconnect recovery with local polling (#74)

### DIFF
--- a/e2e/runtime_integration_test.go
+++ b/e2e/runtime_integration_test.go
@@ -311,12 +311,9 @@ func TestRuntimeBrokerRestartReconnect(t *testing.T) {
 		return true
 	})
 
-	// Step 10: Wait a bit longer to ensure manager's reconnect loop picks up the new broker
-	// Manager's reconnect backoff starts at PollInterval (500ms) and it needs to retry
-	time.Sleep(2 * time.Second)
-
-	// Step 10: Manager should automatically reconnect
-	// Verify by sending a message via broker #2 and checking it arrives
+	// Step 10: Send message #2 via broker #2 immediately after restart.
+	// This should land in broker storage even if the manager push session has
+	// not reconnected yet; catch-up after reconnect must recover it.
 	sender2, err := client.Connect(paths.Socket, 5*time.Second)
 	if err != nil {
 		t.Fatal(err)
@@ -339,7 +336,7 @@ func TestRuntimeBrokerRestartReconnect(t *testing.T) {
 		t.Fatalf("send message #2 failed: %s", resp.Error)
 	}
 
-	// Step 11: Verify message #2 is in store (with 15s timeout for reconnect)
+	// Step 11: Verify message #2 is in store after reconnect catch-up.
 	waitForConditionWithTimeout(t, "message #2 in store", 15*time.Second, func() bool {
 		rec, err := store.GetRecord("proj-reconnect", "agent-reconnect", 2)
 		return err == nil && !rec.NotifiedAt.IsZero() && rec.Body == "message after restart"
@@ -362,7 +359,7 @@ func TestRuntimeBrokerRestartReconnect(t *testing.T) {
 		t.Fatalf("message #2 body = %q, want 'message after restart'", rec2.Body)
 	}
 
-	// Verify watch count is still 1 (no duplicates)
+	// Step 13: Verify watch count is still 1 (no duplicates)
 	if count := manager.WatchCount(); count != 1 {
 		t.Fatalf("watch count = %d, want 1", count)
 	}

--- a/e2e/runtime_integration_test.go
+++ b/e2e/runtime_integration_test.go
@@ -148,10 +148,243 @@ func pullUnreadRecords(store *rt.Store, projectID, agentName string) ([]rt.Deliv
 	return records, nil
 }
 
+func TestRuntimeBrokerRestartReconnect(t *testing.T) {
+	home, err := os.MkdirTemp("/tmp", "wg-e2e-reconnect-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(home)
+	})
+	t.Setenv("HOME", home)
+	t.Setenv("WAGGLE_PROJECT_ID", "proj-reconnect")
+
+	paths := config.NewPaths("proj-reconnect")
+	if err := broker.EnsureDirs(filepath.Dir(paths.DB), filepath.Dir(paths.Socket)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 1: Start broker #1
+	b1, err := broker.New(broker.Config{
+		SocketPath: paths.Socket,
+		DBPath:     paths.DB,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	brokerDone1 := make(chan error, 1)
+	go func() {
+		brokerDone1 <- b1.Serve()
+	}()
+	var broker1Shutdown bool
+	t.Cleanup(func() {
+		if !broker1Shutdown {
+			_ = b1.Shutdown()
+			select {
+			case <-brokerDone1:
+			case <-time.After(2 * time.Second):
+			}
+		}
+	})
+
+	waitForCondition(t, "broker #1 socket", func() bool {
+		c, err := client.Connect(paths.Socket, 200*time.Millisecond)
+		if err != nil {
+			return false
+		}
+		c.Close()
+		return true
+	})
+
+	// Step 2: Start manager
+	store, err := rt.NewStore(paths.RuntimeDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = store.Close()
+	})
+
+	manager := rt.NewManager(store, rt.NewBrokerListenerFactory(), nil)
+	mgrCtx, mgrCancel := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		mgrCancel()
+		_ = manager.Stop()
+	})
+	if err := manager.Start(mgrCtx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 3: Register watch for agent
+	if err := rt.RegisterWatch(paths, rt.Watch{
+		ProjectID: "proj-reconnect",
+		AgentName: "agent-reconnect",
+		Source:    "explicit",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	waitForCondition(t, "runtime watch propagation", func() bool {
+		return manager.WatchCount() == 1
+	})
+
+	// Step 4: Send message #1 via broker #1
+	sender1, err := client.Connect(paths.Socket, 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sender1.Close()
+
+	if _, err := sender1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "sender1"}); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := sender1.Send(protocol.Request{
+		Cmd:     protocol.CmdSend,
+		Name:    "agent-reconnect",
+		Message: "message before restart",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("send message #1 failed: %s", resp.Error)
+	}
+
+	// Step 5: Verify message #1 is in store
+	waitForCondition(t, "message #1 in store", func() bool {
+		rec, err := store.GetRecord("proj-reconnect", "agent-reconnect", 1)
+		return err == nil && !rec.NotifiedAt.IsZero() && rec.Body == "message before restart"
+	})
+
+	sender1.Close()
+
+	// Step 6: Shutdown broker #1
+	if err := b1.Shutdown(); err != nil {
+		// Ignore shutdown errors from b1 - it's being shut down early
+	}
+	broker1Shutdown = true
+	select {
+	case <-brokerDone1:
+	case <-time.After(2 * time.Second):
+	}
+
+	// Step 7: Verify socket is gone
+	waitForCondition(t, "broker #1 socket gone", func() bool {
+		c, err := client.Connect(paths.Socket, 200*time.Millisecond)
+		if err != nil {
+			return true // Connection failed = socket is gone
+		}
+		c.Close()
+		return false
+	})
+
+	// Step 8: Start broker #2 on the same socket path
+	b2, err := broker.New(broker.Config{
+		SocketPath: paths.Socket,
+		DBPath:     paths.DB,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	brokerDone2 := make(chan error, 1)
+	go func() {
+		brokerDone2 <- b2.Serve()
+	}()
+	t.Cleanup(func() {
+		_ = b2.Shutdown()
+		select {
+		case <-brokerDone2:
+		case <-time.After(2 * time.Second):
+		}
+	})
+
+	// Step 9: Wait for broker #2 socket to be available
+	waitForCondition(t, "broker #2 socket", func() bool {
+		c, err := client.Connect(paths.Socket, 200*time.Millisecond)
+		if err != nil {
+			return false
+		}
+		c.Close()
+		return true
+	})
+
+	// Step 10: Wait a bit longer to ensure manager's reconnect loop picks up the new broker
+	// Manager's reconnect backoff starts at PollInterval (500ms) and it needs to retry
+	time.Sleep(2 * time.Second)
+
+	// Step 10: Manager should automatically reconnect
+	// Verify by sending a message via broker #2 and checking it arrives
+	sender2, err := client.Connect(paths.Socket, 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sender2.Close()
+
+	if _, err := sender2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "sender2"}); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err = sender2.Send(protocol.Request{
+		Cmd:     protocol.CmdSend,
+		Name:    "agent-reconnect",
+		Message: "message after restart",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("send message #2 failed: %s", resp.Error)
+	}
+
+	// Step 11: Verify message #2 is in store (with 15s timeout for reconnect)
+	waitForConditionWithTimeout(t, "message #2 in store", 15*time.Second, func() bool {
+		rec, err := store.GetRecord("proj-reconnect", "agent-reconnect", 2)
+		return err == nil && !rec.NotifiedAt.IsZero() && rec.Body == "message after restart"
+	})
+
+	// Step 12: Verify both messages are in store
+	rec1, err := store.GetRecord("proj-reconnect", "agent-reconnect", 1)
+	if err != nil {
+		t.Fatalf("failed to get message #1: %v", err)
+	}
+	if rec1.Body != "message before restart" {
+		t.Fatalf("message #1 body = %q, want 'message before restart'", rec1.Body)
+	}
+
+	rec2, err := store.GetRecord("proj-reconnect", "agent-reconnect", 2)
+	if err != nil {
+		t.Fatalf("failed to get message #2: %v", err)
+	}
+	if rec2.Body != "message after restart" {
+		t.Fatalf("message #2 body = %q, want 'message after restart'", rec2.Body)
+	}
+
+	// Verify watch count is still 1 (no duplicates)
+	if count := manager.WatchCount(); count != 1 {
+		t.Fatalf("watch count = %d, want 1", count)
+	}
+}
+
 func waitForCondition(t *testing.T, name string, fn func() bool) {
 	t.Helper()
 
 	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for %s", name)
+}
+
+func waitForConditionWithTimeout(t *testing.T, name string, timeout time.Duration, fn func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		if fn() {
 			return

--- a/e2e/runtime_integration_test.go
+++ b/e2e/runtime_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -13,6 +14,16 @@ import (
 	"github.com/seungpyoson/waggle/internal/protocol"
 	rt "github.com/seungpyoson/waggle/internal/runtime"
 )
+
+type catchUpCounter struct {
+	rt.ListenerFactory
+	count int64
+}
+
+func (c *catchUpCounter) CatchUp(w rt.Watch, handler rt.DeliveryHandler) error {
+	atomic.AddInt64(&c.count, 1)
+	return c.ListenerFactory.CatchUp(w, handler)
+}
 
 func TestRuntimeEndToEndPushStoreAndPull(t *testing.T) {
 	home, err := os.MkdirTemp("/tmp", "wg-e2e-")
@@ -206,7 +217,8 @@ func TestRuntimeBrokerRestartReconnect(t *testing.T) {
 		_ = store.Close()
 	})
 
-	manager := rt.NewManager(store, rt.NewBrokerListenerFactory(), nil)
+	factory := &catchUpCounter{ListenerFactory: rt.NewBrokerListenerFactory()}
+	manager := rt.NewManager(store, factory, nil)
 	mgrCtx, mgrCancel := context.WithCancel(context.Background())
 	t.Cleanup(func() {
 		mgrCancel()
@@ -341,6 +353,9 @@ func TestRuntimeBrokerRestartReconnect(t *testing.T) {
 		rec, err := store.GetRecord("proj-reconnect", "agent-reconnect", 2)
 		return err == nil && !rec.NotifiedAt.IsZero() && rec.Body == "message after restart"
 	})
+	if n := atomic.LoadInt64(&factory.count); n == 0 {
+		t.Fatal("CatchUp was never called — message #2 may have arrived via push instead of catch-up")
+	}
 
 	// Step 12: Verify both messages are in store
 	rec1, err := store.GetRecord("proj-reconnect", "agent-reconnect", 1)

--- a/e2e/runtime_integration_test.go
+++ b/e2e/runtime_integration_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -16,12 +17,19 @@ import (
 
 type catchUpCounter struct {
 	rt.ListenerFactory
-	count int64
+	count  int64
+	mu     sync.Mutex
+	bodies []string
 }
 
 func (c *catchUpCounter) CatchUp(w rt.Watch, handler rt.DeliveryHandler) error {
 	atomic.AddInt64(&c.count, 1)
-	return c.ListenerFactory.CatchUp(w, handler)
+	return c.ListenerFactory.CatchUp(w, func(d rt.Delivery) error {
+		c.mu.Lock()
+		c.bodies = append(c.bodies, d.Body)
+		c.mu.Unlock()
+		return handler(d)
+	})
 }
 
 func TestRuntimeEndToEndPushStoreAndPull(t *testing.T) {
@@ -344,6 +352,19 @@ func TestRuntimeBrokerRestartReconnect(t *testing.T) {
 	})
 	if n := atomic.LoadInt64(&factory.count); n == 0 {
 		t.Fatal("CatchUp was never called — message #2 may have arrived via push instead of catch-up")
+	}
+
+	// Verify message #2 was specifically delivered by CatchUp, not push.
+	factory.mu.Lock()
+	var catchUpDeliveredMsg2 bool
+	for _, body := range factory.bodies {
+		if body == "message after restart" {
+			catchUpDeliveredMsg2 = true
+		}
+	}
+	factory.mu.Unlock()
+	if !catchUpDeliveredMsg2 {
+		t.Fatal("message #2 was not delivered by CatchUp — arrived via push instead")
 	}
 
 	// Step 12: Verify both messages are in store

--- a/e2e/runtime_integration_test.go
+++ b/e2e/runtime_integration_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
@@ -26,13 +25,8 @@ func (c *catchUpCounter) CatchUp(w rt.Watch, handler rt.DeliveryHandler) error {
 }
 
 func TestRuntimeEndToEndPushStoreAndPull(t *testing.T) {
-	home, err := os.MkdirTemp("/tmp", "wg-e2e-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		_ = os.RemoveAll(home)
-	})
+	t.Setenv("GOTMPDIR", "/tmp") // keep socket path under macOS 104-byte limit
+	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("WAGGLE_PROJECT_ID", "proj-e2e")
 
@@ -160,13 +154,8 @@ func pullUnreadRecords(store *rt.Store, projectID, agentName string) ([]rt.Deliv
 }
 
 func TestRuntimeBrokerRestartReconnect(t *testing.T) {
-	home, err := os.MkdirTemp("/tmp", "wg-e2e-reconnect-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		_ = os.RemoveAll(home)
-	})
+	t.Setenv("GOTMPDIR", "/tmp") // keep socket path under macOS 104-byte limit
+	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("WAGGLE_PROJECT_ID", "proj-reconnect")
 
@@ -382,15 +371,7 @@ func TestRuntimeBrokerRestartReconnect(t *testing.T) {
 
 func waitForCondition(t *testing.T, name string, fn func() bool) {
 	t.Helper()
-
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		if fn() {
-			return
-		}
-		time.Sleep(25 * time.Millisecond)
-	}
-	t.Fatalf("timeout waiting for %s", name)
+	waitForConditionWithTimeout(t, name, 5*time.Second, fn)
 }
 
 func waitForConditionWithTimeout(t *testing.T, name string, timeout time.Duration, fn func() bool) {

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -1290,41 +1290,46 @@ func TestBroker_SendToSelf(t *testing.T) {
 	}
 }
 
-// TestBroker_SessionNameCollision — connect same name twice, disconnect first, verify second still works for push
+// TestBroker_SessionNameCollision — second connect with same name is rejected (session hijack prevention)
 func TestBroker_SessionNameCollision(t *testing.T) {
 	sockPath, _, cleanup := startTestBroker(t)
 	defer cleanup()
 
 	// Alice connects on first connection
 	c1 := connectClient(t, sockPath)
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	defer c1.Close()
+	resp1, _ := c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	if !resp1.OK {
+		t.Fatalf("first connect failed: %s", resp1.Error)
+	}
 
-	// Alice connects on second connection (overwrites first in sessions map)
+	// Second connection tries same name — must be rejected
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	resp2, _ := c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	if resp2.OK {
+		t.Fatal("expected second connect to fail, but got OK")
+	}
+	if resp2.Code != protocol.ErrAlreadyConnected {
+		t.Fatalf("expected code %s, got %s", protocol.ErrAlreadyConnected, resp2.Code)
+	}
 
-	// First connection disconnects
-	c1.Close()
-	time.Sleep(50 * time.Millisecond)
-
-	// Bob sends to alice — should reach the second connection
+	// Original alice still works — bob can send to her and she receives push
 	c3 := connectClient(t, sockPath)
 	defer c3.Close()
 	c3.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
-	resp, _ := c3.Send(protocol.Request{
+	sendResp, _ := c3.Send(protocol.Request{
 		Cmd:     protocol.CmdSend,
 		Name:    "alice",
 		Message: "test collision",
 	})
-	if !resp.OK {
-		t.Fatalf("send failed: %s", resp.Error)
+	if !sendResp.OK {
+		t.Fatalf("send failed: %s", sendResp.Error)
 	}
 
-	// Alice (second connection) should receive the push
-	pushResp, err := c2.Receive()
+	pushResp, err := c1.Receive()
 	if err != nil {
-		t.Fatalf("alice (second connection) failed to receive push: %v", err)
+		t.Fatalf("alice (first connection) failed to receive push: %v", err)
 	}
 	if !pushResp.OK {
 		t.Fatalf("push response not OK: %s", pushResp.Error)
@@ -1334,6 +1339,57 @@ func TestBroker_SessionNameCollision(t *testing.T) {
 	json.Unmarshal(pushResp.Data, &pushData)
 	if pushData["body"] != "test collision" {
 		t.Errorf("push body = %q, want 'test collision'", pushData["body"])
+	}
+}
+
+// TestBroker_DuplicateNameRejected — dedicated test for session hijack prevention
+func TestBroker_DuplicateNameRejected(t *testing.T) {
+	sockPath, _, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	// Client A connects as "agent-dup"
+	cA := connectClient(t, sockPath)
+	defer cA.Close()
+	respA, _ := cA.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "agent-dup"})
+	if !respA.OK {
+		t.Fatalf("client A connect failed: %s", respA.Error)
+	}
+
+	// Client B tries to connect as "agent-dup" — must be rejected
+	cB := connectClient(t, sockPath)
+	defer cB.Close()
+	respB, _ := cB.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "agent-dup"})
+	if respB.OK {
+		t.Fatal("expected client B connect to fail, but got OK")
+	}
+	if respB.Code != protocol.ErrAlreadyConnected {
+		t.Fatalf("expected code %s, got %s", protocol.ErrAlreadyConnected, respB.Code)
+	}
+
+	// Client A is still functional — verify by sending a message to it
+	cC := connectClient(t, sockPath)
+	defer cC.Close()
+	cC.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "verifier"})
+	sendResp, _ := cC.Send(protocol.Request{
+		Cmd:     protocol.CmdSend,
+		Name:    "agent-dup",
+		Message: "still alive",
+	})
+	if !sendResp.OK {
+		t.Fatalf("send to agent-dup failed: %s", sendResp.Error)
+	}
+
+	pushResp, err := cA.Receive()
+	if err != nil {
+		t.Fatalf("client A failed to receive push: %v", err)
+	}
+	if !pushResp.OK {
+		t.Fatalf("push response not OK: %s", pushResp.Error)
+	}
+	var pushData map[string]interface{}
+	json.Unmarshal(pushResp.Data, &pushData)
+	if pushData["body"] != "still alive" {
+		t.Errorf("push body = %q, want 'still alive'", pushData["body"])
 	}
 }
 

--- a/internal/broker/router.go
+++ b/internal/broker/router.go
@@ -96,8 +96,12 @@ func handleConnect(s *Session, req protocol.Request) protocol.Response {
 		return protocol.ErrResponse(protocol.ErrAlreadyConnected, "already connected")
 	}
 
-	s.name = req.Name
 	s.broker.mu.Lock()
+	if existing, ok := s.broker.sessions[req.Name]; ok && existing != s {
+		s.broker.mu.Unlock()
+		return protocol.ErrResponse(protocol.ErrAlreadyConnected, "session name already in use")
+	}
+	s.name = req.Name
 	s.broker.sessions[s.name] = s
 	s.broker.mu.Unlock()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,6 +88,7 @@ var Defaults = struct {
 	StartupPollInterval                   time.Duration
 	StartupTimeout                        time.Duration
 	DisconnectTimeout                     time.Duration
+	CatchUpMaxRetries                     int
 	RuntimeNotificationRetryLimit         int
 	MaxRetries                            int
 	MaxPriority                           int
@@ -149,6 +150,7 @@ var Defaults = struct {
 	StartupPollInterval:                   100 * time.Millisecond,
 	StartupTimeout:                        2 * time.Second,
 	DisconnectTimeout:                     2 * time.Second,
+	CatchUpMaxRetries:                     3,
 	RuntimeNotificationRetryLimit:         5,
 	MaxRetries:                            3,
 	MaxPriority:                           100,

--- a/internal/runtime/listener.go
+++ b/internal/runtime/listener.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -33,6 +34,73 @@ func (f *BrokerListenerFactory) NewListener(w Watch) (Listener, error) {
 		socketPath: paths.Socket,
 		name:       w.AgentName + "-push",
 	}, nil
+}
+
+func (f *BrokerListenerFactory) CatchUp(w Watch, handler DeliveryHandler) error {
+	if w.ProjectID == "" || w.AgentName == "" {
+		return fmt.Errorf("project_id and agent_name required")
+	}
+
+	paths := config.NewPaths(w.ProjectID)
+	if paths.Socket == "" {
+		return fmt.Errorf("cannot determine broker socket path")
+	}
+
+	c, err := client.Connect(paths.Socket, config.Defaults.ConnectTimeout)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	if err := c.SetDeadline(config.Defaults.ConnectTimeout); err != nil {
+		return fmt.Errorf("set deadline: %w", err)
+	}
+	resp, err := c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: w.AgentName})
+	if err != nil {
+		return err
+	}
+	if !resp.OK {
+		return fmt.Errorf("%s: %s", resp.Code, resp.Error)
+	}
+	if err := c.ClearDeadline(); err != nil {
+		return fmt.Errorf("clear deadline: %w", err)
+	}
+
+	resp, err = c.Send(protocol.Request{Cmd: protocol.CmdInbox})
+	if err != nil {
+		return err
+	}
+	if !resp.OK {
+		return fmt.Errorf("inbox: %s: %s", resp.Code, resp.Error)
+	}
+
+	var msgs []struct {
+		ID        int64  `json:"id"`
+		From      string `json:"from"`
+		Body      string `json:"body"`
+		CreatedAt string `json:"created_at"`
+	}
+	if err := json.Unmarshal(resp.Data, &msgs); err != nil {
+		return fmt.Errorf("parse inbox: %w", err)
+	}
+
+	for _, msg := range msgs {
+		sentAt, err := time.Parse(time.RFC3339, msg.CreatedAt)
+		if err != nil {
+			continue
+		}
+		if err := handler(Delivery{
+			MessageID:  msg.ID,
+			FromName:   msg.From,
+			Body:       msg.Body,
+			SentAt:     sentAt,
+			ReceivedAt: time.Now().UTC(),
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 type brokerListener struct {

--- a/internal/runtime/listener.go
+++ b/internal/runtime/listener.go
@@ -91,7 +91,7 @@ func (f *BrokerListenerFactory) CatchUp(w Watch, handler DeliveryHandler) error 
 	for _, msg := range msgs {
 		sentAt, err := time.Parse(time.RFC3339, msg.CreatedAt)
 		if err != nil {
-			continue
+			return fmt.Errorf("parse created_at for message %d: %w", msg.ID, err)
 		}
 		if err := handler(Delivery{
 			MessageID:  msg.ID,

--- a/internal/runtime/listener.go
+++ b/internal/runtime/listener.go
@@ -50,8 +50,15 @@ func (f *BrokerListenerFactory) CatchUp(w Watch, handler DeliveryHandler) error 
 	if err != nil {
 		return err
 	}
-	defer c.Close()
+	defer func() {
+		// Clean disconnect prevents task requeue and lock release.
+		if err := c.SetDeadline(config.Defaults.DisconnectTimeout); err == nil {
+			_, _ = c.Send(protocol.Request{Cmd: protocol.CmdDisconnect})
+		}
+		c.Close()
+	}()
 
+	// Set deadline for the entire catch-up operation (handshake + inbox + disconnect).
 	if err := c.SetDeadline(config.Defaults.ConnectTimeout); err != nil {
 		return fmt.Errorf("set deadline: %w", err)
 	}
@@ -61,9 +68,6 @@ func (f *BrokerListenerFactory) CatchUp(w Watch, handler DeliveryHandler) error 
 	}
 	if !resp.OK {
 		return fmt.Errorf("%s: %s", resp.Code, resp.Error)
-	}
-	if err := c.ClearDeadline(); err != nil {
-		return fmt.Errorf("clear deadline: %w", err)
 	}
 
 	resp, err = c.Send(protocol.Request{Cmd: protocol.CmdInbox})

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -314,6 +314,7 @@ func (m *Manager) runWatch(ctx context.Context, w Watch) {
 			m.clearDeliveryError(watchListenerErrorKey(w))
 			break
 		}
+		m.clearDeliveryError(watchListenerErrorKey(w))
 
 		err = listener.Listen(ctx, func(d Delivery) error {
 			return m.handleDelivery(w, d)

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -254,7 +254,7 @@ func (m *Manager) stopWatch(key watchKey) {
 	worker.cancel()
 	<-worker.stopped
 	m.clearDeliveryStateForWatch(key)
-	m.clearDeliveryError(watchTransportErrorKey(worker.watch))
+	m.clearDeliveryError(watchListenerErrorKey(worker.watch))
 	m.clearDeliveryError(watchDeliveryErrorKey(worker.watch.ProjectID, worker.watch.AgentName))
 	_ = m.refreshWatchDeliveryState(worker.watch.ProjectID, worker.watch.AgentName)
 }
@@ -286,22 +286,22 @@ func (m *Manager) runWatch(ctx context.Context, w Watch) {
 		}
 		listener, err := m.factory.NewListener(w)
 		if err != nil {
-			m.captureDeliveryError(watchTransportErrorKey(w), fmt.Errorf("create listener for %s/%s: %w", w.ProjectID, w.AgentName, err))
+			m.captureDeliveryError(watchListenerErrorKey(w), fmt.Errorf("create listener for %s/%s: %w", w.ProjectID, w.AgentName, err))
 			if !sleepWithContext(ctx, backoff) {
 				return
 			}
 			backoff = nextReconnectBackoff(backoff)
 			continue
 		}
-		m.clearDeliveryError(watchTransportErrorKey(w))
+		m.clearDeliveryError(watchListenerErrorKey(w))
 		// Catch up on messages queued in the broker during disconnect.
 		// handleDelivery deduplicates via AddRecordIfAbsent, so overlaps with
-		// push delivery are harmless.
+		// listener delivery are harmless.
 		for attempt := 1; attempt <= config.Defaults.CatchUpMaxRetries; attempt++ {
 			if err := m.factory.CatchUp(w, func(d Delivery) error {
 				return m.handleDelivery(w, d)
 			}); err != nil {
-				m.captureDeliveryError(watchTransportErrorKey(w),
+				m.captureDeliveryError(watchListenerErrorKey(w),
 					fmt.Errorf("catch-up inbox for %s/%s (attempt %d/%d): %w",
 						w.ProjectID, w.AgentName, attempt, config.Defaults.CatchUpMaxRetries, err))
 				if attempt < config.Defaults.CatchUpMaxRetries {
@@ -311,7 +311,7 @@ func (m *Manager) runWatch(ctx context.Context, w Watch) {
 				}
 				continue
 			}
-			m.clearDeliveryError(watchTransportErrorKey(w))
+			m.clearDeliveryError(watchListenerErrorKey(w))
 			break
 		}
 
@@ -322,7 +322,7 @@ func (m *Manager) runWatch(ctx context.Context, w Watch) {
 			return
 		}
 		if err != nil {
-			m.captureDeliveryError(watchTransportErrorKey(w), fmt.Errorf("listen for %s/%s: %w", w.ProjectID, w.AgentName, err))
+			m.captureDeliveryError(watchListenerErrorKey(w), fmt.Errorf("listen for %s/%s: %w", w.ProjectID, w.AgentName, err))
 			if !sleepWithContext(ctx, backoff) {
 				return
 			}
@@ -497,8 +497,8 @@ func (m *Manager) clearDeliveryError(key string) {
 	delete(m.lastDeliveryErr, key)
 }
 
-func watchTransportErrorKey(w Watch) string {
-	return fmt.Sprintf("watch-transport/%s/%s", w.ProjectID, w.AgentName)
+func watchListenerErrorKey(w Watch) string {
+	return fmt.Sprintf("watch-listener/%s/%s", w.ProjectID, w.AgentName)
 }
 
 func watchDeliveryErrorKey(projectID, agentName string) string {

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -255,6 +255,7 @@ func (m *Manager) stopWatch(key watchKey) {
 	<-worker.stopped
 	m.clearDeliveryStateForWatch(key)
 	m.clearDeliveryError(watchListenerErrorKey(worker.watch))
+	m.clearDeliveryError(watchCatchUpErrorKey(worker.watch))
 	m.clearDeliveryError(watchDeliveryErrorKey(worker.watch.ProjectID, worker.watch.AgentName))
 	_ = m.refreshWatchDeliveryState(worker.watch.ProjectID, worker.watch.AgentName)
 }
@@ -301,7 +302,7 @@ func (m *Manager) runWatch(ctx context.Context, w Watch) {
 			if err := m.factory.CatchUp(w, func(d Delivery) error {
 				return m.handleDelivery(w, d)
 			}); err != nil {
-				m.captureDeliveryError(watchListenerErrorKey(w),
+				m.captureDeliveryError(watchCatchUpErrorKey(w),
 					fmt.Errorf("catch-up inbox for %s/%s (attempt %d/%d): %w",
 						w.ProjectID, w.AgentName, attempt, config.Defaults.CatchUpMaxRetries, err))
 				if attempt < config.Defaults.CatchUpMaxRetries {
@@ -311,10 +312,9 @@ func (m *Manager) runWatch(ctx context.Context, w Watch) {
 				}
 				continue
 			}
-			m.clearDeliveryError(watchListenerErrorKey(w))
+			m.clearDeliveryError(watchCatchUpErrorKey(w))
 			break
 		}
-		m.clearDeliveryError(watchListenerErrorKey(w))
 
 		err = listener.Listen(ctx, func(d Delivery) error {
 			return m.handleDelivery(w, d)
@@ -500,6 +500,10 @@ func (m *Manager) clearDeliveryError(key string) {
 
 func watchListenerErrorKey(w Watch) string {
 	return fmt.Sprintf("watch-listener/%s/%s", w.ProjectID, w.AgentName)
+}
+
+func watchCatchUpErrorKey(w Watch) string {
+	return fmt.Sprintf("watch-catchup/%s/%s", w.ProjectID, w.AgentName)
 }
 
 func watchDeliveryErrorKey(projectID, agentName string) string {

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -297,11 +297,22 @@ func (m *Manager) runWatch(ctx context.Context, w Watch) {
 		// Catch up on messages queued in the broker during disconnect.
 		// handleDelivery deduplicates via AddRecordIfAbsent, so overlaps with
 		// push delivery are harmless.
-		if err := m.factory.CatchUp(w, func(d Delivery) error {
-			return m.handleDelivery(w, d)
-		}); err != nil {
-			// CatchUp failure is non-fatal — push stream still works.
-			m.captureDeliveryError(watchTransportErrorKey(w), fmt.Errorf("catch-up inbox for %s/%s: %w", w.ProjectID, w.AgentName, err))
+		for attempt := 1; attempt <= config.Defaults.CatchUpMaxRetries; attempt++ {
+			if err := m.factory.CatchUp(w, func(d Delivery) error {
+				return m.handleDelivery(w, d)
+			}); err != nil {
+				m.captureDeliveryError(watchTransportErrorKey(w),
+					fmt.Errorf("catch-up inbox for %s/%s (attempt %d/%d): %w",
+						w.ProjectID, w.AgentName, attempt, config.Defaults.CatchUpMaxRetries, err))
+				if attempt < config.Defaults.CatchUpMaxRetries {
+					if !sleepWithContext(ctx, config.Defaults.PollInterval) {
+						return
+					}
+				}
+				continue
+			}
+			m.clearDeliveryError(watchTransportErrorKey(w))
+			break
 		}
 
 		err = listener.Listen(ctx, func(d Delivery) error {

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -36,6 +36,7 @@ type Listener interface {
 // ListenerFactory creates listeners for persisted watches.
 type ListenerFactory interface {
 	NewListener(w Watch) (Listener, error)
+	CatchUp(w Watch, handler DeliveryHandler) error
 }
 
 type watchKey struct {
@@ -293,6 +294,15 @@ func (m *Manager) runWatch(ctx context.Context, w Watch) {
 			continue
 		}
 		m.clearDeliveryError(watchTransportErrorKey(w))
+		// Catch up on messages queued in the broker during disconnect.
+		// handleDelivery deduplicates via AddRecordIfAbsent, so overlaps with
+		// push delivery are harmless.
+		if err := m.factory.CatchUp(w, func(d Delivery) error {
+			return m.handleDelivery(w, d)
+		}); err != nil {
+			// CatchUp failure is non-fatal — push stream still works.
+			m.captureDeliveryError(watchTransportErrorKey(w), fmt.Errorf("catch-up inbox for %s/%s: %w", w.ProjectID, w.AgentName, err))
+		}
 
 		err = listener.Listen(ctx, func(d Delivery) error {
 			return m.handleDelivery(w, d)

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -1007,6 +1007,44 @@ func TestManager_UsesRuntimeRetrySweepInterval(t *testing.T) {
 	})
 }
 
+func TestManager_RetriesCatchUpBeforeListening(t *testing.T) {
+	store := newTestStore(t)
+	watch := Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}
+	if err := store.UpsertWatch(watch); err != nil {
+		t.Fatal(err)
+	}
+
+	origPoll := config.Defaults.PollInterval
+	origRetries := config.Defaults.CatchUpMaxRetries
+	config.Defaults.PollInterval = 10 * time.Millisecond
+	config.Defaults.CatchUpMaxRetries = 3
+	defer func() {
+		config.Defaults.PollInterval = origPoll
+		config.Defaults.CatchUpMaxRetries = origRetries
+	}()
+
+	factory := newCatchUpRetryFactory([]error{
+		errors.New("first catch-up failed"),
+		errors.New("second catch-up failed"),
+		nil,
+	})
+	manager := NewManager(store, factory, &fakeNotifier{})
+
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Stop()
+
+	_ = factory.waitForListener(t, watch)
+	waitFor(t, "catch-up retries", func() bool {
+		return factory.catchUpCallCount() == 3
+	})
+
+	if err := manager.LastDeliveryError(); err != nil {
+		t.Fatalf("LastDeliveryError() = %v, want nil after catch-up retry success", err)
+	}
+}
+
 func TestManager_RetryPendingNotificationsContinuesPastFailedRecord(t *testing.T) {
 	store := newTestStore(t)
 	manager := NewManager(store, newFakeListenerFactory(), &fakeNotifier{
@@ -1707,6 +1745,38 @@ func waitForNewListener(t *testing.T, f *fakeListenerFactory, watch Watch, prior
 		return next != nil && next != prior
 	})
 	return next
+}
+
+type catchUpRetryFactory struct {
+	*fakeListenerFactory
+	mu         sync.Mutex
+	catchUpErr []error
+	catchUpCnt int
+}
+
+func newCatchUpRetryFactory(errs []error) *catchUpRetryFactory {
+	return &catchUpRetryFactory{
+		fakeListenerFactory: newFakeListenerFactory(),
+		catchUpErr:          append([]error(nil), errs...),
+	}
+}
+
+func (f *catchUpRetryFactory) CatchUp(_ Watch, _ DeliveryHandler) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.catchUpCnt++
+	if len(f.catchUpErr) == 0 {
+		return nil
+	}
+	err := f.catchUpErr[0]
+	f.catchUpErr = f.catchUpErr[1:]
+	return err
+}
+
+func (f *catchUpRetryFactory) catchUpCallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.catchUpCnt
 }
 
 type fakeListener struct {

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -1672,6 +1672,10 @@ func (f *fakeListenerFactory) NewListener(w Watch) (Listener, error) {
 	return listener, nil
 }
 
+func (f *fakeListenerFactory) CatchUp(w Watch, handler DeliveryHandler) error {
+	return nil
+}
+
 func (f *fakeListenerFactory) waitForListener(t *testing.T, watch Watch) *fakeListener {
 	t.Helper()
 
@@ -1785,6 +1789,10 @@ func (f *restartingListenerFactory) NewListener(_ Watch) (Listener, error) {
 	f.listeners = append(f.listeners, l)
 	f.created <- l
 	return l, nil
+}
+
+func (f *restartingListenerFactory) CatchUp(w Watch, handler DeliveryHandler) error {
+	return nil
 }
 
 func (f *restartingListenerFactory) waitForCreated(t *testing.T, want int) *restartableListener {

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -340,6 +340,49 @@ func TestManager_ReconcileClearsOnlyReconcileErrorOnSuccess(t *testing.T) {
 	}
 }
 
+func TestManager_CatchUpAndListenErrorsVisibleSimultaneously(t *testing.T) {
+	store := newTestStore(t)
+	manager := NewManager(store, newFakeListenerFactory(), &fakeNotifier{})
+
+	w := Watch{ProjectID: "proj-x", AgentName: "agent-y"}
+
+	// Inject both error keys simultaneously.
+	manager.captureDeliveryError(watchCatchUpErrorKey(w), errors.New("catch-up failed"))
+	manager.captureDeliveryError(watchListenerErrorKey(w), errors.New("listen failed"))
+
+	err := manager.LastDeliveryError()
+	if err == nil {
+		t.Fatal("LastDeliveryError() = nil, want both errors")
+	}
+	errStr := err.Error()
+	if !strings.Contains(errStr, "watch-catchup/") {
+		t.Fatalf("LastDeliveryError() = %v, want catch-up error present", err)
+	}
+	if !strings.Contains(errStr, "watch-listener/") {
+		t.Fatalf("LastDeliveryError() = %v, want listener error present", err)
+	}
+
+	// Clear only catch-up — listener error must survive.
+	manager.clearDeliveryError(watchCatchUpErrorKey(w))
+	err = manager.LastDeliveryError()
+	if err == nil {
+		t.Fatal("LastDeliveryError() = nil after clearing catch-up, want listener error")
+	}
+	errStr = err.Error()
+	if strings.Contains(errStr, "watch-catchup/") {
+		t.Fatalf("LastDeliveryError() = %v, want catch-up error gone", err)
+	}
+	if !strings.Contains(errStr, "watch-listener/") {
+		t.Fatalf("LastDeliveryError() = %v, want listener error still present", err)
+	}
+
+	// Clear listener — no errors remain.
+	manager.clearDeliveryError(watchListenerErrorKey(w))
+	if err := manager.LastDeliveryError(); err != nil {
+		t.Fatalf("LastDeliveryError() = %v, want nil", err)
+	}
+}
+
 func TestManager_UsesRuntimeReconcileIntervalForWatchReconciliation(t *testing.T) {
 	store := newTestStore(t)
 	factory := newFakeListenerFactory()

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -324,7 +324,7 @@ func TestManager_ReconcileClearsOnlyReconcileErrorOnSuccess(t *testing.T) {
 	manager := NewManager(store, newFakeListenerFactory(), &fakeNotifier{})
 
 	manager.captureDeliveryError("reconcile", errors.New("stale reconcile error"))
-	manager.captureDeliveryError(watchTransportErrorKey(Watch{ProjectID: "proj-a", AgentName: "agent-1"}), errors.New("live watch error"))
+	manager.captureDeliveryError(watchListenerErrorKey(Watch{ProjectID: "proj-a", AgentName: "agent-1"}), errors.New("live watch error"))
 	if err := manager.reconcile(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -335,7 +335,7 @@ func TestManager_ReconcileClearsOnlyReconcileErrorOnSuccess(t *testing.T) {
 	if strings.Contains(err.Error(), "reconcile") {
 		t.Fatalf("LastDeliveryError() = %v, want reconcile error cleared", err)
 	}
-	if !strings.Contains(err.Error(), "watch-transport/proj-a/agent-1") {
+	if !strings.Contains(err.Error(), "watch-listener/proj-a/agent-1") {
 		t.Fatalf("LastDeliveryError() = %v, want remaining watch error", err)
 	}
 }
@@ -427,7 +427,7 @@ func TestManager_StopWatchClearsWorkerErrorsButPreservesDetachedInflightState(t 
 	manager.mu.Lock()
 	manager.inflight[key] = struct{}{}
 	manager.mu.Unlock()
-	manager.captureDeliveryError(watchTransportErrorKey(watch), errors.New("transport error"))
+	manager.captureDeliveryError(watchListenerErrorKey(watch), errors.New("transport error"))
 	manager.captureDeliveryError(watchDeliveryErrorKey(watch.ProjectID, watch.AgentName), errors.New("delivery error"))
 	manager.captureDeliveryError(refreshDeliveryStatusErrorKey(watch.ProjectID, watch.AgentName), errors.New("status refresh error"))
 
@@ -439,7 +439,7 @@ func TestManager_StopWatchClearsWorkerErrorsButPreservesDetachedInflightState(t 
 		manager.mu.Lock()
 		defer manager.mu.Unlock()
 		_, inflightExists := manager.inflight[key]
-		_, transportExists := manager.lastDeliveryErr[watchTransportErrorKey(watch)]
+		_, transportExists := manager.lastDeliveryErr[watchListenerErrorKey(watch)]
 		_, deliveryExists := manager.lastDeliveryErr[watchDeliveryErrorKey(watch.ProjectID, watch.AgentName)]
 		_, statusExists := manager.lastDeliveryErr[refreshDeliveryStatusErrorKey(watch.ProjectID, watch.AgentName)]
 		return len(manager.workers) == 0 && inflightExists && !transportExists && !deliveryExists && !statusExists
@@ -1040,9 +1040,9 @@ func TestManager_RetriesCatchUpBeforeListening(t *testing.T) {
 		return factory.catchUpCallCount() == 3
 	})
 
-	if err := manager.LastDeliveryError(); err != nil {
-		t.Fatalf("LastDeliveryError() = %v, want nil after catch-up retry success", err)
-	}
+	waitFor(t, "catch-up error cleared", func() bool {
+		return manager.LastDeliveryError() == nil
+	})
 }
 
 func TestManager_RetryPendingNotificationsContinuesPastFailedRecord(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds **reconnect catch-up recovery** to the Waggle runtime manager and **hardens broker session identity**. When the broker restarts, the runtime recovers missed messages by connecting to the new broker, reading the inbox, and delivering them through the existing dedup pipeline. The broker now rejects duplicate session names to prevent session hijack.

Closes #74

## What changed

| File | Change |
|------|--------|
| `internal/runtime/listener.go` | `CatchUp()` method — connects to broker, reads inbox via `CmdInbox`, delivers missed messages |
| `internal/runtime/manager.go` | CatchUp retry loop in `runWatch()`, separate CatchUp/Listen error keys |
| `internal/runtime/manager_test.go` | CatchUp retry test, factory stubs, race-stable assertions |
| `internal/config/config.go` | `CatchUpMaxRetries` config (default: 3) |
| `internal/broker/router.go` | `handleConnect` rejects duplicate session names with `ALREADY_CONNECTED` |
| `internal/broker/broker_test.go` | Duplicate-name rejection tests, updated collision test |
| `e2e/runtime_integration_test.go` | E2E test proving post-restart message recovery specifically via CatchUp |

**7 files changed**

## Design

1. **CatchUp method** — On reconnect, runtime connects to broker as the agent, reads inbox via `CmdInbox`, delivers each message through `handleDelivery` (dedup via `AddRecordIfAbsent`)
2. **Retry loop** — CatchUp retries up to `CatchUpMaxRetries` (3) with `PollInterval` backoff
3. **Fail loud** — Timestamp parse errors return an error (not silently skipped), triggering retry
4. **Session hijack prevention** — Broker rejects `CONNECT` with a name already in use by another session
5. **Independent error observability** — CatchUp errors use `watch-catchup/` key, Listen errors use `watch-listener/` key, so `waggle status` shows both independently
6. **E2E proof** — Test starts broker, sends message #1, shuts down broker, starts new broker, sends message #2, verifies message #2 was specifically delivered by CatchUp (tracked via instrumented handler)

## Trust boundary

This PR operates under **Option 1: trust same-user local access**. Same-user local DB/socket access is trusted. The PR does not claim or implement cross-agent isolation.

## Review history

Adversarially reviewed by Claude, Gemini, and Codex at multiple SHAs.

| Finding | Reviewer | Resolution |
|---------|----------|------------|
| Silent message drop on timestamp parse | Claude, Gemini, Codex | **Fixed** — return error instead of continue |
| Stale CatchUp error during Listen | Claude, Gemini | **Fixed** — separate `watchCatchUpErrorKey` |
| CatchUp error hides backlog failure | Codex | **Fixed** — separate error keys preserve both signals |
| E2E does not prove CatchUp delivered msg #2 | Codex | **Fixed** — instrumented handler tracks CatchUp deliveries |
| CatchUp hijacks real agent session | Codex | **Fixed** — broker rejects duplicate session names |
| `os.MkdirTemp` instead of `t.TempDir()` | Gemini | **Fixed** — `t.TempDir()` with `GOTMPDIR` for macOS socket limit |
| `waitForCondition` duplication | Gemini | **Fixed** — delegates to `waitForConditionWithTimeout` |
| Stale `watchTransportErrorKey` naming | Claude | **Fixed** — renamed to `watchListenerErrorKey` |
| Race in CatchUp retry test | Verification | **Fixed** — async `waitFor` instead of synchronous assertion |
| CatchUp-Listen message gap | Claude, Gemini, Codex | **Architectural** — tracked in #98 |
| No ack / unbounded inbox | Gemini | **Architectural** — tracked in #98 |
| Inbox size ceiling (1MB buffer) | Codex, Claude | **Architectural** — tracked in #98 |
| Notification timeout blocks CatchUp | Gemini | **Disproven** — socket deadline only affects I/O; handler loop is local |

## Known Limitations

Three architectural limitations require broker protocol changes, tracked in **#98 (Phase 2: gapless delivery protocol)**:

1. **CatchUp-Listen gap (~10-100ms)** — Between CatchUp disconnect and Listen connect, messages are stored but not pushed. Recovered on next reconnect.
2. **CatchUp re-reads full inbox** — No `CmdAck` means every CatchUp fetches entire agent history.
3. **Inbox size bounded by 1MB buffer / 5s deadline** — Large backlogs can exceed client buffer or timeout.

**Before this PR**, all three were worse: missed messages during disconnect were **unrecoverable**. This PR makes reconnect strictly better while the protocol evolves.

## Verification

All checks pass on current tip:

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./... -count=1` — 15/15 packages pass
- `go test -race ./internal/runtime/... -count=1` — clean
- `go test -race ./internal/broker/... -count=1` — clean
- `go test ./e2e/... -v -run TestRuntimeBrokerRestartReconnect` — pass
- `waggle --help` from `/tmp` without broker — pass