### PR TITLE
feat: Augment adapter integration (#90)

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -77,8 +77,22 @@ var installCmd = &cobra.Command{
 				}
 				printJSON(map[string]any{"ok": true, "message": "Auggie integration installed. Restart Auggie to activate."})
 			}
+		case "augment":
+			if installUninstall {
+				if err := install.UninstallAugment(); err != nil {
+					printErr("INSTALL_ERROR", err.Error())
+					return nil
+				}
+				printJSON(map[string]any{"ok": true, "message": "Augment integration removed"})
+			} else {
+				if err := install.InstallAugment(); err != nil {
+					printErr("INSTALL_ERROR", err.Error())
+					return nil
+				}
+				printJSON(map[string]any{"ok": true, "message": "Augment integration installed. Restart Augment to activate."})
+			}
 		default:
-			printErr("INVALID_REQUEST", fmt.Sprintf("unknown platform: %s (supported: claude-code, codex, gemini, auggie)", platform))
+			printErr("INVALID_REQUEST", fmt.Sprintf("unknown platform: %s (supported: claude-code, codex, gemini, auggie, augment)", platform))
 		}
 		return nil
 	},

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -159,6 +159,10 @@ func buildAdapterStatus(homeDir string) map[string]any {
 	agIssues, agState := install.CheckAuggie(homeDir)
 	result["auggie"] = formatAdapterState(agState, agIssues, "waggle install auggie")
 
+	// Check Augment
+	augIssues, augState := install.CheckAugment(homeDir)
+	result["augment"] = formatAdapterState(augState, augIssues, "waggle install augment")
+
 	return result
 }
 

--- a/docs/augment-adapter-design.md
+++ b/docs/augment-adapter-design.md
@@ -1,0 +1,62 @@
+# Augment Adapter Design
+
+## 1. Source of Truth for Session Identity
+
+Agent identity is derived from the `waggle adapter bootstrap augment --format markdown` command output. This command returns the agent name assigned by the broker for the current session. The identity is **ephemeral per session** but **stable across commands within that session**.
+
+The Augment skill file (installed at `~/.augment/skills/waggle.md`) contains the bootstrap instruction but does not hardcode any state. State lives in the broker.
+
+## 2. Detecting Active Augment Workspace
+
+The workspace is detected by checking for the presence of `~/.augment/` directory with a `skills/` subdirectory. Within this directory, the file `~/.augment/skills/waggle.md` serves as the fingerprint — its presence and content signal that Augment has been integrated with Waggle.
+
+The detection is passive and file-based, not dynamic. It does not require Augment to be running.
+
+## 3. Normal Path (No User Commands)
+
+**Single user action:** `waggle install augment` (run once, in any waggle-enabled repo)
+
+**Automatic path thereafter:**
+1. User opens Augment session in waggle-enabled repo
+2. Augment reads `~/.augment/skills/waggle.md` at session start
+3. Augment sees the `<!-- WAGGLE-AUGMENT-BEGIN -->` block with instruction
+4. Augment **automatically executes** `waggle adapter bootstrap augment --format markdown` at session start
+5. Broker assigns agent identity and returns it to Augment
+6. Augment receives agent name and uses it for all waggle commands in that session
+
+**Zero additional user action required after install.**
+
+## 4. Fallback Path & Temporary Tracking
+
+If the skill file is missing or malformed:
+- User can manually run `waggle adapter bootstrap augment --format markdown`
+- This is a **temporary workaround**, not the normal path
+- Manual runs are not tracked or encouraged — they indicate installation failure
+
+Fallback is documented in error messages but requires explicit user action, reinforcing that install is the correct path.
+
+## 5. No Dual Transport
+
+This design creates **one authoritative path**:
+- **Wire path:** Augment → broker via socket (using waggle client)
+- **Configuration path:** Install writes to `~/.augment/skills/waggle.md` (Augment's config)
+- **Bootstrap path:** Augment calls `waggle adapter bootstrap augment` (single source of truth)
+
+There is no second transport. Augment does not directly register with the broker. Augment does not create parallel connection state. All coordination flows through the single `adapter bootstrap` command.
+
+## 6. User Interaction Elimination
+
+**Before this PR:**
+- User runs `waggle install augment` (installs integration)
+- User manually runs `waggle adapter bootstrap augment` in **every Augment session**
+- Augment never receives coordination messages
+- Manual step required, error-prone, UX friction
+
+**After this PR:**
+- User runs `waggle install augment` **once** (installs integration)
+- Augment skill file automatically bootstraps at session start
+- Augment receives agent name from bootstrap output
+- Augment can receive coordination messages
+- **Zero manual steps per session**
+
+The skill file becomes a persistent contract: "Augment will run this command at session start." Users do not manually run `adapter bootstrap` anymore.

--- a/docs/augment-adapter-design.md
+++ b/docs/augment-adapter-design.md
@@ -29,11 +29,9 @@ The detection is passive and file-based, not dynamic. It does not require Augmen
 ## 4. Fallback Path & Temporary Tracking
 
 If the skill file is missing or malformed:
-- User can manually run `waggle adapter bootstrap augment --format markdown`
-- This is a **temporary workaround**, not the normal path
+- `waggle status` reports the adapter as `broken` or `not_installed` with repair guidance: `waggle install augment`
+- User can manually run `waggle adapter bootstrap augment --format markdown` as a temporary workaround
 - Manual runs are not tracked or encouraged — they indicate installation failure
-
-Fallback is documented in error messages but requires explicit user action, reinforcing that install is the correct path.
 
 ## 5. No Dual Transport
 

--- a/docs/augment-adapter-design.md
+++ b/docs/augment-adapter-design.md
@@ -29,7 +29,7 @@ The detection is passive and file-based, not dynamic. It does not require Augmen
 ## 4. Fallback Path & Temporary Tracking
 
 If the skill file is missing or malformed:
-- `waggle status` reports the adapter as `broken` or `not_installed` with repair guidance: `waggle install augment`
+- `waggle status` reports the adapter as `broken` with repair guidance (`waggle install augment`) or `not_installed` without repair guidance
 - User can manually run `waggle adapter bootstrap augment --format markdown` as a temporary workaround
 - Manual runs are not tracked or encouraged — they indicate installation failure
 

--- a/e2e_zombie_test.go
+++ b/e2e_zombie_test.go
@@ -195,6 +195,12 @@ func TestE2E_ZombieFailFast_NoAutoStart(t *testing.T) {
 		if !strings.Contains(output, `"BROKER_UNRESPONSIVE"`) {
 			t.Errorf("expected BROKER_UNRESPONSIVE code in output, got:\n%s", output)
 		}
+		if !strings.Contains(output, `"adapters"`) {
+			t.Errorf("expected adapters in output, got:\n%s", output)
+		}
+		if !strings.Contains(output, `"augment"`) {
+			t.Errorf("expected augment adapter status in output, got:\n%s", output)
+		}
 	case <-time.After(10 * time.Second):
 		if cmd.Process != nil {
 			cmd.Process.Kill()

--- a/e2e_zombie_test.go
+++ b/e2e_zombie_test.go
@@ -198,7 +198,7 @@ func TestE2E_ZombieFailFast_NoAutoStart(t *testing.T) {
 		if !strings.Contains(output, `"adapters"`) {
 			t.Errorf("expected adapters in output, got:\n%s", output)
 		}
-		if !strings.Contains(output, `"augment"`) {
+		if !strings.Contains(output, `"augment":`) {
 			t.Errorf("expected augment adapter status in output, got:\n%s", output)
 		}
 	case <-time.After(10 * time.Second):
@@ -311,6 +311,7 @@ func TestE2E_HelpFromNonGitDir(t *testing.T) {
 		{"task", "--help"},
 		{"lock", "--help"},
 		{"events", "--help"},
+		{"install", "--help"},
 		{"listen", "-h"},
 	}
 

--- a/integrations/augment/SKILL-block.md
+++ b/integrations/augment/SKILL-block.md
@@ -1,0 +1,7 @@
+## Waggle Runtime
+
+At the start of every session in a waggle-enabled repository, run:
+
+    waggle adapter bootstrap augment --format markdown
+
+Do not skip this step. If waggle is not installed, the command will fail silently — continue normally. Use the agent name from the output for any subsequent waggle commands in this session.

--- a/integrations/augment/SKILL-block.md
+++ b/integrations/augment/SKILL-block.md
@@ -1,7 +1,12 @@
 ## Waggle Runtime
 
-At the start of every session in a waggle-enabled repository, run:
+At the start of every session, run:
 
     waggle adapter bootstrap augment --format markdown
 
-Do not skip this step. If waggle is not installed, the command will fail silently — continue normally. Use the agent name from the output for any subsequent waggle commands in this session.
+What to do with the result:
+
+1. If the command succeeds, note the `Agent:` value from the output and use it for any subsequent waggle commands in this session.
+2. If the command fails or waggle is not installed, continue normally — this is not an error.
+
+Do not start background listeners or invent a separate transport path. The bootstrap command is the single entry point for waggle coordination.

--- a/internal/install/augment.go
+++ b/internal/install/augment.go
@@ -57,7 +57,7 @@ func uninstallAugment(homeDir string) error {
 	skillPath := filepath.Join(augmentDir, "skills", "waggle.md")
 
 	if err := removeManagedBlock(skillPath, augmentBlockBegin, augmentBlockEnd); err != nil {
-		return fmt.Errorf("updating Augment waggle.md: %w", err)
+		return fmt.Errorf("removing managed block from Augment waggle.md: %w", err)
 	}
 
 	return nil

--- a/internal/install/augment.go
+++ b/internal/install/augment.go
@@ -1,0 +1,64 @@
+package install
+
+import (
+	"embed"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	augmentBlockBegin = "<!-- WAGGLE-AUGMENT-BEGIN -->"
+	augmentBlockEnd   = "<!-- WAGGLE-AUGMENT-END -->"
+)
+
+// The canonical Augment integration assets live in integrations/augment/.
+// This mirrored copy exists in-package so go:embed can bundle them for install.
+//
+//go:embed all:augment
+var augmentFiles embed.FS
+
+func InstallAugment() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("getting home dir: %w", err)
+	}
+	return installAugment(home)
+}
+
+func UninstallAugment() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("getting home dir: %w", err)
+	}
+	return uninstallAugment(home)
+}
+
+func installAugment(homeDir string) error {
+	augmentDir := filepath.Join(homeDir, ".augment")
+	skillDir := filepath.Join(augmentDir, "skills")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		return fmt.Errorf("creating Augment skill dir: %w", err)
+	}
+
+	blockData, err := augmentFiles.ReadFile("augment/SKILL-block.md")
+	if err != nil {
+		return fmt.Errorf("reading embedded Augment block: %w", err)
+	}
+	if err := upsertManagedBlock(filepath.Join(skillDir, "waggle.md"), augmentBlockBegin, augmentBlockEnd, string(blockData)); err != nil {
+		return fmt.Errorf("updating Augment waggle.md: %w", err)
+	}
+
+	return nil
+}
+
+func uninstallAugment(homeDir string) error {
+	augmentDir := filepath.Join(homeDir, ".augment")
+	skillPath := filepath.Join(augmentDir, "skills", "waggle.md")
+
+	if err := removeManagedBlock(skillPath, augmentBlockBegin, augmentBlockEnd); err != nil {
+		return fmt.Errorf("updating Augment waggle.md: %w", err)
+	}
+
+	return nil
+}

--- a/internal/install/augment/SKILL-block.md
+++ b/internal/install/augment/SKILL-block.md
@@ -1,0 +1,7 @@
+## Waggle Runtime
+
+At the start of every session in a waggle-enabled repository, run:
+
+    waggle adapter bootstrap augment --format markdown
+
+Do not skip this step. If waggle is not installed, the command will fail silently — continue normally. Use the agent name from the output for any subsequent waggle commands in this session.

--- a/internal/install/augment/SKILL-block.md
+++ b/internal/install/augment/SKILL-block.md
@@ -1,7 +1,12 @@
 ## Waggle Runtime
 
-At the start of every session in a waggle-enabled repository, run:
+At the start of every session, run:
 
     waggle adapter bootstrap augment --format markdown
 
-Do not skip this step. If waggle is not installed, the command will fail silently — continue normally. Use the agent name from the output for any subsequent waggle commands in this session.
+What to do with the result:
+
+1. If the command succeeds, note the `Agent:` value from the output and use it for any subsequent waggle commands in this session.
+2. If the command fails or waggle is not installed, continue normally — this is not an error.
+
+Do not start background listeners or invent a separate transport path. The bootstrap command is the single entry point for waggle coordination.

--- a/internal/install/augment_test.go
+++ b/internal/install/augment_test.go
@@ -1,0 +1,236 @@
+package install
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstall_AugmentCreatesBlock(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	if err := installAugment(tmpHome); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	skillPath := filepath.Join(tmpHome, ".augment", "skills", "waggle.md")
+	data, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("skill file not created: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, augmentBlockBegin) {
+		t.Errorf("begin marker not found in waggle.md")
+	}
+	if !strings.Contains(content, augmentBlockEnd) {
+		t.Errorf("end marker not found in waggle.md")
+	}
+}
+
+func TestInstall_AugmentIdempotent(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	if err := installAugment(tmpHome); err != nil {
+		t.Fatalf("first install failed: %v", err)
+	}
+	if err := installAugment(tmpHome); err != nil {
+		t.Fatalf("second install failed: %v", err)
+	}
+
+	skillPath := filepath.Join(tmpHome, ".augment", "skills", "waggle.md")
+	data, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+
+	count := strings.Count(string(data), augmentBlockBegin)
+	if count != 1 {
+		t.Errorf("expected 1 block, got %d", count)
+	}
+}
+
+func TestInstall_AugmentUninstall(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	if err := installAugment(tmpHome); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+	if err := uninstallAugment(tmpHome); err != nil {
+		t.Fatalf("uninstall failed: %v", err)
+	}
+
+	skillPath := filepath.Join(tmpHome, ".augment", "skills", "waggle.md")
+	data, err := os.ReadFile(skillPath)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("read failed: %v", err)
+	}
+	if err == nil {
+		content := string(data)
+		if strings.Contains(content, augmentBlockBegin) {
+			t.Errorf("block still present after uninstall")
+		}
+	}
+}
+
+func TestInstall_AugmentPreservesOtherContent(t *testing.T) {
+	tmpHome := t.TempDir()
+	augmentDir := filepath.Join(tmpHome, ".augment", "skills")
+	os.MkdirAll(augmentDir, 0755)
+
+	skillPath := filepath.Join(augmentDir, "waggle.md")
+	original := "# Existing content\n\nKeep this.\n"
+	os.WriteFile(skillPath, []byte(original), 0644)
+
+	if err := installAugment(tmpHome); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	data, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "# Existing content") {
+		t.Errorf("existing content was removed")
+	}
+	if !strings.Contains(content, augmentBlockBegin) {
+		t.Errorf("managed block not added")
+	}
+}
+
+func TestCheckAugment_NotInstalled(t *testing.T) {
+	tmpHome := t.TempDir()
+	issues, state := CheckAugment(tmpHome)
+
+	if state != StateNotInstalled {
+		t.Errorf("expected StateNotInstalled, got %d", state)
+	}
+	if len(issues) != 0 {
+		t.Errorf("expected no issues, got %d", len(issues))
+	}
+}
+
+func TestCheckAugment_NotInstalledNoMarker(t *testing.T) {
+	tmpHome := t.TempDir()
+	augmentDir := filepath.Join(tmpHome, ".augment", "skills")
+	os.MkdirAll(augmentDir, 0755)
+
+	// Create skill file without marker
+	skillPath := filepath.Join(augmentDir, "waggle.md")
+	os.WriteFile(skillPath, []byte("# No marker here\n"), 0644)
+
+	issues, state := CheckAugment(tmpHome)
+
+	if state != StateNotInstalled {
+		t.Errorf("expected StateNotInstalled, got %d", state)
+	}
+	if len(issues) != 0 {
+		t.Errorf("expected no issues, got %d", len(issues))
+	}
+}
+
+func TestCheckAugment_Healthy(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	if err := installAugment(tmpHome); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	issues, state := CheckAugment(tmpHome)
+
+	if state != StateHealthy {
+		t.Errorf("expected StateHealthy, got %d", state)
+	}
+	if len(issues) != 0 {
+		t.Errorf("expected no issues, got %d: %v", len(issues), issues)
+	}
+}
+
+func TestCheckAugment_Broken(t *testing.T) {
+	tmpHome := t.TempDir()
+	augmentDir := filepath.Join(tmpHome, ".augment", "skills")
+	os.MkdirAll(augmentDir, 0755)
+
+	// Create skill file with begin marker but missing end marker
+	skillPath := filepath.Join(augmentDir, "waggle.md")
+	os.WriteFile(skillPath, []byte("<!-- WAGGLE-AUGMENT-BEGIN -->\nBroken block\n"), 0644)
+
+	issues, state := CheckAugment(tmpHome)
+
+	if state != StateBroken {
+		t.Errorf("expected StateBroken, got %d", state)
+	}
+	if len(issues) == 0 {
+		t.Errorf("expected issues for broken block, got none")
+	}
+}
+
+func TestEmbeddedAugmentFilesMatch(t *testing.T) {
+	sourceDir := filepath.Join("..", "..", "integrations", "augment")
+	embedDir := filepath.Join("augment")
+
+	if _, err := os.Stat(sourceDir); os.IsNotExist(err) {
+		t.Skip("source directory not found (running outside repo root)")
+	}
+
+	sourceFiles := make(map[string][]byte)
+	err := filepath.WalkDir(sourceDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, _ := filepath.Rel(sourceDir, path)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		sourceFiles[rel] = data
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking source dir: %v", err)
+	}
+
+	embedFiles := make(map[string][]byte)
+	err = filepath.WalkDir(embedDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, _ := filepath.Rel(embedDir, path)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		embedFiles[rel] = data
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking embed dir: %v", err)
+	}
+
+	for name, sourceData := range sourceFiles {
+		embedData, ok := embedFiles[name]
+		if !ok {
+			t.Errorf("file %s exists in integrations/augment/ but not in internal/install/augment/", name)
+			continue
+		}
+		if !bytes.Equal(sourceData, embedData) {
+			t.Errorf("embedded copy diverged from source: %s", name)
+		}
+	}
+
+	for name := range embedFiles {
+		if _, ok := sourceFiles[name]; !ok {
+			t.Errorf("file %s exists in internal/install/augment/ but not in integrations/augment/", name)
+		}
+	}
+}

--- a/internal/install/augment_test.go
+++ b/internal/install/augment_test.go
@@ -107,7 +107,7 @@ func TestCheckAugment_NotInstalled(t *testing.T) {
 	issues, state := CheckAugment(tmpHome)
 
 	if state != StateNotInstalled {
-		t.Errorf("expected StateNotInstalled, got %d", state)
+		t.Errorf("expected StateNotInstalled, got %q", state)
 	}
 	if len(issues) != 0 {
 		t.Errorf("expected no issues, got %d", len(issues))
@@ -126,7 +126,7 @@ func TestCheckAugment_NotInstalledNoMarker(t *testing.T) {
 	issues, state := CheckAugment(tmpHome)
 
 	if state != StateNotInstalled {
-		t.Errorf("expected StateNotInstalled, got %d", state)
+		t.Errorf("expected StateNotInstalled, got %q", state)
 	}
 	if len(issues) != 0 {
 		t.Errorf("expected no issues, got %d", len(issues))
@@ -143,7 +143,7 @@ func TestCheckAugment_Healthy(t *testing.T) {
 	issues, state := CheckAugment(tmpHome)
 
 	if state != StateHealthy {
-		t.Errorf("expected StateHealthy, got %d", state)
+		t.Errorf("expected StateHealthy, got %q", state)
 	}
 	if len(issues) != 0 {
 		t.Errorf("expected no issues, got %d: %v", len(issues), issues)
@@ -162,7 +162,7 @@ func TestCheckAugment_Broken(t *testing.T) {
 	issues, state := CheckAugment(tmpHome)
 
 	if state != StateBroken {
-		t.Errorf("expected StateBroken, got %d", state)
+		t.Errorf("expected StateBroken, got %q", state)
 	}
 	if len(issues) == 0 {
 		t.Errorf("expected issues for broken block, got none")

--- a/internal/install/augment_test.go
+++ b/internal/install/augment_test.go
@@ -241,6 +241,61 @@ func TestCheckAugment_ReadError(t *testing.T) {
 	}
 }
 
+func TestCheckAugment_OrphanedEndMarker(t *testing.T) {
+	tmpHome := t.TempDir()
+	augmentDir := filepath.Join(tmpHome, ".augment", "skills")
+	os.MkdirAll(augmentDir, 0755)
+
+	skillPath := filepath.Join(augmentDir, "waggle.md")
+	os.WriteFile(skillPath, []byte(augmentBlockEnd+"\norphaned end\n"), 0644)
+
+	issues, state := CheckAugment(tmpHome)
+
+	if state != StateBroken {
+		t.Errorf("expected StateBroken for orphaned end marker, got %q", state)
+	}
+	if len(issues) == 0 {
+		t.Errorf("expected issues for orphaned end marker, got none")
+	}
+}
+
+func TestCheckAugment_DuplicateBeginMarkers(t *testing.T) {
+	tmpHome := t.TempDir()
+	augmentDir := filepath.Join(tmpHome, ".augment", "skills")
+	os.MkdirAll(augmentDir, 0755)
+
+	skillPath := filepath.Join(augmentDir, "waggle.md")
+	content := augmentBlockBegin + "\nfirst\n" + augmentBlockEnd + "\n" + augmentBlockBegin + "\nsecond\n" + augmentBlockEnd + "\n"
+	os.WriteFile(skillPath, []byte(content), 0644)
+
+	issues, state := CheckAugment(tmpHome)
+
+	if state != StateBroken {
+		t.Errorf("expected StateBroken for duplicate markers, got %q", state)
+	}
+	if len(issues) == 0 {
+		t.Errorf("expected issues for duplicate markers, got none")
+	}
+}
+
+func TestCheckAugment_InvertedMarkers(t *testing.T) {
+	tmpHome := t.TempDir()
+	augmentDir := filepath.Join(tmpHome, ".augment", "skills")
+	os.MkdirAll(augmentDir, 0755)
+
+	skillPath := filepath.Join(augmentDir, "waggle.md")
+	os.WriteFile(skillPath, []byte(augmentBlockEnd+"\ncontent\n"+augmentBlockBegin+"\n"), 0644)
+
+	issues, state := CheckAugment(tmpHome)
+
+	if state != StateBroken {
+		t.Errorf("expected StateBroken for inverted markers, got %q", state)
+	}
+	if len(issues) == 0 {
+		t.Errorf("expected issues for inverted markers, got none")
+	}
+}
+
 func TestEmbeddedAugmentFilesMatch(t *testing.T) {
 	sourceDir := filepath.Join("..", "..", "integrations", "augment")
 	embedDir := filepath.Join("augment")

--- a/internal/install/augment_test.go
+++ b/internal/install/augment_test.go
@@ -296,6 +296,44 @@ func TestCheckAugment_InvertedMarkers(t *testing.T) {
 	}
 }
 
+func TestCheckAugment_DuplicateEndMarkers(t *testing.T) {
+	tmpHome := t.TempDir()
+	augmentDir := filepath.Join(tmpHome, ".augment", "skills")
+	os.MkdirAll(augmentDir, 0755)
+
+	skillPath := filepath.Join(augmentDir, "waggle.md")
+	content := augmentBlockBegin + "\ncontent\n" + augmentBlockEnd + "\nextra\n" + augmentBlockEnd + "\n"
+	os.WriteFile(skillPath, []byte(content), 0644)
+
+	issues, state := CheckAugment(tmpHome)
+
+	if state != StateBroken {
+		t.Errorf("expected StateBroken for duplicate end markers, got %q", state)
+	}
+	if len(issues) == 0 {
+		t.Errorf("expected issues for duplicate end markers, got none")
+	}
+}
+
+func TestCheckAugment_BeginNotAtStartOfLine(t *testing.T) {
+	tmpHome := t.TempDir()
+	augmentDir := filepath.Join(tmpHome, ".augment", "skills")
+	os.MkdirAll(augmentDir, 0755)
+
+	skillPath := filepath.Join(augmentDir, "waggle.md")
+	content := "prefix " + augmentBlockBegin + "\ncontent\n" + augmentBlockEnd + "\n"
+	os.WriteFile(skillPath, []byte(content), 0644)
+
+	issues, state := CheckAugment(tmpHome)
+
+	if state != StateBroken {
+		t.Errorf("expected StateBroken for begin not at start of line, got %q", state)
+	}
+	if len(issues) == 0 {
+		t.Errorf("expected issues for begin not at start of line, got none")
+	}
+}
+
 func TestEmbeddedAugmentFilesMatch(t *testing.T) {
 	sourceDir := filepath.Join("..", "..", "integrations", "augment")
 	embedDir := filepath.Join("augment")

--- a/internal/install/augment_test.go
+++ b/internal/install/augment_test.go
@@ -78,6 +78,45 @@ func TestInstall_AugmentUninstall(t *testing.T) {
 	}
 }
 
+func TestInstall_AugmentUninstallIdempotent(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	if err := installAugment(tmpHome); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+	if err := uninstallAugment(tmpHome); err != nil {
+		t.Fatalf("first uninstall failed: %v", err)
+	}
+	if err := uninstallAugment(tmpHome); err != nil {
+		t.Fatalf("second uninstall failed: %v", err)
+	}
+}
+
+func TestInstall_AugmentUninstallMissingFile(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	if err := uninstallAugment(tmpHome); err != nil {
+		t.Fatalf("uninstall on missing file failed: %v", err)
+	}
+}
+
+func TestInstall_AugmentUninstallTruncatedBlock(t *testing.T) {
+	tmpHome := t.TempDir()
+	augmentDir := filepath.Join(tmpHome, ".augment", "skills")
+	os.MkdirAll(augmentDir, 0755)
+
+	skillPath := filepath.Join(augmentDir, "waggle.md")
+	os.WriteFile(skillPath, []byte(augmentBlockBegin+"\ntruncated block\n"), 0644)
+
+	err := uninstallAugment(tmpHome)
+	if err == nil {
+		t.Fatal("expected error for truncated block, got nil")
+	}
+	if !strings.Contains(err.Error(), "managed block start found without end marker") {
+		t.Errorf("expected truncation error, got: %v", err)
+	}
+}
+
 func TestInstall_AugmentPreservesOtherContent(t *testing.T) {
 	tmpHome := t.TempDir()
 	augmentDir := filepath.Join(tmpHome, ".augment", "skills")

--- a/internal/install/augment_test.go
+++ b/internal/install/augment_test.go
@@ -108,12 +108,18 @@ func TestInstall_AugmentUninstallTruncatedBlock(t *testing.T) {
 	skillPath := filepath.Join(augmentDir, "waggle.md")
 	os.WriteFile(skillPath, []byte(augmentBlockBegin+"\ntruncated block\n"), 0644)
 
-	err := uninstallAugment(tmpHome)
-	if err == nil {
-		t.Fatal("expected error for truncated block, got nil")
+	// removeManagedBlock self-heals truncated blocks (begin without end)
+	// by removing everything from begin marker to EOF
+	if err := uninstallAugment(tmpHome); err != nil {
+		t.Fatalf("expected self-healing uninstall, got error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "managed block start found without end marker") {
-		t.Errorf("expected truncation error, got: %v", err)
+
+	data, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if strings.Contains(string(data), augmentBlockBegin) {
+		t.Errorf("begin marker still present after self-healing uninstall")
 	}
 }
 

--- a/internal/install/augment_test.go
+++ b/internal/install/augment_test.go
@@ -28,6 +28,9 @@ func TestInstall_AugmentCreatesBlock(t *testing.T) {
 	if !strings.Contains(content, augmentBlockEnd) {
 		t.Errorf("end marker not found in waggle.md")
 	}
+	if !strings.Contains(content, "waggle adapter bootstrap augment") {
+		t.Errorf("expected waggle adapter bootstrap command in skill block:\n%s", content)
+	}
 }
 
 func TestInstall_AugmentIdempotent(t *testing.T) {
@@ -157,7 +160,7 @@ func TestCheckAugment_Broken(t *testing.T) {
 
 	// Create skill file with begin marker but missing end marker
 	skillPath := filepath.Join(augmentDir, "waggle.md")
-	os.WriteFile(skillPath, []byte("<!-- WAGGLE-AUGMENT-BEGIN -->\nBroken block\n"), 0644)
+	os.WriteFile(skillPath, []byte(augmentBlockBegin+"\nBroken block\n"), 0644)
 
 	issues, state := CheckAugment(tmpHome)
 
@@ -166,6 +169,27 @@ func TestCheckAugment_Broken(t *testing.T) {
 	}
 	if len(issues) == 0 {
 		t.Errorf("expected issues for broken block, got none")
+	}
+}
+
+func TestCheckAugment_ReadError(t *testing.T) {
+	tmpHome := t.TempDir()
+	augmentDir := filepath.Join(tmpHome, ".augment", "skills")
+	os.MkdirAll(augmentDir, 0755)
+
+	// Create skill file then remove read permission
+	skillPath := filepath.Join(augmentDir, "waggle.md")
+	os.WriteFile(skillPath, []byte(augmentBlockBegin+"\ncontent\n"+augmentBlockEnd+"\n"), 0644)
+	os.Chmod(skillPath, 0000)
+	t.Cleanup(func() { os.Chmod(skillPath, 0644) })
+
+	issues, state := CheckAugment(tmpHome)
+
+	if state != StateBroken {
+		t.Errorf("expected StateBroken for unreadable file, got %q", state)
+	}
+	if len(issues) == 0 {
+		t.Errorf("expected issues for unreadable file, got none")
 	}
 }
 

--- a/internal/install/augment_test.go
+++ b/internal/install/augment_test.go
@@ -173,6 +173,9 @@ func TestCheckAugment_Broken(t *testing.T) {
 }
 
 func TestCheckAugment_ReadError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("test not meaningful when running as root")
+	}
 	tmpHome := t.TempDir()
 	augmentDir := filepath.Join(tmpHome, ".augment", "skills")
 	os.MkdirAll(augmentDir, 0755)

--- a/internal/install/health.go
+++ b/internal/install/health.go
@@ -354,7 +354,14 @@ func CheckAugment(homeDir string) ([]HealthIssue, AdapterState) {
 	skillPath := filepath.Join(homeDir, ".augment", "skills", "waggle.md")
 	data, err := os.ReadFile(skillPath)
 	if err != nil {
-		return nil, StateNotInstalled
+		if os.IsNotExist(err) {
+			return nil, StateNotInstalled
+		}
+		return []HealthIssue{{
+			Asset:   skillPath,
+			Problem: "cannot read skill file: " + err.Error(),
+			Repair:  repairCmd,
+		}}, StateBroken
 	}
 
 	content := string(data)

--- a/internal/install/health.go
+++ b/internal/install/health.go
@@ -348,6 +348,30 @@ func CheckAuggie(homeDir string) ([]HealthIssue, AdapterState) {
 	return nil, StateHealthy
 }
 
+// CheckAugment checks the health of the Augment integration.
+func CheckAugment(homeDir string) ([]HealthIssue, AdapterState) {
+	const repairCmd = "waggle install augment"
+	skillPath := filepath.Join(homeDir, ".augment", "skills", "waggle.md")
+	data, err := os.ReadFile(skillPath)
+	if err != nil {
+		return nil, StateNotInstalled
+	}
+
+	content := string(data)
+	if !strings.Contains(content, augmentBlockBegin) {
+		return nil, StateNotInstalled
+	}
+	if !strings.Contains(content, augmentBlockEnd) {
+		return []HealthIssue{{
+			Asset:   skillPath,
+			Problem: "managed block truncated (begin marker without end marker)",
+			Repair:  repairCmd,
+		}}, StateBroken
+	}
+
+	return nil, StateHealthy
+}
+
 // fileExists returns true if a path exists on disk (file or directory).
 func fileExists(path string) bool {
 	_, err := os.Stat(path)

--- a/internal/install/health.go
+++ b/internal/install/health.go
@@ -349,9 +349,14 @@ func CheckAuggie(homeDir string) ([]HealthIssue, AdapterState) {
 }
 
 // CheckAugment checks the health of the Augment integration.
+// Same topology-aware flow as CheckGemini: detect any marker, validate topology,
+// then derive state. This ensures health never reports "not_installed" or "healthy"
+// for a file that upsertManagedBlock would reject.
 func CheckAugment(homeDir string) ([]HealthIssue, AdapterState) {
 	const repairCmd = "waggle install augment"
+	var issues []HealthIssue
 	skillPath := filepath.Join(homeDir, ".augment", "skills", "waggle.md")
+
 	data, err := os.ReadFile(skillPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -365,17 +370,36 @@ func CheckAugment(homeDir string) ([]HealthIssue, AdapterState) {
 	}
 
 	content := string(data)
-	if !strings.Contains(content, augmentBlockBegin) {
+	hasBeginMarker := strings.Contains(content, augmentBlockBegin)
+	hasEndMarker := strings.Contains(content, augmentBlockEnd)
+
+	// Validate marker topology before deriving state.
+	hasAnyMarker := hasBeginMarker || hasEndMarker
+	if hasAnyMarker {
+		if topErr := validateMarkerTopology(content, augmentBlockBegin, augmentBlockEnd); topErr != nil {
+			issues = append(issues, HealthIssue{
+				Asset:   skillPath,
+				Problem: "managed block has invalid topology: " + topErr.Error(),
+				Repair:  repairCmd,
+			})
+		}
+	}
+
+	if !hasAnyMarker {
 		return nil, StateNotInstalled
 	}
-	if !strings.Contains(content, augmentBlockEnd) {
-		return []HealthIssue{{
+
+	if hasBeginMarker && !hasEndMarker && len(issues) == 0 {
+		issues = append(issues, HealthIssue{
 			Asset:   skillPath,
 			Problem: "managed block truncated (begin marker without end marker)",
 			Repair:  repairCmd,
-		}}, StateBroken
+		})
 	}
 
+	if len(issues) > 0 {
+		return issues, StateBroken
+	}
 	return nil, StateHealthy
 }
 


### PR DESCRIPTION
## PR 7 — Augment Adapter

**Issue:** #90
**Branch:** `feat/pr7-augment-adapter`
**Frozen SHA:** `37932fd`
**Status:** Ready for merge

---

### Problem

Augment users in waggle-enabled repos are not in the coordination mesh. The fix must be automatic — no manual waggle commands required in the normal path.

### Solution

**Install path:** `waggle install augment` upserts a managed block into `~/.augment/skills/waggle.md`. Augment reads global skills from `~/.augment/skills/` at every session start. Once installed, every future Augment session auto-executes `waggle adapter bootstrap augment --format markdown`.

**Health checks:** Topology-aware three-state model (`not_installed` / `healthy` / `broken`) via `CheckAugment(homeDir)`. Calls `validateMarkerTopology()` matching CheckGemini/CheckCodex pattern. Detects: missing file, orphaned markers, duplicate markers, inverted markers, truncated blocks, permission errors.

**Broker-independent status:** `waggle status` always shows adapter health without requiring a running broker.

### Magical UX Bar

- User runs `waggle install augment` once.
- Every future Augment session auto-bootstraps. No manual commands needed in the normal path.
- Same model as Claude Code, Codex, Gemini, and Auggie adapters.

---

### MECE Smoke Tests (all PASS)

```
A: Fresh install creates block           PASS
B: Idempotent (block appears once)       PASS
C: Status not_installed before install   PASS
D: Status healthy after install          PASS
E: Asset copies identical                PASS
F: Uninstall removes block               PASS
G: Bootstrap command in skill block      PASS
H: Permission error -> broken            PASS
I: Root-user skip guard on perm test     PASS
J: Idempotent uninstall                  PASS
K: Missing file uninstall                PASS
L: Truncated block self-healing          PASS
M: Orphaned end marker -> broken         PASS
N: Duplicate markers -> broken           PASS
O: Inverted markers -> broken            PASS
```

### External Review Summary

**Round 1** (pre-fix code):
| Reviewer | PASS | FAIL | Notes |
|----------|------|------|-------|
| Gemini | 63 | 5 | All fixed in subsequent commits |
| Claude | 41 | 9 | All fixed in subsequent commits |
| Codex | 61 | 3 | Doc + tests fixed, symlink deferred |

**Round 2** (post-rebase, current code):
| Reviewer | PASS | FAIL | Notes |
|----------|------|------|-------|
| Gemini | 68 | 0 | Clean pass |
| Claude | 48 | 2 | Topology validation (fixed in 37932fd) |
| Codex | 61 | 4 | Topology + doc (fixed in 37932fd) |

**PR Review Panel:** 7 rounds, 16/20 models passed, 0 findings in final round (3/3 PASS).

### Commits (9)

1. `3934984` docs: add augment adapter design note
2. `8b9fc00` feat: add Augment adapter install path
3. `515f351` feat: add Augment health check to waggle status
4. `f6e2943` fix: harden augment adapter health check and test parity
5. `cdb9b33` fix: add root-user skip guard to permission test
6. `8a336f5` docs: clarify SKILL-block bootstrap instructions
7. `84b97d0` fix: address external review findings (R1)
8. `4a12afe` fix: align truncated block test with self-healing removeManagedBlock
9. `37932fd` fix: add topology validation to CheckAugment (R2)

**Noted for separate PR:** Symlink following in install/uninstall is a cross-adapter class issue (all 5 adapters).

### Full Test Suite

15/15 packages PASS (rebased onto main with PR4 Gemini + PR8 Auggie)

### Files Changed (9 files)

- cmd/install.go — augment case (alongside gemini, auggie)
- cmd/status.go — augment in broker-independent status
- docs/augment-adapter-design.md — design rationale
- e2e_zombie_test.go — augment assertions in zombie + help tests
- integrations/augment/SKILL-block.md — source asset
- internal/install/augment.go — install/uninstall logic
- internal/install/augment/SKILL-block.md — embedded asset
- internal/install/augment_test.go — 17 tests
- internal/install/health.go — topology-aware CheckAugment

Closes #90
