### PR TITLE
#102: Last-mile push delivery via shell hook + signal files

### DIFF
--- a/cmd/runtime_start.go
+++ b/cmd/runtime_start.go
@@ -42,6 +42,7 @@ var runtimeStartCmd = &cobra.Command{
 			defer store.Close()
 
 			manager := rt.NewManager(store, rt.NewBrokerListenerFactory(), rt.NewCommandNotifier())
+			manager.SetSignalDir(runtimePaths.RuntimeSignalDir)
 			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 			defer stop()
 			return rt.RunDaemon(ctx, runtimePaths, manager)

--- a/cmd/runtime_start.go
+++ b/cmd/runtime_start.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"os/signal"
 	"syscall"
@@ -18,7 +19,9 @@ var runtimeForeground bool
 
 func init() {
 	runtimeStartCmd.Flags().BoolVar(&runtimeForeground, "foreground", false, "Run machine runtime in foreground")
-	_ = runtimeStartCmd.Flags().MarkHidden("foreground")
+	if err := runtimeStartCmd.Flags().MarkHidden("foreground"); err != nil {
+		panic(fmt.Sprintf("hide runtime foreground flag: %v", err))
+	}
 
 	runtimeCmd.AddCommand(runtimeStartCmd)
 	runtimeCmd.AddCommand(runtimeStopCmd)
@@ -28,7 +31,7 @@ func init() {
 var runtimeStartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start the local machine runtime daemon",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, args []string) (retErr error) {
 		runtimePaths, err := resolveRuntimePaths()
 		if err != nil {
 			return err
@@ -68,7 +71,13 @@ var runtimeStartCmd = &cobra.Command{
 			return err
 		}
 		defer func() {
-			_ = releaseLock()
+			if err := releaseLock(); err != nil {
+				if retErr == nil {
+					retErr = fmt.Errorf("release runtime start lock: %w", err)
+					return
+				}
+				log.Printf("warning: release runtime start lock: %v", err)
+			}
 		}()
 
 		daemonArgs := []string{os.Args[0], "runtime", "start", "--foreground"}

--- a/docs/superpowers/plans/2026-03-31-last-mile-push-delivery-part2.md
+++ b/docs/superpowers/plans/2026-03-31-last-mile-push-delivery-part2.md
@@ -1,0 +1,575 @@
+# Last-Mile Push Delivery — Tasks 5-9 (v4 master)
+
+Continuation of `2026-03-31-last-mile-push-delivery.md`.
+
+---
+
+### Task 5: Shell Hook Installer (continued)
+
+**Files:** `internal/install/shell_hook.go`, `internal/install/shell_hook_test.go`
+
+- [ ] **Step 1: Write tests**
+
+```go
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallShellHook_WritesScript(t *testing.T) {
+	home := t.TempDir()
+	if err := installShellHook(home); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".waggle", "shell-hook.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "__waggle_check") {
+		t.Fatal("missing function")
+	}
+}
+
+func TestInstallShellHook_ZshenvWithMarkers(t *testing.T) {
+	home := t.TempDir()
+	os.WriteFile(filepath.Join(home, ".zshenv"), []byte("# existing\n"), 0o644)
+	installShellHook(home)
+	data, _ := os.ReadFile(filepath.Join(home, ".zshenv"))
+	s := string(data)
+	if !strings.Contains(s, "WAGGLE-SHELL-HOOK-BEGIN") {
+		t.Fatal("missing begin marker")
+	}
+	if !strings.Contains(s, "WAGGLE-SHELL-HOOK-END") {
+		t.Fatal("missing end marker")
+	}
+	if !strings.Contains(s, "shell-hook.sh") {
+		t.Fatal("missing source line")
+	}
+	if !strings.Contains(s, "# existing") {
+		t.Fatal("lost existing content")
+	}
+}
+
+func TestInstallShellHook_BashrcWithMarkers(t *testing.T) {
+	home := t.TempDir()
+	os.WriteFile(filepath.Join(home, ".bashrc"), []byte("# bash\n"), 0o644)
+	installShellHook(home)
+	data, _ := os.ReadFile(filepath.Join(home, ".bashrc"))
+	if !strings.Contains(string(data), "WAGGLE-SHELL-HOOK-BEGIN") {
+		t.Fatal("missing marker in .bashrc")
+	}
+}
+
+func TestInstallShellHook_Idempotent(t *testing.T) {
+	home := t.TempDir()
+	installShellHook(home)
+	installShellHook(home)
+	data, _ := os.ReadFile(filepath.Join(home, ".zshenv"))
+	if strings.Count(string(data), "WAGGLE-SHELL-HOOK-BEGIN") != 1 {
+		t.Fatal("marker duplicated")
+	}
+}
+
+func TestUninstallShellHook_RemovesBlock(t *testing.T) {
+	home := t.TempDir()
+	installShellHook(home)
+	uninstallShellHook(home)
+	for _, f := range []string{".zshenv", ".bashrc"} {
+		data, _ := os.ReadFile(filepath.Join(home, f))
+		if strings.Contains(string(data), "waggle") {
+			t.Fatalf("%s still has waggle content", f)
+		}
+	}
+}
+
+func TestUninstallShellHook_PreservesOtherContent(t *testing.T) {
+	home := t.TempDir()
+	os.WriteFile(filepath.Join(home, ".zshenv"), []byte("# keep this\n"), 0o644)
+	installShellHook(home)
+	uninstallShellHook(home)
+	data, _ := os.ReadFile(filepath.Join(home, ".zshenv"))
+	if !strings.Contains(string(data), "# keep this") {
+		t.Fatal("lost existing content")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+Run: `go test ./internal/install/ -run TestInstallShellHook -v`
+
+- [ ] **Step 3: Implement shell_hook.go**
+
+```go
+package install
+
+import (
+	"embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+//go:embed shell-hook/shell-hook.sh
+var shellHookFS embed.FS
+
+const (
+	shellHookBegin = "# <!-- WAGGLE-SHELL-HOOK-BEGIN -->"
+	shellHookEnd   = "# <!-- WAGGLE-SHELL-HOOK-END -->"
+)
+
+var shellHookBlock = strings.Join([]string{
+	shellHookBegin,
+	`[ -f "$HOME/.waggle/shell-hook.sh" ] && source "$HOME/.waggle/shell-hook.sh"`,
+	`export BASH_ENV="$HOME/.waggle/shell-hook.sh"`,
+	shellHookEnd,
+}, "\n")
+
+// InstallShellHook installs the universal shell hook.
+func InstallShellHook() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	return installShellHook(home)
+}
+
+// UninstallShellHook removes the shell hook.
+func UninstallShellHook() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	return uninstallShellHook(home)
+}
+
+func installShellHook(homeDir string) error {
+	waggleDir := filepath.Join(homeDir, ".waggle")
+	if err := os.MkdirAll(waggleDir, 0o700); err != nil {
+		return fmt.Errorf("create dir: %w", err)
+	}
+	hookData, err := shellHookFS.ReadFile("shell-hook/shell-hook.sh")
+	if err != nil {
+		return fmt.Errorf("read embedded hook: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(waggleDir, "shell-hook.sh"), hookData, 0o644); err != nil {
+		return fmt.Errorf("write hook: %w", err)
+	}
+	for _, rc := range []string{".zshenv", ".bashrc"} {
+		if err := upsertShellHookBlock(filepath.Join(homeDir, rc)); err != nil {
+			return fmt.Errorf("update %s: %w", rc, err)
+		}
+	}
+	return nil
+}
+
+func uninstallShellHook(homeDir string) error {
+	for _, rc := range []string{".zshenv", ".bashrc"} {
+		removeShellHookBlock(filepath.Join(homeDir, rc))
+	}
+	os.Remove(filepath.Join(homeDir, ".waggle", "shell-hook.sh"))
+	return nil
+}
+
+func upsertShellHookBlock(path string) error {
+	existing, _ := os.ReadFile(path)
+	content := string(existing)
+	if strings.Contains(content, shellHookBegin) {
+		return nil // already present
+	}
+	if len(content) > 0 && !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	content += shellHookBlock + "\n"
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+func removeShellHookBlock(path string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	lines := strings.Split(string(data), "\n")
+	var filtered []string
+	inBlock := false
+	for _, line := range lines {
+		if strings.Contains(line, "WAGGLE-SHELL-HOOK-BEGIN") {
+			inBlock = true
+			continue
+		}
+		if strings.Contains(line, "WAGGLE-SHELL-HOOK-END") {
+			inBlock = false
+			continue
+		}
+		if !inBlock {
+			filtered = append(filtered, line)
+		}
+	}
+	os.WriteFile(path, []byte(strings.Join(filtered, "\n")), 0o644)
+}
+```
+
+- [ ] **Step 4: Wire into platform installers**
+
+In each platform's install function (`installClaudeCode`, `installCodex`, `installGemini`, `installAugment`, `installAuggie`), add as the final step:
+
+```go
+if err := installShellHook(homeDir); err != nil {
+	return fmt.Errorf("installing shell hook: %w", err)
+}
+```
+
+- [ ] **Step 5: Run tests — expect PASS**
+
+Run: `go test ./internal/install/ -run "TestInstallShellHook|TestUninstallShellHook" -v`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/install/shell_hook.go internal/install/shell_hook_test.go
+git commit -m "feat: marker-based shell hook installer"
+```
+
+---
+
+### Task 6: Claude Code PreToolUse Hook (v4 — PPID env var fix)
+
+**Files:** `integrations/claude-code/waggle-push.js`, `internal/install/claude_code.go`
+
+**Critical context:** Like bootstrap.go, the Node hook's `process.ppid` returns the intermediate shell PID, not Claude Code's PID. Fix: hook command uses `WAGGLE_PPID=$PPID` prefix so `$PPID` (= Claude Code PID) is passed via env var.
+
+- [ ] **Step 1: Rewrite waggle-push.js**
+
+Replace contents of `integrations/claude-code/waggle-push.js`:
+
+```javascript
+#!/usr/bin/env node
+// waggle-push.js — PreToolUse hook for Claude Code.
+// Reads signal files via PPID mapping. Atomic consume via rename.
+// WAGGLE_PPID env var provides the real agent PID (set by hook command).
+const fs = require('fs');
+const path = require('path');
+
+const home = process.env.HOME;
+if (!home) process.exit(0);
+
+const rtDir = path.join(home, '.waggle', 'runtime');
+// Use WAGGLE_PPID (agent PID) not process.ppid (intermediate shell PID)
+const ppid = process.env.WAGGLE_PPID || String(process.ppid);
+const mapFile = path.join(rtDir, 'agent-ppid-' + ppid);
+
+try {
+    if (!fs.existsSync(mapFile)) process.exit(0);
+
+    const agent = fs.readFileSync(mapFile, 'utf8').trim().split('\n')[0];
+    if (!agent) process.exit(0);
+
+    const sigFile = path.join(rtDir, 'signals', agent);
+    if (!fs.existsSync(sigFile)) process.exit(0);
+
+    // Atomic: rename then read (daemon writes to original path are safe)
+    const tmpFile = sigFile + '.c-' + process.pid;
+    try { fs.renameSync(sigFile, tmpFile); } catch { process.exit(0); }
+
+    const content = fs.readFileSync(tmpFile, 'utf8').trim();
+    try { fs.unlinkSync(tmpFile); } catch {}
+
+    if (!content) process.exit(0);
+
+    console.log(JSON.stringify({
+        additionalContext: '\n' + content +
+            '\nRespond to waggle messages using: ' +
+            'WAGGLE_AGENT_NAME="' + agent + '" waggle send <sender> "<reply>"\n'
+    }));
+} catch {
+    process.exit(0);
+}
+```
+
+- [ ] **Step 2: Copy to go:embed location**
+
+```bash
+cp integrations/claude-code/waggle-push.js internal/install/claude-code/waggle-push.js
+```
+
+- [ ] **Step 3: Add PreToolUse registration to claude_code.go**
+
+In `internal/install/claude_code.go`, add constant — note `WAGGLE_PPID=$PPID` prefix:
+
+```go
+const wagglePushCommand = "WAGGLE_PPID=$PPID node $HOME/.claude/hooks/waggle-push.js"
+```
+
+Add registration function:
+
+```go
+func registerPreToolUseHook(claudeDir string) error {
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	settings, _ := readSettingsJSON(settingsPath)
+
+	hooks, _ := settings["hooks"].(map[string]interface{})
+	if hooks == nil {
+		hooks = make(map[string]interface{})
+	}
+
+	preToolUse, _ := hooks["PreToolUse"].([]interface{})
+	for _, entry := range preToolUse {
+		em, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		hs, _ := em["hooks"].([]interface{})
+		for _, h := range hs {
+			hm, _ := h.(map[string]interface{})
+			if cmd, _ := hm["command"].(string); cmd == wagglePushCommand {
+				return nil // already registered
+			}
+		}
+	}
+
+	preToolUse = append(preToolUse, map[string]interface{}{
+		"hooks": []interface{}{
+			map[string]interface{}{"type": "command", "command": wagglePushCommand},
+		},
+	})
+	hooks["PreToolUse"] = preToolUse
+	settings["hooks"] = hooks
+
+	out, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(settingsPath, out, 0o644)
+}
+```
+
+- [ ] **Step 4: Wire into installClaudeCode**
+
+In `installClaudeCode`, after copying the heartbeat script, add:
+
+```go
+// Copy PreToolUse push hook
+pushData, err := claudeCodeFiles.ReadFile("claude-code/waggle-push.js")
+if err != nil {
+	return fmt.Errorf("reading waggle-push.js: %w", err)
+}
+if err := os.WriteFile(filepath.Join(hookDir, "waggle-push.js"), pushData, 0o755); err != nil {
+	return fmt.Errorf("writing push hook: %w", err)
+}
+```
+
+After `registerSessionStartHook`, add:
+
+```go
+if err := registerPreToolUseHook(claudeDir); err != nil {
+	return fmt.Errorf("registering push hook: %w", err)
+}
+```
+
+- [ ] **Step 5: Run install tests**
+
+Run: `go test ./internal/install/ -run TestInstallClaudeCode -v`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add integrations/claude-code/waggle-push.js internal/install/claude_code.go internal/install/claude-code/waggle-push.js
+git commit -m "feat: Claude Code PreToolUse hook for signal file delivery"
+```
+
+---
+
+### Task 7: Presence Fix
+
+**Files:** `internal/broker/router.go`, `internal/broker/broker_test.go`
+
+- [ ] **Step 1: Write test**
+
+Add to `internal/broker/broker_test.go`:
+
+```go
+func TestPresence_StripsPushAndDeduplicates(t *testing.T) {
+	sockPath, _, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	c1 := connectClient(t, sockPath)
+	defer c1.Close()
+	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Args: map[string]any{"name": "alice-push"}})
+
+	c2 := connectClient(t, sockPath)
+	defer c2.Close()
+	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Args: map[string]any{"name": "bob"}})
+
+	c3 := connectClient(t, sockPath)
+	defer c3.Close()
+	c3.Send(protocol.Request{Cmd: protocol.CmdConnect, Args: map[string]any{"name": "probe"}})
+
+	resp, _ := c3.Send(protocol.Request{Cmd: protocol.CmdPresence})
+	var agents []map[string]string
+	json.Unmarshal(resp.Data, &agents)
+
+	names := make(map[string]bool)
+	for _, a := range agents {
+		if strings.HasSuffix(a["name"], "-push") {
+			t.Fatalf("name %q should not have -push suffix", a["name"])
+		}
+		names[a["name"]] = true
+	}
+	if !names["alice"] {
+		t.Fatal("expected alice (stripped from alice-push)")
+	}
+	if !names["bob"] {
+		t.Fatal("expected bob")
+	}
+}
+```
+
+Add `"strings"` to the test file imports if not present.
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+Run: `go test ./internal/broker/ -run TestPresence_StripsPush -v`
+
+- [ ] **Step 3: Fix handlePresence**
+
+Replace the `handlePresence` function in `internal/broker/router.go`:
+
+```go
+func handlePresence(s *Session) protocol.Response {
+	s.broker.mu.RLock()
+	seen := make(map[string]bool)
+	agents := make([]map[string]string, 0, len(s.broker.sessions))
+	for name := range s.broker.sessions {
+		displayName := strings.TrimSuffix(name, "-push")
+		if seen[displayName] {
+			continue
+		}
+		seen[displayName] = true
+		agents = append(agents, map[string]string{"name": displayName, "state": "online"})
+	}
+	s.broker.mu.RUnlock()
+
+	sort.Slice(agents, func(i, j int) bool { return agents[i]["name"] < agents[j]["name"] })
+
+	return protocol.OKResponse(mustMarshal(agents))
+}
+```
+
+`strings` and `sort` are already imported in router.go.
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/broker/ -run TestPresence -v && go test ./internal/broker/ -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/broker/router.go internal/broker/broker_test.go
+git commit -m "fix: presence strips -push suffix, deduplicates"
+```
+
+---
+
+### Task 8: E2E Verification
+
+- [ ] **Step 1: Rebuild and install**
+
+```bash
+cd ~/Projects/Claude/waggle
+go build -o waggle . && cp waggle ~/bin/waggle
+waggle install claude-code
+waggle install codex
+```
+
+- [ ] **Step 2: Verify installation**
+
+```bash
+cat ~/.waggle/shell-hook.sh | head -3
+grep WAGGLE ~/.zshenv
+ls ~/.claude/hooks/waggle-push.js
+```
+
+- [ ] **Step 3: Test signal delivery end-to-end**
+
+```bash
+cd ~/Projects/Claude/waggle
+waggle stop 2>/dev/null; waggle start
+A=$(waggle adapter bootstrap claude-code --format json | jq -r .agent_name)
+B=$(waggle adapter bootstrap codex --format json | jq -r .agent_name)
+echo "Claude=$A Codex=$B"
+WAGGLE_AGENT_NAME=$A waggle send $B "e2e test message"
+sleep 2
+cat ~/.waggle/runtime/signals/$B  # should show message
+ls ~/.waggle/runtime/agent-ppid-*  # should show mappings
+```
+
+- [ ] **Step 4: Test atomic consumption**
+
+```bash
+SIG=~/.waggle/runtime/signals/$B
+TMP="$SIG.c-$$"
+mv "$SIG" "$TMP" && cat "$TMP" && rm "$TMP"
+# Message displayed, signal consumed, no file left
+```
+
+- [ ] **Step 5: Test presence**
+
+```bash
+WAGGLE_AGENT_NAME=probe waggle presence
+# Names without -push, sorted
+```
+
+- [ ] **Step 6: Full test suite**
+
+```bash
+go test ./... -count=1
+```
+
+- [ ] **Step 7: Commit any E2E fixes**
+
+---
+
+### Task 9: Adapter Instruction Updates
+
+**Files:** `integrations/codex/AGENTS-block.md`, `integrations/gemini/GEMINI-block.md`, `integrations/auggie/RULE-block.md`, `integrations/augment/SKILL-block.md`
+
+- [ ] **Step 1: Add delivery explanation to each block**
+
+After bootstrap instruction in each file, add:
+
+```markdown
+Messages from other agents appear automatically in your shell command output,
+prefixed with 📨. When you see a waggle message, respond to the sender:
+
+    WAGGLE_AGENT_NAME="<your-agent>" waggle send <sender-name> "<response>"
+
+Use `waggle presence` to discover connected agents.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add integrations/
+git commit -m "docs: adapter instructions for automatic message delivery"
+```
+
+---
+
+## Known Limitations
+
+1. **New shell per command assumption.** The shell hook relies on each agent tool call spawning a fresh shell process (verified for Claude Code). If a platform reuses a persistent shell, messages only surface on the first command. Mitigation: add `precmd`/`PROMPT_COMMAND` in a future PR if needed.
+
+2. **PPID relies on env var propagation.** The `WAGGLE_AGENT_PPID=$PPID` pattern requires the calling shell to expand `$PPID` correctly. This works for standard `sh`/`bash`/`zsh` invocations. If an agent bypasses the shell entirely (direct exec without shell), the env var won't be set, and fallback to `os.Getppid()` gives the wrong PID. Mitigation: all known agent platforms use shell invocation.
+
+3. **PID reuse.** A stale PPID mapping file could match a recycled PID. Mitigation: mtime-based 24h cleanup in daemon maintenance loop. PID reuse in <24h is rare for long-lived agent processes.
+
+4. **Message content in shell output.** Arbitrary message text is written to stderr. Very long messages or control characters could disrupt output. Mitigation: 64KB signal file cap. Future: sanitize/truncate message content.
+
+5. **Single machine scope.** PPID mapping and signal files are local. Remote agents cannot use this mechanism. The runtime daemon handles cross-machine delivery; this is the local presentation layer.
+
+6. **Two consumers for Claude Code.** PreToolUse hook and shell hook both check signals. No race because PreToolUse fires before Bash tool (atomic consume clears signal before shell hook runs). Non-Bash tools (Read, Write) only trigger PreToolUse — no shell hook involvement.

--- a/docs/superpowers/plans/2026-03-31-last-mile-push-delivery.md
+++ b/docs/superpowers/plans/2026-03-31-last-mile-push-delivery.md
@@ -1,0 +1,521 @@
+# Last-Mile Push Delivery — Master Plan (v4)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Waggle messages appear automatically in every agent session across all 5 platforms.
+
+**Architecture:** Daemon writes signal files on delivery. Shell hook in `.zshenv` checks signal files before every command (each agent tool call = new shell process, verified). PPID mapping links bootstrap to commands. Claude Code gets additional PreToolUse hook for clean `additionalContext` injection.
+
+**Verified assumptions:**
+- Each Bash tool call spawns a new shell (PIDs 50991→51092, PPID=36007 stable)
+- `.zshenv` sources fresh each invocation (non-interactive zsh)
+- PPID guard prevents overhead in non-agent shells (1 file stat = ns)
+
+**Critical fix in v4 (from GPT-5.4 review):** `os.Getppid()` in bootstrap.go returns the intermediate SHELL pid, not the agent pid. Process tree: `agent→shell→waggle bootstrap`, so `os.Getppid()=shell`, but shell hook checks `$PPID=agent`. Fix: pass agent PID via env var `WAGGLE_AGENT_PPID=$PPID` when calling bootstrap. The `$PPID` in the calling shell IS the agent PID. Same fix for PreToolUse hook: `WAGGLE_PPID=$PPID node waggle-push.js`.
+
+**Review history:** v1: Grok+Gemini. v2: revised. v3: setter pattern, markers, correct tests. v4: PPID generation fix (GPT-5.4 finding).
+
+**Tasks 1-5 here. Tasks 6-9 in part2.**
+
+---
+
+## File Map
+
+| File | Action | What |
+|---|---|---|
+| `internal/runtime/signal.go` | create | Write + atomic-consume signal files |
+| `internal/runtime/signal_test.go` | create | Tests with race-condition coverage |
+| `internal/config/config.go` | modify | SignalDirName, SignalMaxBytes, RuntimeSignalDir |
+| `internal/runtime/manager.go` | modify | SetSignalDir + call WriteSignal in notifyRecord |
+| `cmd/runtime_start.go` | modify | Call manager.SetSignalDir |
+| `internal/adapter/bootstrap.go` | modify | WritePPIDMapping + call from Bootstrap |
+| `internal/install/shell-hook/shell-hook.sh` | create | Shell hook (go:embed source) |
+| `internal/install/shell_hook.go` | create | Installer for .zshenv/.bashrc |
+| `internal/install/shell_hook_test.go` | create | Install/uninstall/idempotency tests |
+| `integrations/claude-code/waggle-push.js` | modify | Read signal files via PPID mapping |
+| `internal/install/claude_code.go` | modify | Copy+register PreToolUse hook |
+| `internal/broker/router.go` | modify | Strip -push in presence, dedup |
+
+---
+
+### Task 1: Signal File Writer
+
+**Files:** `internal/runtime/signal.go`, `internal/runtime/signal_test.go`, `internal/config/config.go`
+
+- [ ] **Step 1: Config changes**
+
+In `internal/config/config.go`, add to the Defaults struct definition (after `RuntimeLogFile string`):
+
+```go
+SignalDirName  string
+SignalMaxBytes int64
+```
+
+Add to the Defaults literal (after `RuntimeLogFile`):
+
+```go
+SignalDirName:  "signals",
+SignalMaxBytes: 65536,
+```
+
+Add to Paths struct (after `RuntimeStartLockDir string`):
+
+```go
+RuntimeSignalDir string
+```
+
+Add to NewPaths (after `RuntimeStartLockDir` assignment):
+
+```go
+RuntimeSignalDir: filepath.Join(runtimeDir, Defaults.SignalDirName),
+```
+
+- [ ] **Step 2: Write signal_test.go**
+
+```go
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteSignal_CreatesFileWithContent(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteSignal(dir, "agent-1", "alice", "hello", 65536); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "agent-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	if !strings.Contains(s, "alice") || !strings.Contains(s, "hello") {
+		t.Fatalf("content = %q", s)
+	}
+}
+
+func TestWriteSignal_Appends(t *testing.T) {
+	dir := t.TempDir()
+	WriteSignal(dir, "a", "alice", "one", 65536)
+	WriteSignal(dir, "a", "bob", "two", 65536)
+	data, _ := os.ReadFile(filepath.Join(dir, "a"))
+	if c := strings.Count(string(data), "\n"); c != 2 {
+		t.Fatalf("expected 2 lines, got %d: %q", c, data)
+	}
+}
+
+func TestWriteSignal_DropsWhenOverCap(t *testing.T) {
+	dir := t.TempDir()
+	// First write: long body to exceed small cap
+	WriteSignal(dir, "a", "alice", strings.Repeat("x", 100), 50)
+	// File is now ~133 bytes > 50 cap
+	WriteSignal(dir, "a", "bob", "should-be-dropped", 50)
+	data, _ := os.ReadFile(filepath.Join(dir, "a"))
+	if strings.Contains(string(data), "bob") {
+		t.Fatalf("second write should be dropped, got: %q", data)
+	}
+}
+
+func TestWriteSignal_DirPermissions(t *testing.T) {
+	sigDir := filepath.Join(t.TempDir(), "signals")
+	WriteSignal(sigDir, "a", "alice", "test", 65536)
+	info, err := os.Stat(sigDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Fatalf("dir perm = %o, want 700", perm)
+	}
+}
+
+func TestConsumeSignal_AtomicReadAndDelete(t *testing.T) {
+	dir := t.TempDir()
+	WriteSignal(dir, "a", "alice", "hello", 65536)
+	content, err := ConsumeSignal(dir, "a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(content, "alice") {
+		t.Fatalf("content = %q", content)
+	}
+	// Original gone
+	if _, err := os.Stat(filepath.Join(dir, "a")); !os.IsNotExist(err) {
+		t.Fatal("original should be deleted")
+	}
+	// No temp files left
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.Contains(e.Name(), "consuming") {
+			t.Fatalf("temp file left behind: %s", e.Name())
+		}
+	}
+}
+
+func TestConsumeSignal_NoFile_Empty(t *testing.T) {
+	content, err := ConsumeSignal(t.TempDir(), "nope")
+	if err != nil || content != "" {
+		t.Fatalf("expected empty, got %q err=%v", content, err)
+	}
+}
+
+func TestConsumeSignal_NewWriteDuringConsume(t *testing.T) {
+	dir := t.TempDir()
+	WriteSignal(dir, "a", "alice", "first", 65536)
+	// Simulate atomic rename (what ConsumeSignal does internally)
+	orig := filepath.Join(dir, "a")
+	tmp := orig + ".consuming-test"
+	os.Rename(orig, tmp)
+	// Daemon writes new message to original path AFTER rename
+	WriteSignal(dir, "a", "bob", "second", 65536)
+	// Consumed content has first message only
+	data, _ := os.ReadFile(tmp)
+	os.Remove(tmp)
+	if !strings.Contains(string(data), "alice") || strings.Contains(string(data), "bob") {
+		t.Fatalf("consumed = %q", data)
+	}
+	// New message survives at original path
+	data2, _ := os.ReadFile(orig)
+	if !strings.Contains(string(data2), "bob") {
+		t.Fatalf("new message lost, orig = %q", data2)
+	}
+}
+```
+
+- [ ] **Step 3: Run tests — expect FAIL**
+
+Run: `go test ./internal/runtime/ -run "TestWriteSignal|TestConsumeSignal" -v`
+
+- [ ] **Step 4: Implement signal.go**
+
+```go
+package runtime
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// WriteSignal appends a formatted message to the agent's signal file.
+// Drops the write silently if the file already exceeds maxBytes.
+func WriteSignal(signalDir, agentName, fromName, body string, maxBytes int64) error {
+	if err := os.MkdirAll(signalDir, 0o700); err != nil {
+		return fmt.Errorf("create signal dir: %w", err)
+	}
+	path := filepath.Join(signalDir, agentName)
+	if maxBytes > 0 {
+		if info, err := os.Stat(path); err == nil && info.Size() >= maxBytes {
+			return nil
+		}
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("open signal: %w", err)
+	}
+	defer f.Close()
+	_, err = fmt.Fprintf(f, "\xf0\x9f\x93\xa8 waggle message from %s: %s\n", fromName, body)
+	return err
+}
+
+// ConsumeSignal atomically reads and removes the signal file.
+// Rename-then-read ensures no data loss if the daemon writes during consume.
+func ConsumeSignal(signalDir, agentName string) (string, error) {
+	path := filepath.Join(signalDir, agentName)
+	tmp := fmt.Sprintf("%s.consuming-%d", path, time.Now().UnixNano())
+	if err := os.Rename(path, tmp); err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	data, err := os.ReadFile(tmp)
+	os.Remove(tmp)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// PruneStaleFiles removes files matching prefix older than maxAge.
+func PruneStaleFiles(dir, prefix string, maxAge time.Duration) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-maxAge)
+	for _, e := range entries {
+		if !strings.HasPrefix(e.Name(), prefix) {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if info.ModTime().Before(cutoff) {
+			os.Remove(filepath.Join(dir, e.Name()))
+		}
+	}
+}
+```
+
+Note: `\xf0\x9f\x93\xa8` is the raw UTF-8 bytes for the 📨 emoji.
+
+- [ ] **Step 5: Run tests — expect PASS**
+
+Run: `go test ./internal/runtime/ -run "TestWriteSignal|TestConsumeSignal" -v`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/runtime/signal.go internal/runtime/signal_test.go internal/config/config.go
+git commit -m "feat: signal file writer with atomic consumption and size cap"
+```
+
+---
+
+### Task 2: Wire into Delivery Pipeline
+
+**Files:** `internal/runtime/manager.go`, `cmd/runtime_start.go`
+
+- [ ] **Step 1: Add signalDir field and setter to Manager**
+
+In `internal/runtime/manager.go`, add field to Manager struct:
+
+```go
+signalDir string // set via SetSignalDir; enables shell-hook signal files
+```
+
+Add setter method (after NewManager):
+
+```go
+// SetSignalDir enables signal file writing for shell-hook delivery.
+func (m *Manager) SetSignalDir(dir string) {
+	m.signalDir = dir
+}
+```
+
+- [ ] **Step 2: Add signal writing to notifyRecord**
+
+In `notifyRecord` (line 466), after the OS notification block and before `store.MarkNotified`, add:
+
+```go
+if m.signalDir != "" {
+	_ = WriteSignal(m.signalDir, agentName, senderFromTitle(title), body, config.Defaults.SignalMaxBytes)
+}
+```
+
+Add helper (after `notificationTitle`):
+
+```go
+func senderFromTitle(title string) string {
+	const prefix = "Message from "
+	if strings.HasPrefix(title, prefix) {
+		return strings.TrimPrefix(title, prefix)
+	}
+	return "unknown"
+}
+```
+
+- [ ] **Step 3: Add stale PPID cleanup to maintenance loop**
+
+In `runMaintenanceLoop`, inside the ticker case, after `PruneDeliveryRecords`:
+
+```go
+if m.signalDir != "" {
+	PruneStaleFiles(filepath.Dir(m.signalDir), "agent-ppid-", 24*time.Hour)
+}
+```
+
+Add `"path/filepath"` to imports if not already present (check: it's not in manager.go imports currently, but `strings` and `time` are).
+
+- [ ] **Step 4: Set signal dir in daemon startup**
+
+In `cmd/runtime_start.go`, after `rt.NewManager(store, rt.NewBrokerListenerFactory(), rt.NewCommandNotifier())` (line 44), add:
+
+```go
+manager.SetSignalDir(paths.RuntimeSignalDir)
+```
+
+Ensure `paths` is resolved before this line. Check the existing code to find where paths are computed.
+
+- [ ] **Step 5: Run all tests**
+
+Run: `go test ./internal/runtime/ -v && go test ./cmd/ -v`
+Expected: PASS — no test breakage since NewManager signature unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/runtime/manager.go cmd/runtime_start.go
+git commit -m "feat: wire signal files into delivery pipeline via setter"
+```
+
+---
+
+### Task 3: PPID Mapping (v4 — env var fix)
+
+**Files:** `internal/adapter/bootstrap.go`, `integrations/claude-code/hook.sh`, all adapter blocks
+
+**Critical context:** `os.Getppid()` returns the intermediate shell PID, NOT the agent PID. Process tree: `agent(X) → shell(Y) → waggle bootstrap(Z)`. `os.Getppid()=Y`, but shell hook checks `$PPID=X`. Fix: callers pass agent PID via `WAGGLE_AGENT_PPID=$PPID`.
+
+- [ ] **Step 1: Add WritePPIDMapping with env var override**
+
+Add to `internal/adapter/bootstrap.go` (add `"strconv"` to imports):
+
+```go
+// WritePPIDMapping writes agent name keyed by PID for shell hook discovery.
+func WritePPIDMapping(runtimeDir string, ppid int, agentName string) error {
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(
+		filepath.Join(runtimeDir, fmt.Sprintf("agent-ppid-%d", ppid)),
+		[]byte(agentName+"\n"),
+		0o600,
+	)
+}
+
+// resolveAgentPPID returns the agent process PID for PPID mapping.
+// Prefers WAGGLE_AGENT_PPID env var (set by callers who know the real agent PID)
+// over os.Getppid() (which returns the intermediate shell, not the agent).
+func resolveAgentPPID() int {
+	if ep := os.Getenv("WAGGLE_AGENT_PPID"); ep != "" {
+		if p, err := strconv.Atoi(ep); err == nil && p > 0 {
+			return p
+		}
+	}
+	return os.Getppid()
+}
+```
+
+- [ ] **Step 2: Call from Bootstrap function**
+
+After watch registration, before return:
+
+```go
+_ = WritePPIDMapping(runtimePaths.RuntimeDir, resolveAgentPPID(), result.AgentName)
+```
+
+- [ ] **Step 3: Update hook.sh to pass WAGGLE_AGENT_PPID**
+
+In `integrations/claude-code/hook.sh`, change the bootstrap call to:
+
+```bash
+OUTPUT=$($TIMEOUT_CMD 3 env WAGGLE_AGENT_PPID=$PPID waggle adapter bootstrap claude-code --format markdown 2>/dev/null) || OUTPUT=""
+```
+
+`$PPID` in hook.sh = Claude Code PID (the hook's parent). This passes through to bootstrap.go.
+
+- [ ] **Step 4: Update all adapter instruction blocks**
+
+Each adapter's instruction must include `WAGGLE_AGENT_PPID=$PPID`:
+
+`integrations/codex/AGENTS-block.md`:
+```
+WAGGLE_AGENT_PPID=$PPID waggle adapter bootstrap codex --format markdown
+```
+
+Same for `gemini/GEMINI-block.md`, `auggie/RULE-block.md`, `augment/SKILL-block.md`.
+
+- [ ] **Step 5: Write test**
+
+Add to `internal/adapter/bootstrap_test.go`:
+
+```go
+func TestWritePPIDMapping(t *testing.T) {
+	dir := t.TempDir()
+	if err := WritePPIDMapping(dir, 12345, "claude-99"); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "agent-ppid-12345"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "claude-99" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestResolveAgentPPID_PrefersEnvVar(t *testing.T) {
+	t.Setenv("WAGGLE_AGENT_PPID", "99999")
+	got := resolveAgentPPID()
+	if got != 99999 {
+		t.Fatalf("got %d, want 99999", got)
+	}
+}
+
+func TestResolveAgentPPID_FallsBackToGetppid(t *testing.T) {
+	t.Setenv("WAGGLE_AGENT_PPID", "")
+	got := resolveAgentPPID()
+	if got != os.Getppid() {
+		t.Fatalf("got %d, want %d", got, os.Getppid())
+	}
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `go test ./internal/adapter/ -run "TestWritePPIDMapping|TestResolveAgentPPID" -v`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/adapter/bootstrap.go integrations/
+git commit -m "feat: PPID mapping via WAGGLE_AGENT_PPID env var (fixes generation mismatch)"
+```
+
+---
+
+### Task 4: Shell Hook Script
+
+**Files:** `internal/install/shell-hook/shell-hook.sh`
+
+- [ ] **Step 1: Create directory and script**
+
+```bash
+mkdir -p internal/install/shell-hook
+```
+
+Create `internal/install/shell-hook/shell-hook.sh`:
+
+```bash
+# waggle shell-hook — surfaces messages on every agent command.
+# Sourced from .zshenv/.bashrc. Each agent tool call = new shell = fresh source.
+# Cost when no messages: 1 file stat (~ns). Guarded by PPID mapping.
+__waggle_check() {
+    local _wd="$HOME/.waggle/runtime"
+    local _wm="$_wd/agent-ppid-$PPID"
+    [ -f "$_wm" ] || return 0
+    local _wa
+    read -r _wa < "$_wm" 2>/dev/null || return 0
+    [ -n "$_wa" ] || return 0
+    local _ws="$_wd/signals/$_wa"
+    [ -f "$_ws" ] || return 0
+    # Atomic: rename then read. If daemon writes after mv, new file at original path.
+    local _wt="$_ws.c-$$"
+    mv "$_ws" "$_wt" 2>/dev/null || return 0
+    cat "$_wt" >&2 2>/dev/null
+    rm -f "$_wt" 2>/dev/null
+}
+__waggle_check
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add internal/install/shell-hook/shell-hook.sh
+git commit -m "feat: shell hook script for universal message delivery"
+```
+
+---
+
+### Task 5: Shell Hook Installer
+
+**Files:** `internal/install/shell_hook.go`, `internal/install/shell_hook_test.go`
+
+Continued in `2026-03-31-last-mile-push-delivery-part2.md`, Task 5 (full test code + implementation).

--- a/e2e/runtime_integration_test.go
+++ b/e2e/runtime_integration_test.go
@@ -80,7 +80,9 @@ func TestRuntimeEndToEndPushStoreAndPull(t *testing.T) {
 		_ = store.Close()
 	})
 
-	manager := rt.NewManager(store, rt.NewBrokerListenerFactory(), nil)
+	listenerFactory := rt.NewBrokerListenerFactory()
+	listenerFactory.PushToken = b.PushToken()
+	manager := rt.NewManager(store, listenerFactory, nil)
 	mgrCtx, mgrCancel := context.WithCancel(context.Background())
 	t.Cleanup(func() {
 		mgrCancel()
@@ -214,7 +216,9 @@ func TestRuntimeBrokerRestartReconnect(t *testing.T) {
 		_ = store.Close()
 	})
 
-	factory := &catchUpCounter{ListenerFactory: rt.NewBrokerListenerFactory()}
+	listenerFactory := rt.NewBrokerListenerFactory()
+	listenerFactory.PushToken = b1.PushToken()
+	factory := &catchUpCounter{ListenerFactory: listenerFactory}
 	manager := rt.NewManager(store, factory, nil)
 	mgrCtx, mgrCancel := context.WithCancel(context.Background())
 	t.Cleanup(func() {
@@ -309,6 +313,7 @@ func TestRuntimeBrokerRestartReconnect(t *testing.T) {
 		case <-time.After(2 * time.Second):
 		}
 	})
+	listenerFactory.PushToken = b2.PushToken()
 
 	// Step 9: Wait for broker #2 socket to be available
 	waitForCondition(t, "broker #2 socket", func() bool {

--- a/e2e/runtime_integration_test.go
+++ b/e2e/runtime_integration_test.go
@@ -80,9 +80,7 @@ func TestRuntimeEndToEndPushStoreAndPull(t *testing.T) {
 		_ = store.Close()
 	})
 
-	listenerFactory := rt.NewBrokerListenerFactory()
-	listenerFactory.PushToken = b.PushToken()
-	manager := rt.NewManager(store, listenerFactory, nil)
+	manager := rt.NewManager(store, rt.NewBrokerListenerFactory(), nil)
 	mgrCtx, mgrCancel := context.WithCancel(context.Background())
 	t.Cleanup(func() {
 		mgrCancel()
@@ -216,9 +214,7 @@ func TestRuntimeBrokerRestartReconnect(t *testing.T) {
 		_ = store.Close()
 	})
 
-	listenerFactory := rt.NewBrokerListenerFactory()
-	listenerFactory.PushToken = b1.PushToken()
-	factory := &catchUpCounter{ListenerFactory: listenerFactory}
+	factory := &catchUpCounter{ListenerFactory: rt.NewBrokerListenerFactory()}
 	manager := rt.NewManager(store, factory, nil)
 	mgrCtx, mgrCancel := context.WithCancel(context.Background())
 	t.Cleanup(func() {
@@ -313,7 +309,6 @@ func TestRuntimeBrokerRestartReconnect(t *testing.T) {
 		case <-time.After(2 * time.Second):
 		}
 	})
-	listenerFactory.PushToken = b2.PushToken()
 
 	// Step 9: Wait for broker #2 socket to be available
 	waitForCondition(t, "broker #2 socket", func() bool {

--- a/integrations/auggie/RULE-block.md
+++ b/integrations/auggie/RULE-block.md
@@ -2,6 +2,6 @@
 
 At the start of every session, run:
 
-  waggle adapter bootstrap auggie --format markdown
+  WAGGLE_AGENT_PPID=$PPID waggle adapter bootstrap auggie --format markdown
 
 If waggle is not installed or the command fails, continue normally. Use the agent name from the output for any subsequent waggle commands in this session.

--- a/integrations/augment/SKILL-block.md
+++ b/integrations/augment/SKILL-block.md
@@ -2,7 +2,7 @@
 
 At the start of every session, run:
 
-    waggle adapter bootstrap augment --format markdown
+    WAGGLE_AGENT_PPID=$PPID waggle adapter bootstrap augment --format markdown
 
 What to do with the result:
 

--- a/integrations/claude-code/hook.sh
+++ b/integrations/claude-code/hook.sh
@@ -29,7 +29,7 @@ fi
 
 # Bootstrap this Claude session into the waggle mesh.
 # The adapter bootstrap command is the single authoritative path for tool registration.
-OUTPUT=$($TIMEOUT_CMD 3 waggle adapter bootstrap claude-code --format markdown 2>/dev/null) || OUTPUT=""
+OUTPUT=$($TIMEOUT_CMD 3 env WAGGLE_AGENT_PPID=$PPID waggle adapter bootstrap claude-code --format markdown 2>/dev/null) || OUTPUT=""
 if [ -n "$OUTPUT" ]; then
     echo ""
     echo "$OUTPUT"

--- a/integrations/claude-code/waggle-push.js
+++ b/integrations/claude-code/waggle-push.js
@@ -29,21 +29,37 @@ try {
 
     const now = new Date();
     try { fs.utimesSync(sessionFile, now, now); } catch {}
+    try { fs.utimesSync(pointerFile, now, now); } catch {}
 
-    const sigFile = path.join(rtDir, 'signals', project, agent);
-    if (!fs.existsSync(sigFile)) process.exit(0);
+    const signalDir = path.join(rtDir, 'signals', project);
+    const sigFile = path.join(signalDir, agent);
+    const chunks = [];
 
-    // Atomic: rename then read (daemon writes to original path are safe)
-    const tmpFile = sigFile + '.c-' + process.pid;
-    try { fs.renameSync(sigFile, tmpFile); } catch { process.exit(0); }
+    try {
+        for (const entry of fs.readdirSync(signalDir)) {
+            if (!entry.startsWith(agent + '.c-')) continue;
+            const orphanFile = path.join(signalDir, entry);
+            const orphanContent = fs.readFileSync(orphanFile, 'utf8').trim();
+            try { fs.unlinkSync(orphanFile); } catch {}
+            if (orphanContent) chunks.push(orphanContent);
+        }
+    } catch {}
 
-    const content = fs.readFileSync(tmpFile, 'utf8').trim();
-    try { fs.unlinkSync(tmpFile); } catch {}
+    if (fs.existsSync(sigFile)) {
+        // Atomic: rename then read (daemon writes to original path are safe)
+        const tmpFile = sigFile + '.c-' + process.pid;
+        try {
+            fs.renameSync(sigFile, tmpFile);
+            const content = fs.readFileSync(tmpFile, 'utf8').trim();
+            try { fs.unlinkSync(tmpFile); } catch {}
+            if (content) chunks.push(content);
+        } catch {}
+    }
 
-    if (!content) process.exit(0);
+    if (chunks.length === 0) process.exit(0);
 
     console.log(JSON.stringify({
-        additionalContext: '\n' + content +
+        additionalContext: '\n' + chunks.join('\n') +
             '\nRespond to waggle messages using: ' +
             'WAGGLE_AGENT_NAME="' + agent + '" waggle send <sender> "<reply>"\n'
     }));

--- a/integrations/claude-code/waggle-push.js
+++ b/integrations/claude-code/waggle-push.js
@@ -29,23 +29,6 @@ try {
 
     const now = new Date();
     try { fs.utimesSync(sessionFile, now, now); } catch {}
-    try { fs.utimesSync(pointerFile, now, now); } catch {}
-
-    let orphanContent = '';
-    try {
-        const sigDirPath = path.join(rtDir, 'signals', project);
-        const entries = fs.readdirSync(sigDirPath);
-        for (const f of entries) {
-            if (f.startsWith(agent + '.c-')) {
-                const orphanPath = path.join(sigDirPath, f);
-                try {
-                    const data = fs.readFileSync(orphanPath, 'utf8').trim();
-                    if (data) orphanContent += (orphanContent ? '\n' : '') + data;
-                    fs.unlinkSync(orphanPath);
-                } catch {}
-            }
-        }
-    } catch {}
 
     const sigFile = path.join(rtDir, 'signals', project, agent);
     if (!fs.existsSync(sigFile)) process.exit(0);
@@ -57,11 +40,10 @@ try {
     const content = fs.readFileSync(tmpFile, 'utf8').trim();
     try { fs.unlinkSync(tmpFile); } catch {}
 
-    const allContent = [orphanContent, content].filter(Boolean).join('\n');
-    if (!allContent) process.exit(0);
+    if (!content) process.exit(0);
 
     console.log(JSON.stringify({
-        additionalContext: '\n' + allContent +
+        additionalContext: '\n' + content +
             '\nRespond to waggle messages using: ' +
             'WAGGLE_AGENT_NAME="' + agent + '" waggle send <sender> "<reply>"\n'
     }));

--- a/integrations/claude-code/waggle-push.js
+++ b/integrations/claude-code/waggle-push.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // waggle-push.js — PreToolUse hook for Claude Code.
-// Reads signal files via PPID mapping. Atomic consume via rename.
+// Reads signal files via PPID pointer + session mapping. Atomic consume via rename.
 // WAGGLE_PPID env var provides the real agent PID (set by hook command).
 const fs = require('fs');
 const path = require('path');
@@ -11,15 +11,24 @@ if (!home) process.exit(0);
 const rtDir = path.join(home, '.waggle', 'runtime');
 // Use WAGGLE_PPID (agent PID) not process.ppid (intermediate shell PID)
 const ppid = process.env.WAGGLE_PPID || String(process.ppid);
-const mapFile = path.join(rtDir, 'agent-ppid-' + ppid);
+const pointerFile = path.join(rtDir, 'agent-ppid-' + ppid);
 
 try {
-    if (!fs.existsSync(mapFile)) process.exit(0);
+    if (!fs.existsSync(pointerFile)) process.exit(0);
 
-    const lines = fs.readFileSync(mapFile, 'utf8').trim().split('\n');
+    const nonce = fs.readFileSync(pointerFile, 'utf8').trim();
+    if (!nonce) process.exit(0);
+
+    const sessionFile = path.join(rtDir, 'agent-session-' + nonce);
+    if (!fs.existsSync(sessionFile)) process.exit(0);
+
+    const lines = fs.readFileSync(sessionFile, 'utf8').trim().split('\n');
     const agent = lines[0];
     const project = lines[1] || '';
     if (!agent) process.exit(0);
+
+    const now = new Date();
+    try { fs.utimesSync(sessionFile, now, now); } catch {}
 
     const sigFile = path.join(rtDir, 'signals', project, agent);
     if (!fs.existsSync(sigFile)) process.exit(0);

--- a/integrations/claude-code/waggle-push.js
+++ b/integrations/claude-code/waggle-push.js
@@ -11,6 +11,7 @@ if (!home) process.exit(0);
 const rtDir = path.join(home, '.waggle', 'runtime');
 // Use WAGGLE_PPID (agent PID) not process.ppid (intermediate shell PID)
 const ppid = process.env.WAGGLE_PPID || String(process.ppid);
+if (!/^\d+$/.test(ppid)) process.exit(0);
 const pointerFile = path.join(rtDir, 'agent-ppid-' + ppid);
 
 try {
@@ -25,7 +26,9 @@ try {
     const lines = fs.readFileSync(sessionFile, 'utf8').trim().split('\n');
     const agent = lines[0];
     const project = lines[1] || '';
+    const tokenPattern = /^[a-zA-Z0-9_-]+$/;
     if (!agent) process.exit(0);
+    if (!tokenPattern.test(agent) || !tokenPattern.test(project)) process.exit(0);
 
     const now = new Date();
     try { fs.utimesSync(sessionFile, now, now); } catch {}

--- a/integrations/claude-code/waggle-push.js
+++ b/integrations/claude-code/waggle-push.js
@@ -16,10 +16,12 @@ const mapFile = path.join(rtDir, 'agent-ppid-' + ppid);
 try {
     if (!fs.existsSync(mapFile)) process.exit(0);
 
-    const agent = fs.readFileSync(mapFile, 'utf8').trim().split('\n')[0];
+    const lines = fs.readFileSync(mapFile, 'utf8').trim().split('\n');
+    const agent = lines[0];
+    const project = lines[1] || '';
     if (!agent) process.exit(0);
 
-    const sigFile = path.join(rtDir, 'signals', agent);
+    const sigFile = path.join(rtDir, 'signals', project, agent);
     if (!fs.existsSync(sigFile)) process.exit(0);
 
     // Atomic: rename then read (daemon writes to original path are safe)

--- a/integrations/claude-code/waggle-push.js
+++ b/integrations/claude-code/waggle-push.js
@@ -29,6 +29,23 @@ try {
 
     const now = new Date();
     try { fs.utimesSync(sessionFile, now, now); } catch {}
+    try { fs.utimesSync(pointerFile, now, now); } catch {}
+
+    let orphanContent = '';
+    try {
+        const sigDirPath = path.join(rtDir, 'signals', project);
+        const entries = fs.readdirSync(sigDirPath);
+        for (const f of entries) {
+            if (f.startsWith(agent + '.c-')) {
+                const orphanPath = path.join(sigDirPath, f);
+                try {
+                    const data = fs.readFileSync(orphanPath, 'utf8').trim();
+                    if (data) orphanContent += (orphanContent ? '\n' : '') + data;
+                    fs.unlinkSync(orphanPath);
+                } catch {}
+            }
+        }
+    } catch {}
 
     const sigFile = path.join(rtDir, 'signals', project, agent);
     if (!fs.existsSync(sigFile)) process.exit(0);
@@ -40,10 +57,11 @@ try {
     const content = fs.readFileSync(tmpFile, 'utf8').trim();
     try { fs.unlinkSync(tmpFile); } catch {}
 
-    if (!content) process.exit(0);
+    const allContent = [orphanContent, content].filter(Boolean).join('\n');
+    if (!allContent) process.exit(0);
 
     console.log(JSON.stringify({
-        additionalContext: '\n' + content +
+        additionalContext: '\n' + allContent +
             '\nRespond to waggle messages using: ' +
             'WAGGLE_AGENT_NAME="' + agent + '" waggle send <sender> "<reply>"\n'
     }));

--- a/integrations/claude-code/waggle-push.js
+++ b/integrations/claude-code/waggle-push.js
@@ -1,45 +1,41 @@
 #!/usr/bin/env node
-// waggle-push.js — PreToolUse hook
-// Reads pushed messages from waggle listener and injects via additionalContext
-
+// waggle-push.js — PreToolUse hook for Claude Code.
+// Reads signal files via PPID mapping. Atomic consume via rename.
+// WAGGLE_PPID env var provides the real agent PID (set by hook command).
 const fs = require('fs');
+const path = require('path');
 
-const agentName = process.env.WAGGLE_AGENT_NAME;
-if (!agentName) process.exit(0);
+const home = process.env.HOME;
+if (!home) process.exit(0);
 
-const listenFile = process.env.WAGGLE_LISTEN_FILE || `/tmp/waggle-${agentName}.jsonl`;
+const rtDir = path.join(home, '.waggle', 'runtime');
+// Use WAGGLE_PPID (agent PID) not process.ppid (intermediate shell PID)
+const ppid = process.env.WAGGLE_PPID || String(process.ppid);
+const mapFile = path.join(rtDir, 'agent-ppid-' + ppid);
 
 try {
-    if (!fs.existsSync(listenFile)) process.exit(0);
+    if (!fs.existsSync(mapFile)) process.exit(0);
 
-    const content = fs.readFileSync(listenFile, 'utf8').trim();
+    const agent = fs.readFileSync(mapFile, 'utf8').trim().split('\n')[0];
+    if (!agent) process.exit(0);
+
+    const sigFile = path.join(rtDir, 'signals', agent);
+    if (!fs.existsSync(sigFile)) process.exit(0);
+
+    // Atomic: rename then read (daemon writes to original path are safe)
+    const tmpFile = sigFile + '.c-' + process.pid;
+    try { fs.renameSync(sigFile, tmpFile); } catch { process.exit(0); }
+
+    const content = fs.readFileSync(tmpFile, 'utf8').trim();
+    try { fs.unlinkSync(tmpFile); } catch {}
+
     if (!content) process.exit(0);
 
-    // Clear the file immediately (atomic: write empty, not unlink)
-    fs.writeFileSync(listenFile, '');
-
-    // Parse messages
-    const messages = content.split('\n')
-        .filter(line => line.trim())
-        .map(line => {
-            try { return JSON.parse(line); }
-            catch { return null; }
-        })
-        .filter(Boolean);
-
-    if (messages.length === 0) process.exit(0);
-
-    // Format for injection
-    const formatted = messages.map(m =>
-        `[waggle] Message from ${m.from}: ${m.body}`
-    ).join('\n');
-
-    // Output additionalContext
     console.log(JSON.stringify({
-        additionalContext: `\n📨 Waggle: ${messages.length} new message(s):\n${formatted}\n`
+        additionalContext: '\n' + content +
+            '\nRespond to waggle messages using: ' +
+            'WAGGLE_AGENT_NAME="' + agent + '" waggle send <sender> "<reply>"\n'
     }));
-} catch (e) {
-    // Silent failure — don't block tool calls
+} catch {
     process.exit(0);
 }
-

--- a/integrations/codex/AGENTS-block.md
+++ b/integrations/codex/AGENTS-block.md
@@ -2,6 +2,6 @@
 
 At the start of every session, run:
 
-  waggle adapter bootstrap codex --format markdown
+  WAGGLE_AGENT_PPID=$PPID waggle adapter bootstrap codex --format markdown
 
 Do not skip this step. If the command fails or waggle is not installed, continue normally. Use the agent name from the output for any subsequent waggle commands in this session.

--- a/integrations/gemini/GEMINI-block.md
+++ b/integrations/gemini/GEMINI-block.md
@@ -2,6 +2,6 @@
 
 At the start of every session, run:
 
-    waggle adapter bootstrap gemini --format markdown
+    WAGGLE_AGENT_PPID=$PPID waggle adapter bootstrap gemini --format markdown
 
 Do not skip this step. If waggle is not installed, the command will fail silently — continue normally. Use the agent name from the output for any subsequent waggle commands in this session.

--- a/internal/adapter/bootstrap.go
+++ b/internal/adapter/bootstrap.go
@@ -1,8 +1,10 @@
 package adapter
 
 import (
+	"errors"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -81,7 +83,11 @@ func Bootstrap(input BootstrapInput) (BootstrapResult, error) {
 
 	ppid := resolveAgentPPID()
 	nonce := fmt.Sprintf("%d-%d", ppid, time.Now().UnixNano())
-	_ = WriteSessionMapping(runtimePaths.RuntimeDir, ppid, nonce, agentName, projectID)
+	// Best-effort: runtime delivery is driven by the watch store, and this mapping only
+	// enables shell-hook signal discovery for the current terminal session.
+	if err := WriteSessionMapping(runtimePaths.RuntimeDir, ppid, nonce, agentName, projectID); err != nil {
+		log.Printf("warning: write session mapping failed: %v; push delivery degraded", err)
+	}
 
 	records, err := store.Unread(projectID, agentName)
 	if err != nil {
@@ -144,7 +150,7 @@ func resolveProjectID(explicit string) (string, error) {
 	return config.ResolveProjectID()
 }
 
-func ensureRuntimeStarted(runtimePaths config.Paths) error {
+func ensureRuntimeStarted(runtimePaths config.Paths) (retErr error) {
 	if rt.IsRunning(runtimePaths) {
 		return nil
 	}
@@ -160,7 +166,13 @@ func ensureRuntimeStarted(runtimePaths config.Paths) error {
 		return err
 	}
 	defer func() {
-		_ = releaseLock()
+		if err := releaseLock(); err != nil {
+			if retErr == nil {
+				retErr = fmt.Errorf("release runtime start lock: %w", err)
+				return
+			}
+			log.Printf("warning: release runtime start lock: %v", err)
+		}
 	}()
 
 	daemonArgs := []string{os.Args[0], "runtime", "start", "--foreground"}
@@ -203,16 +215,16 @@ func sanitizeTTY(tty string) string {
 }
 
 // WriteSessionMapping writes the PPID pointer and unique session mapping for hook discovery.
-// The projectID is sanitized for filesystem safety before writing to the session file,
-// so shell/JS hooks receive the same safe value used for signal directory names.
+// The projectID is hashed to the same opaque key used for signal directory names,
+// so shell/JS hooks never receive raw project paths in session mapping files.
 func WriteSessionMapping(runtimeDir string, ppid int, nonce, agentName, projectID string) error {
 	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
 		return err
 	}
 
-	safeProjectID := rt.SanitizeProjectIDForPath(projectID)
+	projectKey := rt.ProjectPathKey(projectID)
 	sessionPath := filepath.Join(runtimeDir, "agent-session-"+nonce)
-	if err := writeRuntimeFileAtomic(sessionPath, []byte(agentName+"\n"+safeProjectID+"\n"), 0o600); err != nil {
+	if err := writeRuntimeFileAtomic(sessionPath, []byte(agentName+"\n"+projectKey+"\n"), 0o600); err != nil {
 		return err
 	}
 
@@ -220,7 +232,7 @@ func WriteSessionMapping(runtimeDir string, ppid int, nonce, agentName, projectI
 	return writeRuntimeFileAtomic(ppidPath, []byte(nonce+"\n"), 0o600)
 }
 
-func writeRuntimeFileAtomic(path string, data []byte, perm os.FileMode) error {
+func writeRuntimeFileAtomic(path string, data []byte, perm os.FileMode) (retErr error) {
 	dir := filepath.Dir(path)
 	base := filepath.Base(path)
 
@@ -229,9 +241,19 @@ func writeRuntimeFileAtomic(path string, data []byte, perm os.FileMode) error {
 		return err
 	}
 	tmpName := tmp.Name()
+	tmpOpen := true
+	cleanupPending := true
 	defer func() {
-		_ = tmp.Close()
-		_ = os.Remove(tmpName)
+		if tmpOpen {
+			if err := tmp.Close(); err != nil {
+				retErr = errors.Join(retErr, fmt.Errorf("close temp %s: %w", tmpName, err))
+			}
+		}
+		if cleanupPending {
+			if err := os.Remove(tmpName); err != nil && !os.IsNotExist(err) {
+				retErr = errors.Join(retErr, fmt.Errorf("remove temp %s: %w", tmpName, err))
+			}
+		}
 	}()
 
 	if err := tmp.Chmod(perm); err != nil {
@@ -243,10 +265,16 @@ func writeRuntimeFileAtomic(path string, data []byte, perm os.FileMode) error {
 	if err := tmp.Sync(); err != nil {
 		return err
 	}
-	if err := tmp.Close(); err != nil {
+	closeErr := tmp.Close()
+	tmpOpen = false
+	if closeErr != nil {
+		return closeErr
+	}
+	if err := os.Rename(tmpName, path); err != nil {
 		return err
 	}
-	return os.Rename(tmpName, path)
+	cleanupPending = false
+	return nil
 }
 
 // resolveAgentPPID returns the agent process PID for PPID mapping.

--- a/internal/adapter/bootstrap.go
+++ b/internal/adapter/bootstrap.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/seungpyoson/waggle/internal/broker"
@@ -76,6 +77,8 @@ func Bootstrap(input BootstrapInput) (BootstrapResult, error) {
 	}); err != nil {
 		return BootstrapResult{}, err
 	}
+
+	_ = WritePPIDMapping(runtimePaths.RuntimeDir, resolveAgentPPID(), agentName)
 
 	records, err := store.Unread(projectID, agentName)
 	if err != nil {
@@ -194,6 +197,30 @@ func sanitizeTTY(tty string) string {
 		return ""
 	}
 	return sanitizeToken(base)
+}
+
+// WritePPIDMapping writes agent name keyed by PID for shell hook discovery.
+func WritePPIDMapping(runtimeDir string, ppid int, agentName string) error {
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(
+		filepath.Join(runtimeDir, fmt.Sprintf("agent-ppid-%d", ppid)),
+		[]byte(agentName+"\n"),
+		0o600,
+	)
+}
+
+// resolveAgentPPID returns the agent process PID for PPID mapping.
+// Prefers WAGGLE_AGENT_PPID env var (set by callers who know the real agent PID)
+// over os.Getppid() (which returns the intermediate shell, not the agent).
+func resolveAgentPPID() int {
+	if ep := os.Getenv("WAGGLE_AGENT_PPID"); ep != "" {
+		if p, err := strconv.Atoi(ep); err == nil && p > 0 {
+			return p
+		}
+	}
+	return os.Getppid()
 }
 
 func sanitizeToken(v string) string {

--- a/internal/adapter/bootstrap.go
+++ b/internal/adapter/bootstrap.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/seungpyoson/waggle/internal/broker"
 	"github.com/seungpyoson/waggle/internal/config"
@@ -78,7 +79,9 @@ func Bootstrap(input BootstrapInput) (BootstrapResult, error) {
 		return BootstrapResult{}, err
 	}
 
-	_ = WritePPIDMapping(runtimePaths.RuntimeDir, resolveAgentPPID(), agentName, projectID)
+	ppid := resolveAgentPPID()
+	nonce := fmt.Sprintf("%d-%d", ppid, time.Now().UnixNano())
+	_ = WriteSessionMapping(runtimePaths.RuntimeDir, ppid, nonce, agentName, projectID)
 
 	records, err := store.Unread(projectID, agentName)
 	if err != nil {
@@ -199,16 +202,51 @@ func sanitizeTTY(tty string) string {
 	return sanitizeToken(base)
 }
 
-// WritePPIDMapping writes agent name and project ID keyed by PID for shell hook discovery.
-func WritePPIDMapping(runtimeDir string, ppid int, agentName, projectID string) error {
+// WriteSessionMapping writes the PPID pointer and unique session mapping for hook discovery.
+// The projectID is sanitized for filesystem safety before writing to the session file,
+// so shell/JS hooks receive the same safe value used for signal directory names.
+func WriteSessionMapping(runtimeDir string, ppid int, nonce, agentName, projectID string) error {
 	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
 		return err
 	}
-	return os.WriteFile(
-		filepath.Join(runtimeDir, fmt.Sprintf("agent-ppid-%d", ppid)),
-		[]byte(agentName+"\n"+projectID+"\n"),
-		0o600,
-	)
+
+	safeProjectID := rt.SanitizeProjectIDForPath(projectID)
+	sessionPath := filepath.Join(runtimeDir, "agent-session-"+nonce)
+	if err := writeRuntimeFileAtomic(sessionPath, []byte(agentName+"\n"+safeProjectID+"\n"), 0o600); err != nil {
+		return err
+	}
+
+	ppidPath := filepath.Join(runtimeDir, fmt.Sprintf("agent-ppid-%d", ppid))
+	return writeRuntimeFileAtomic(ppidPath, []byte(nonce+"\n"), 0o600)
+}
+
+func writeRuntimeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+
+	tmp, err := os.CreateTemp(dir, base+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+	}()
+
+	if err := tmp.Chmod(perm); err != nil {
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
 }
 
 // resolveAgentPPID returns the agent process PID for PPID mapping.

--- a/internal/adapter/bootstrap.go
+++ b/internal/adapter/bootstrap.go
@@ -78,7 +78,7 @@ func Bootstrap(input BootstrapInput) (BootstrapResult, error) {
 		return BootstrapResult{}, err
 	}
 
-	_ = WritePPIDMapping(runtimePaths.RuntimeDir, resolveAgentPPID(), agentName)
+	_ = WritePPIDMapping(runtimePaths.RuntimeDir, resolveAgentPPID(), agentName, projectID)
 
 	records, err := store.Unread(projectID, agentName)
 	if err != nil {
@@ -106,10 +106,10 @@ func Bootstrap(input BootstrapInput) (BootstrapResult, error) {
 
 func ResolveAgentName(tool, explicit, tty string, ppid, pid int) string {
 	if explicit != "" {
-		return explicit
+		return sanitizeToken(explicit)
 	}
 	if env := os.Getenv("WAGGLE_AGENT_NAME"); env != "" {
-		return env
+		return sanitizeToken(env)
 	}
 
 	tool = sanitizeToken(tool)
@@ -199,14 +199,14 @@ func sanitizeTTY(tty string) string {
 	return sanitizeToken(base)
 }
 
-// WritePPIDMapping writes agent name keyed by PID for shell hook discovery.
-func WritePPIDMapping(runtimeDir string, ppid int, agentName string) error {
+// WritePPIDMapping writes agent name and project ID keyed by PID for shell hook discovery.
+func WritePPIDMapping(runtimeDir string, ppid int, agentName, projectID string) error {
 	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
 		return err
 	}
 	return os.WriteFile(
 		filepath.Join(runtimeDir, fmt.Sprintf("agent-ppid-%d", ppid)),
-		[]byte(agentName+"\n"),
+		[]byte(agentName+"\n"+projectID+"\n"),
 		0o600,
 	)
 }

--- a/internal/adapter/bootstrap_test.go
+++ b/internal/adapter/bootstrap_test.go
@@ -2,6 +2,8 @@ package adapter
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -170,5 +172,35 @@ func TestAdapterBootstrap_SkipsGracefullyWithoutProjectContext(t *testing.T) {
 	}
 	if result.Tool != "codex" {
 		t.Fatalf("Bootstrap should still set Tool even when skipped, got %q", result.Tool)
+	}
+}
+
+func TestWritePPIDMapping(t *testing.T) {
+	dir := t.TempDir()
+	if err := WritePPIDMapping(dir, 12345, "claude-99"); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "agent-ppid-12345"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "claude-99" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestResolveAgentPPID_PrefersEnvVar(t *testing.T) {
+	t.Setenv("WAGGLE_AGENT_PPID", "99999")
+	got := resolveAgentPPID()
+	if got != 99999 {
+		t.Fatalf("got %d, want 99999", got)
+	}
+}
+
+func TestResolveAgentPPID_FallsBackToGetppid(t *testing.T) {
+	t.Setenv("WAGGLE_AGENT_PPID", "")
+	got := resolveAgentPPID()
+	if got != os.Getppid() {
+		t.Fatalf("got %d, want %d", got, os.Getppid())
 	}
 }

--- a/internal/adapter/bootstrap_test.go
+++ b/internal/adapter/bootstrap_test.go
@@ -1,7 +1,9 @@
 package adapter
 
 import (
+	"bytes"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -193,8 +195,8 @@ func TestWriteSessionMapping(t *testing.T) {
 	if lines[0] != "claude-99" {
 		t.Fatalf("agent = %q, want claude-99", lines[0])
 	}
-	if lines[1] != "proj-abc" {
-		t.Fatalf("project = %q, want proj-abc", lines[1])
+	if lines[1] != rt.ProjectPathKey("proj-abc") {
+		t.Fatalf("project = %q, want %q", lines[1], rt.ProjectPathKey("proj-abc"))
 	}
 
 	ppidData, err := os.ReadFile(filepath.Join(dir, "agent-ppid-12345"))
@@ -229,6 +231,74 @@ func TestWriteSessionMapping_NoncesAreDifferent(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, "agent-session-"+nonce2)); err != nil {
 		t.Fatalf("second session file missing: %v", err)
+	}
+}
+
+func TestWriteSessionMapping_StoresOpaqueProjectKey(t *testing.T) {
+	dir := t.TempDir()
+	nonce := "12345-1711843200000000001"
+	projectID := "path:/Users/test/project"
+
+	if err := WriteSessionMapping(dir, 12345, nonce, "claude-99", projectID); err != nil {
+		t.Fatal(err)
+	}
+
+	sessionData, err := os.ReadFile(filepath.Join(dir, "agent-session-"+nonce))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(string(sessionData), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %q", len(lines), sessionData)
+	}
+	if lines[1] != rt.ProjectPathKey(projectID) {
+		t.Fatalf("project key = %q, want %q", lines[1], rt.ProjectPathKey(projectID))
+	}
+	if strings.Contains(lines[1], "Users") || strings.Contains(lines[1], "project") {
+		t.Fatalf("project key leaked raw project path: %q", lines[1])
+	}
+}
+
+func TestBootstrap_LogsWhenSessionMappingWriteFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("WAGGLE_PROJECT_ID", "proj-log-warning")
+	t.Setenv("WAGGLE_ADAPTER_SKIP_RUNTIME_START", "1")
+	t.Setenv("WAGGLE_AGENT_PPID", "4242")
+
+	runtimeDir := config.NewPaths("").RuntimeDir
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(runtimeDir, "agent-ppid-4242"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	oldWriter := log.Writer()
+	oldFlags := log.Flags()
+	oldPrefix := log.Prefix()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	log.SetPrefix("")
+	t.Cleanup(func() {
+		log.SetOutput(oldWriter)
+		log.SetFlags(oldFlags)
+		log.SetPrefix(oldPrefix)
+	})
+
+	result, err := Bootstrap(BootstrapInput{Tool: "codex"})
+	if err != nil {
+		t.Fatalf("Bootstrap returned error: %v", err)
+	}
+	if result.ProjectID != "proj-log-warning" {
+		t.Fatalf("ProjectID = %q, want proj-log-warning", result.ProjectID)
+	}
+	if !strings.Contains(buf.String(), "warning: write session mapping failed") {
+		t.Fatalf("expected degraded push delivery warning, got %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "push delivery degraded") {
+		t.Fatalf("expected push delivery degraded detail, got %q", buf.String())
 	}
 }
 

--- a/internal/adapter/bootstrap_test.go
+++ b/internal/adapter/bootstrap_test.go
@@ -1,6 +1,7 @@
 package adapter
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -175,24 +176,59 @@ func TestAdapterBootstrap_SkipsGracefullyWithoutProjectContext(t *testing.T) {
 	}
 }
 
-func TestWritePPIDMapping(t *testing.T) {
+func TestWriteSessionMapping(t *testing.T) {
 	dir := t.TempDir()
-	if err := WritePPIDMapping(dir, 12345, "claude-99", "proj-abc"); err != nil {
+	nonce := "12345-1711843200000000000"
+	if err := WriteSessionMapping(dir, 12345, nonce, "claude-99", "proj-abc"); err != nil {
 		t.Fatal(err)
 	}
-	data, err := os.ReadFile(filepath.Join(dir, "agent-ppid-12345"))
+	sessionData, err := os.ReadFile(filepath.Join(dir, "agent-session-"+nonce))
 	if err != nil {
 		t.Fatal(err)
 	}
-	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	lines := strings.Split(strings.TrimRight(string(sessionData), "\n"), "\n")
 	if len(lines) != 2 {
-		t.Fatalf("expected 2 lines, got %d: %q", len(lines), data)
+		t.Fatalf("expected 2 lines, got %d: %q", len(lines), sessionData)
 	}
 	if lines[0] != "claude-99" {
 		t.Fatalf("agent = %q, want claude-99", lines[0])
 	}
 	if lines[1] != "proj-abc" {
 		t.Fatalf("project = %q, want proj-abc", lines[1])
+	}
+
+	ppidData, err := os.ReadFile(filepath.Join(dir, "agent-ppid-12345"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(ppidData) != nonce+"\n" {
+		t.Fatalf("ppid mapping = %q, want %q", string(ppidData), nonce+"\\n")
+	}
+}
+
+func TestWriteSessionMapping_NoncesAreDifferent(t *testing.T) {
+	dir := t.TempDir()
+	ppid := 12345
+	nonce1 := fmt.Sprintf("%d-%d", ppid, time.Now().UnixNano())
+	if err := WriteSessionMapping(dir, ppid, nonce1, "claude-99", "proj-abc"); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(time.Nanosecond)
+
+	nonce2 := fmt.Sprintf("%d-%d", ppid, time.Now().UnixNano())
+	if err := WriteSessionMapping(dir, ppid, nonce2, "claude-99", "proj-abc"); err != nil {
+		t.Fatal(err)
+	}
+
+	if nonce1 == nonce2 {
+		t.Fatalf("nonces should differ, both were %q", nonce1)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "agent-session-"+nonce1)); err != nil {
+		t.Fatalf("first session file missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "agent-session-"+nonce2)); err != nil {
+		t.Fatalf("second session file missing: %v", err)
 	}
 }
 

--- a/internal/adapter/bootstrap_test.go
+++ b/internal/adapter/bootstrap_test.go
@@ -14,18 +14,18 @@ import (
 func TestResolveAgentNamePrefersExplicit(t *testing.T) {
 	t.Setenv("WAGGLE_AGENT_NAME", "env-agent")
 
-	got := ResolveAgentName("codex", "explicit-agent", "/dev/ttys001", 123, 456)
+	got := ResolveAgentName("codex", "Explicit-Agent!", "/dev/ttys001", 123, 456)
 	if got != "explicit-agent" {
-		t.Fatalf("ResolveAgentName() = %q, want explicit-agent", got)
+		t.Fatalf("ResolveAgentName() = %q, want explicit-agent (sanitized)", got)
 	}
 }
 
 func TestResolveAgentNameUsesEnvBeforeTTY(t *testing.T) {
-	t.Setenv("WAGGLE_AGENT_NAME", "env-agent")
+	t.Setenv("WAGGLE_AGENT_NAME", "Env Agent!")
 
 	got := ResolveAgentName("codex", "", "/dev/ttys001", 123, 456)
 	if got != "env-agent" {
-		t.Fatalf("ResolveAgentName() = %q, want env-agent", got)
+		t.Fatalf("ResolveAgentName() = %q, want env-agent (sanitized)", got)
 	}
 }
 
@@ -177,15 +177,22 @@ func TestAdapterBootstrap_SkipsGracefullyWithoutProjectContext(t *testing.T) {
 
 func TestWritePPIDMapping(t *testing.T) {
 	dir := t.TempDir()
-	if err := WritePPIDMapping(dir, 12345, "claude-99"); err != nil {
+	if err := WritePPIDMapping(dir, 12345, "claude-99", "proj-abc"); err != nil {
 		t.Fatal(err)
 	}
 	data, err := os.ReadFile(filepath.Join(dir, "agent-ppid-12345"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := strings.TrimSpace(string(data)); got != "claude-99" {
-		t.Fatalf("got %q", got)
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %q", len(lines), data)
+	}
+	if lines[0] != "claude-99" {
+		t.Fatalf("agent = %q, want claude-99", lines[0])
+	}
+	if lines[1] != "proj-abc" {
+		t.Fatalf("project = %q, want proj-abc", lines[1])
 	}
 }
 

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -1,11 +1,14 @@
 package broker
 
 import (
+	"crypto/rand"
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"log"
 	"net"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -43,7 +46,9 @@ type Broker struct {
 	mu           sync.RWMutex
 	stopCh       chan struct{}
 	wg           sync.WaitGroup
-	ackWaiters   map[int64]chan struct{}
+	pushToken     string
+	pushTokenPath string
+	ackWaiters    map[int64]chan struct{}
 	ackWaitersMu sync.Mutex
 }
 
@@ -73,6 +78,11 @@ func New(cfg Config) (*Broker, error) {
 		if *f.val <= 0 {
 			return nil, fmt.Errorf("broker.Config.%s must be positive, got %v", f.name, *f.val)
 		}
+	}
+
+	pushToken, err := newPushToken()
+	if err != nil {
+		return nil, fmt.Errorf("generate push token: %w", err)
 	}
 
 	// Open database
@@ -136,10 +146,32 @@ func New(cfg Config) (*Broker, error) {
 		listener:   listener,
 		sessions:   make(map[string]*Session),
 		stopCh:     make(chan struct{}),
+		pushToken:  pushToken,
 		ackWaiters: make(map[int64]chan struct{}),
 	}
 
+	// Write push token to file for cross-process sharing with the runtime.
+	// The runtime's listener factory reads this to authenticate push connections.
+	b.pushTokenPath = filepath.Join(filepath.Dir(cfg.SocketPath), "push-token")
+	if err := os.WriteFile(b.pushTokenPath, []byte(pushToken), 0o600); err != nil {
+		listener.Close()
+		store.Close()
+		return nil, fmt.Errorf("write push token: %w", err)
+	}
+
 	return b, nil
+}
+
+func (b *Broker) PushToken() string {
+	return b.pushToken
+}
+
+func newPushToken() (string, error) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
 }
 
 // Serve starts the broker's accept loop and background tasks
@@ -231,9 +263,12 @@ func (b *Broker) Shutdown() error {
 		b.store.Close()
 	}
 
-	// Remove socket file
+	// Remove socket file and push token file
 	if b.config.SocketPath != "" {
 		os.Remove(b.config.SocketPath)
+	}
+	if b.pushTokenPath != "" {
+		os.Remove(b.pushTokenPath)
 	}
 
 	return nil
@@ -280,4 +315,3 @@ func cleanupSocket(path string) error {
 	}
 	return nil
 }
-

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -170,6 +170,38 @@ func (b *Broker) GetPushToken(agent string) string {
 	return b.pushTokens[agent]
 }
 
+func (b *Broker) GeneratePushToken(agent string) (string, error) {
+	if b == nil {
+		return "", fmt.Errorf("broker unavailable")
+	}
+	if agent == "" {
+		return "", fmt.Errorf("agent required")
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if token := b.pushTokens[agent]; token != "" {
+		return token, nil
+	}
+
+	token, err := newPushToken()
+	if err != nil {
+		return "", err
+	}
+	b.pushTokens[agent] = token
+	return token, nil
+}
+
+func (b *Broker) DeletePushToken(agent string) {
+	if b == nil || agent == "" {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delete(b.pushTokens, agent)
+}
+
 func newPushToken() (string, error) {
 	buf := make([]byte, 32)
 	if _, err := rand.Read(buf); err != nil {
@@ -271,6 +303,7 @@ func (b *Broker) Shutdown() error {
 
 	// Remove socket file
 	if b.config.SocketPath != "" {
+		// Best-effort cleanup: listener shutdown may already have removed the socket.
 		os.Remove(b.config.SocketPath)
 	}
 

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -1,7 +1,9 @@
 package broker
 
 import (
+	"crypto/rand"
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"log"
 	"net"
@@ -40,12 +42,15 @@ type Broker struct {
 	spawnMgr     *spawn.Manager
 	listener     net.Listener
 	sessions     map[string]*Session
+	pushTokens   map[string]string
 	mu           sync.RWMutex
 	stopCh       chan struct{}
 	wg           sync.WaitGroup
 	ackWaiters   map[int64]chan struct{}
 	ackWaitersMu sync.Mutex
 }
+
+var brokersBySocket sync.Map
 
 // New creates a new broker instance
 func New(cfg Config) (*Broker, error) {
@@ -135,11 +140,42 @@ func New(cfg Config) (*Broker, error) {
 		spawnMgr:   spawn.NewManager(),
 		listener:   listener,
 		sessions:   make(map[string]*Session),
+		pushTokens: make(map[string]string),
 		stopCh:     make(chan struct{}),
 		ackWaiters: make(map[int64]chan struct{}),
 	}
+	brokersBySocket.Store(cfg.SocketPath, b)
 
 	return b, nil
+}
+
+func LookupBySocket(socketPath string) *Broker {
+	if socketPath == "" {
+		return nil
+	}
+	if b, ok := brokersBySocket.Load(socketPath); ok {
+		if broker, ok := b.(*Broker); ok {
+			return broker
+		}
+	}
+	return nil
+}
+
+func (b *Broker) GetPushToken(agent string) string {
+	if b == nil {
+		return ""
+	}
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.pushTokens[agent]
+}
+
+func newPushToken() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate push token: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
 }
 
 // Serve starts the broker's accept loop and background tasks
@@ -204,6 +240,8 @@ func (b *Broker) Serve() error {
 
 // Shutdown gracefully shuts down the broker
 func (b *Broker) Shutdown() error {
+	brokersBySocket.Delete(b.config.SocketPath)
+
 	// Kill spawned agents before stopping
 	if b.spawnMgr != nil {
 		b.spawnMgr.StopAll()
@@ -280,4 +318,3 @@ func cleanupSocket(path string) error {
 	}
 	return nil
 }
-

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -1,14 +1,11 @@
 package broker
 
 import (
-	"crypto/rand"
 	"database/sql"
-	"encoding/hex"
 	"fmt"
 	"log"
 	"net"
 	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -46,9 +43,7 @@ type Broker struct {
 	mu           sync.RWMutex
 	stopCh       chan struct{}
 	wg           sync.WaitGroup
-	pushToken     string
-	pushTokenPath string
-	ackWaiters    map[int64]chan struct{}
+	ackWaiters   map[int64]chan struct{}
 	ackWaitersMu sync.Mutex
 }
 
@@ -78,11 +73,6 @@ func New(cfg Config) (*Broker, error) {
 		if *f.val <= 0 {
 			return nil, fmt.Errorf("broker.Config.%s must be positive, got %v", f.name, *f.val)
 		}
-	}
-
-	pushToken, err := newPushToken()
-	if err != nil {
-		return nil, fmt.Errorf("generate push token: %w", err)
 	}
 
 	// Open database
@@ -146,32 +136,10 @@ func New(cfg Config) (*Broker, error) {
 		listener:   listener,
 		sessions:   make(map[string]*Session),
 		stopCh:     make(chan struct{}),
-		pushToken:  pushToken,
 		ackWaiters: make(map[int64]chan struct{}),
 	}
 
-	// Write push token to file for cross-process sharing with the runtime.
-	// The runtime's listener factory reads this to authenticate push connections.
-	b.pushTokenPath = filepath.Join(filepath.Dir(cfg.SocketPath), "push-token")
-	if err := os.WriteFile(b.pushTokenPath, []byte(pushToken), 0o600); err != nil {
-		listener.Close()
-		store.Close()
-		return nil, fmt.Errorf("write push token: %w", err)
-	}
-
 	return b, nil
-}
-
-func (b *Broker) PushToken() string {
-	return b.pushToken
-}
-
-func newPushToken() (string, error) {
-	buf := make([]byte, 16)
-	if _, err := rand.Read(buf); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(buf), nil
 }
 
 // Serve starts the broker's accept loop and background tasks
@@ -263,12 +231,9 @@ func (b *Broker) Shutdown() error {
 		b.store.Close()
 	}
 
-	// Remove socket file and push token file
+	// Remove socket file
 	if b.config.SocketPath != "" {
 		os.Remove(b.config.SocketPath)
-	}
-	if b.pushTokenPath != "" {
-		os.Remove(b.pushTokenPath)
 	}
 
 	return nil
@@ -315,3 +280,4 @@ func cleanupSocket(path string) error {
 	}
 	return nil
 }
+

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -73,6 +73,20 @@ func connectClient(t *testing.T, sockPath string) *client.Client {
 	return c
 }
 
+func pushTokenFromResponse(t *testing.T, resp *protocol.Response) string {
+	t.Helper()
+	var payload struct {
+		PushToken string `json:"push_token"`
+	}
+	if err := json.Unmarshal(resp.Data, &payload); err != nil {
+		t.Fatalf("parse connect response: %v", err)
+	}
+	if payload.PushToken == "" {
+		t.Fatal("expected connect response to include push token")
+	}
+	return payload.PushToken
+}
+
 // readStream starts reading events and fatals on error.
 func readStream(t *testing.T, c *client.Client) <-chan protocol.Event {
 	t.Helper()
@@ -317,7 +331,9 @@ func TestBroker_FullRoundTrip_CreateClaimComplete(t *testing.T) {
 		Cmd:    protocol.CmdTaskGet,
 		TaskID: taskIDStr,
 	})
-	var task struct{ State string `json:"State"` }
+	var task struct {
+		State string `json:"State"`
+	}
 	json.Unmarshal(resp.Data, &task)
 	if task.State != "completed" {
 		t.Errorf("state = %q, want completed", task.State)
@@ -539,7 +555,9 @@ func TestBroker_DisconnectUnsubscribesEvents(t *testing.T) {
 		t.Fatalf("status: %s", resp.Error)
 	}
 	// Status should show 0 subscribers after disconnect
-	var status struct{ Subscribers int `json:"subscribers"` }
+	var status struct {
+		Subscribers int `json:"subscribers"`
+	}
 	json.Unmarshal(resp.Data, &status)
 	if status.Subscribers != 0 {
 		t.Errorf("subscribers = %d, want 0 after disconnect", status.Subscribers)
@@ -610,7 +628,6 @@ func TestBroker_InvalidJSONReturnsError(t *testing.T) {
 	}
 }
 
-
 // Test: Worker A disconnects, Worker B's claimed task should NOT be re-queued
 func TestBroker_DisconnectOnlyRequeuesOwnTasks(t *testing.T) {
 	sockPath, _, cleanup := startTestBroker(t)
@@ -621,7 +638,9 @@ func TestBroker_DisconnectOnlyRequeuesOwnTasks(t *testing.T) {
 	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "worker-a"})
 	c1.Send(protocol.Request{Cmd: protocol.CmdTaskCreate, Payload: json.RawMessage(`{"desc":"task1"}`), Type: "test"})
 	resp1, _ := c1.Send(protocol.Request{Cmd: protocol.CmdTaskClaim})
-	var claim1 struct{ ID int64 `json:"ID"` }
+	var claim1 struct {
+		ID int64 `json:"ID"`
+	}
 	json.Unmarshal(resp1.Data, &claim1)
 
 	// Worker B connects and claims task 2
@@ -629,7 +648,9 @@ func TestBroker_DisconnectOnlyRequeuesOwnTasks(t *testing.T) {
 	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "worker-b"})
 	c2.Send(protocol.Request{Cmd: protocol.CmdTaskCreate, Payload: json.RawMessage(`{"desc":"task2"}`), Type: "test"})
 	resp2, _ := c2.Send(protocol.Request{Cmd: protocol.CmdTaskClaim})
-	var claim2 struct{ ID int64 `json:"ID"` }
+	var claim2 struct {
+		ID int64 `json:"ID"`
+	}
 	json.Unmarshal(resp2.Data, &claim2)
 
 	// Worker A disconnects
@@ -638,7 +659,9 @@ func TestBroker_DisconnectOnlyRequeuesOwnTasks(t *testing.T) {
 
 	// Verify Worker B's task is still claimed
 	resp, _ := c2.Send(protocol.Request{Cmd: protocol.CmdTaskGet, TaskID: fmt.Sprintf("%d", claim2.ID)})
-	var task struct{ State string `json:"State"` }
+	var task struct {
+		State string `json:"State"`
+	}
 	json.Unmarshal(resp.Data, &task)
 	if task.State != "claimed" {
 		t.Errorf("Worker B's task state = %q, want claimed (should NOT be re-queued when Worker A disconnects)", task.State)
@@ -803,7 +826,6 @@ func TestIsConnectionClosed_UnrelatedError(t *testing.T) {
 		t.Error("unrelated error should return false")
 	}
 }
-
 
 // ========== Direct Messaging Tests (Task 43) ==========
 
@@ -3055,9 +3077,140 @@ func TestBroker_CustomEventEmptyMessage(t *testing.T) {
 }
 
 // TestBroker_PushToListenerSession verifies that messages sent to "alice" are also pushed to "alice-push" session (L5)
+func TestBroker_PushListenerRejectsMissingToken(t *testing.T) {
+	sockPath, b, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	base := connectClient(t, sockPath)
+	defer base.Close()
+	resp, err := base.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("base connect failed: %s", resp.Error)
+	}
+
+	if token := b.GetPushToken("alice"); token == "" {
+		t.Fatal("expected broker to generate push token for alice")
+	}
+
+	listener := connectClient(t, sockPath)
+	defer listener.Close()
+	resp, err = listener.Send(protocol.Request{
+		Cmd:          protocol.CmdConnect,
+		Name:         "alice-push",
+		PushListener: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.OK {
+		t.Fatal("expected push listener connect without token to fail")
+	}
+	if resp.Code != protocol.ErrForbidden {
+		t.Fatalf("response code = %q, want %q", resp.Code, protocol.ErrForbidden)
+	}
+}
+
+func TestBroker_PushListenerRejectsWrongToken(t *testing.T) {
+	sockPath, b, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	base := connectClient(t, sockPath)
+	defer base.Close()
+	resp, err := base.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("base connect failed: %s", resp.Error)
+	}
+
+	token := b.GetPushToken("alice")
+	if token == "" {
+		t.Fatal("expected broker to generate push token for alice")
+	}
+	wrongToken := token[:len(token)-1] + "0"
+	if wrongToken == token {
+		wrongToken = token[:len(token)-1] + "1"
+	}
+
+	listener := connectClient(t, sockPath)
+	defer listener.Close()
+	resp, err = listener.Send(protocol.Request{
+		Cmd:          protocol.CmdConnect,
+		Name:         "alice-push",
+		PushListener: true,
+		PushToken:    wrongToken,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.OK {
+		t.Fatal("expected push listener connect with wrong token to fail")
+	}
+	if resp.Code != protocol.ErrForbidden {
+		t.Fatalf("response code = %q, want %q", resp.Code, protocol.ErrForbidden)
+	}
+}
+
+func TestBroker_PushListenerAcceptsValidToken(t *testing.T) {
+	sockPath, b, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	base := connectClient(t, sockPath)
+	defer base.Close()
+	resp, err := base.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("base connect failed: %s", resp.Error)
+	}
+
+	token := b.GetPushToken("alice")
+	if token == "" {
+		t.Fatal("expected broker to generate push token for alice")
+	}
+
+	listener := connectClient(t, sockPath)
+	defer listener.Close()
+	resp, err = listener.Send(protocol.Request{
+		Cmd:          protocol.CmdConnect,
+		Name:         "alice-push",
+		PushListener: true,
+		PushToken:    token,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("expected push listener connect with valid token to succeed: %s", resp.Error)
+	}
+}
+
 func TestBroker_PushToListenerSession(t *testing.T) {
 	sockPath, _, cleanup := startTestBroker(t)
 	defer cleanup()
+
+	baseConn, err := client.Connect(sockPath, 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer baseConn.Close()
+
+	baseResp, err := baseConn.Send(protocol.Request{
+		Cmd:  protocol.CmdConnect,
+		Name: "alice",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !baseResp.OK {
+		t.Fatalf("expected base connect to succeed: %s", baseResp.Error)
+	}
+	pushToken := pushTokenFromResponse(t, baseResp)
 
 	// Connect as "alice-push" (the persistent listener)
 	listenerConn, err := client.Connect(sockPath, 5*time.Second)
@@ -3070,9 +3223,14 @@ func TestBroker_PushToListenerSession(t *testing.T) {
 		Cmd:          "connect",
 		Name:         "alice-push",
 		PushListener: true,
+		PushToken:    pushToken,
 	}
-	if _, err := listenerConn.Send(connectReq); err != nil {
+	pushResp, err := listenerConn.Send(connectReq)
+	if err != nil {
 		t.Fatal(err)
+	}
+	if !pushResp.OK {
+		t.Fatalf("push listener connect failed: %s", pushResp.Error)
 	}
 
 	// Connect as sender
@@ -3101,17 +3259,17 @@ func TestBroker_PushToListenerSession(t *testing.T) {
 	}
 
 	// Listener should receive the push
-	resp, err := listenerConn.Receive()
+	recvResp, err := listenerConn.Receive()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !resp.OK {
-		t.Fatalf("expected OK response, got error: %s", resp.Error)
+	if !recvResp.OK {
+		t.Fatalf("expected OK response, got error: %s", recvResp.Error)
 	}
 
 	var data map[string]any
-	if err := json.Unmarshal(resp.Data, &data); err != nil {
+	if err := json.Unmarshal(recvResp.Data, &data); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3131,6 +3289,24 @@ func TestBroker_ListenReceivesPush(t *testing.T) {
 	sockPath, _, cleanup := startTestBroker(t)
 	defer cleanup()
 
+	baseConn, err := client.Connect(sockPath, 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer baseConn.Close()
+
+	baseResp, err := baseConn.Send(protocol.Request{
+		Cmd:  protocol.CmdConnect,
+		Name: "bob",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !baseResp.OK {
+		t.Fatalf("base connect failed: %s", baseResp.Error)
+	}
+	pushToken := pushTokenFromResponse(t, baseResp)
+
 	// Connect listener using ReadMessages
 	listenerConn, err := client.Connect(sockPath, 5*time.Second)
 	if err != nil {
@@ -3142,9 +3318,14 @@ func TestBroker_ListenReceivesPush(t *testing.T) {
 		Cmd:          "connect",
 		Name:         "bob-push",
 		PushListener: true,
+		PushToken:    pushToken,
 	}
-	if _, err := listenerConn.Send(connectReq); err != nil {
+	pushResp, err := listenerConn.Send(connectReq)
+	if err != nil {
 		t.Fatal(err)
+	}
+	if !pushResp.OK {
+		t.Fatalf("push listener connect failed: %s", pushResp.Error)
 	}
 
 	// Start reading messages
@@ -3197,10 +3378,32 @@ func TestClient_ReadMessagesFilters(t *testing.T) {
 	sockPath, _, cleanup := startTestBroker(t)
 	defer cleanup()
 
+	baseConn := connectClient(t, sockPath)
+	defer baseConn.Close()
+	baseResp, err := baseConn.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "filter-test"})
+	if err != nil {
+		t.Fatalf("base connect: %v", err)
+	}
+	if !baseResp.OK {
+		t.Fatalf("base connect failed: %s", baseResp.Error)
+	}
+	pushToken := pushTokenFromResponse(t, baseResp)
+
 	// Connect a listener as "filter-test-push"
 	listenerConn := connectClient(t, sockPath)
 	defer listenerConn.Close()
-	listenerConn.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "filter-test-push", PushListener: true})
+	pushResp, err := listenerConn.Send(protocol.Request{
+		Cmd:          protocol.CmdConnect,
+		Name:         "filter-test-push",
+		PushListener: true,
+		PushToken:    pushToken,
+	})
+	if err != nil {
+		t.Fatalf("push connect: %v", err)
+	}
+	if !pushResp.OK {
+		t.Fatalf("push connect failed: %s", pushResp.Error)
+	}
 
 	// Start ReadMessages — it now owns the scanner
 	msgCh, err := listenerConn.ReadMessages()
@@ -3213,7 +3416,7 @@ func TestClient_ReadMessagesFilters(t *testing.T) {
 	sender := connectClient(t, sockPath)
 	defer sender.Close()
 	sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "sender-filter"})
-	resp, err := sender.Send(protocol.Request{
+	sendResp, err := sender.Send(protocol.Request{
 		Cmd:     protocol.CmdSend,
 		Name:    "filter-test",
 		Message: "filter test message",
@@ -3221,8 +3424,8 @@ func TestClient_ReadMessagesFilters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("send: %v", err)
 	}
-	if !resp.OK {
-		t.Fatalf("send failed: %s", resp.Error)
+	if !sendResp.OK {
+		t.Fatalf("send failed: %s", sendResp.Error)
 	}
 
 	// The listener should receive the pushed message
@@ -3246,9 +3449,31 @@ func TestPresence_StripsPushAndDeduplicates(t *testing.T) {
 	sockPath, _, cleanup := startTestBroker(t)
 	defer cleanup()
 
+	base := connectClient(t, sockPath)
+	defer base.Close()
+	baseResp, err := base.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	if err != nil {
+		t.Fatalf("base connect: %v", err)
+	}
+	if !baseResp.OK {
+		t.Fatalf("base connect failed: %s", baseResp.Error)
+	}
+	pushToken := pushTokenFromResponse(t, baseResp)
+
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice-push", PushListener: true})
+	pushResp, err := c1.Send(protocol.Request{
+		Cmd:          protocol.CmdConnect,
+		Name:         "alice-push",
+		PushListener: true,
+		PushToken:    pushToken,
+	})
+	if err != nil {
+		t.Fatalf("push connect: %v", err)
+	}
+	if !pushResp.OK {
+		t.Fatalf("push connect failed: %s", pushResp.Error)
+	}
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -317,7 +317,9 @@ func TestBroker_FullRoundTrip_CreateClaimComplete(t *testing.T) {
 		Cmd:    protocol.CmdTaskGet,
 		TaskID: taskIDStr,
 	})
-	var task struct{ State string `json:"State"` }
+	var task struct {
+		State string `json:"State"`
+	}
 	json.Unmarshal(resp.Data, &task)
 	if task.State != "completed" {
 		t.Errorf("state = %q, want completed", task.State)
@@ -539,7 +541,9 @@ func TestBroker_DisconnectUnsubscribesEvents(t *testing.T) {
 		t.Fatalf("status: %s", resp.Error)
 	}
 	// Status should show 0 subscribers after disconnect
-	var status struct{ Subscribers int `json:"subscribers"` }
+	var status struct {
+		Subscribers int `json:"subscribers"`
+	}
 	json.Unmarshal(resp.Data, &status)
 	if status.Subscribers != 0 {
 		t.Errorf("subscribers = %d, want 0 after disconnect", status.Subscribers)
@@ -610,7 +614,6 @@ func TestBroker_InvalidJSONReturnsError(t *testing.T) {
 	}
 }
 
-
 // Test: Worker A disconnects, Worker B's claimed task should NOT be re-queued
 func TestBroker_DisconnectOnlyRequeuesOwnTasks(t *testing.T) {
 	sockPath, _, cleanup := startTestBroker(t)
@@ -621,7 +624,9 @@ func TestBroker_DisconnectOnlyRequeuesOwnTasks(t *testing.T) {
 	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "worker-a"})
 	c1.Send(protocol.Request{Cmd: protocol.CmdTaskCreate, Payload: json.RawMessage(`{"desc":"task1"}`), Type: "test"})
 	resp1, _ := c1.Send(protocol.Request{Cmd: protocol.CmdTaskClaim})
-	var claim1 struct{ ID int64 `json:"ID"` }
+	var claim1 struct {
+		ID int64 `json:"ID"`
+	}
 	json.Unmarshal(resp1.Data, &claim1)
 
 	// Worker B connects and claims task 2
@@ -629,7 +634,9 @@ func TestBroker_DisconnectOnlyRequeuesOwnTasks(t *testing.T) {
 	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "worker-b"})
 	c2.Send(protocol.Request{Cmd: protocol.CmdTaskCreate, Payload: json.RawMessage(`{"desc":"task2"}`), Type: "test"})
 	resp2, _ := c2.Send(protocol.Request{Cmd: protocol.CmdTaskClaim})
-	var claim2 struct{ ID int64 `json:"ID"` }
+	var claim2 struct {
+		ID int64 `json:"ID"`
+	}
 	json.Unmarshal(resp2.Data, &claim2)
 
 	// Worker A disconnects
@@ -638,7 +645,9 @@ func TestBroker_DisconnectOnlyRequeuesOwnTasks(t *testing.T) {
 
 	// Verify Worker B's task is still claimed
 	resp, _ := c2.Send(protocol.Request{Cmd: protocol.CmdTaskGet, TaskID: fmt.Sprintf("%d", claim2.ID)})
-	var task struct{ State string `json:"State"` }
+	var task struct {
+		State string `json:"State"`
+	}
 	json.Unmarshal(resp.Data, &task)
 	if task.State != "claimed" {
 		t.Errorf("Worker B's task state = %q, want claimed (should NOT be re-queued when Worker A disconnects)", task.State)
@@ -803,7 +812,6 @@ func TestIsConnectionClosed_UnrelatedError(t *testing.T) {
 		t.Error("unrelated error should return false")
 	}
 }
-
 
 // ========== Direct Messaging Tests (Task 43) ==========
 
@@ -1390,6 +1398,31 @@ func TestBroker_DuplicateNameRejected(t *testing.T) {
 	json.Unmarshal(pushResp.Data, &pushData)
 	if pushData["body"] != "still alive" {
 		t.Errorf("push body = %q, want 'still alive'", pushData["body"])
+	}
+}
+
+func TestConnect_RejectsPushWithoutToken(t *testing.T) {
+	sockPath, _, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	c := connectClient(t, sockPath)
+	defer c.Close()
+
+	resp, err := c.Send(protocol.Request{
+		Cmd:  protocol.CmdConnect,
+		Name: "alice-push",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.OK {
+		t.Fatal("expected push listener connect without token to fail")
+	}
+	if resp.Code != protocol.ErrForbidden {
+		t.Fatalf("error code = %q, want %q", resp.Code, protocol.ErrForbidden)
+	}
+	if resp.Error != "invalid push listener token" {
+		t.Fatalf("error message = %q, want invalid push listener token", resp.Error)
 	}
 }
 
@@ -3056,7 +3089,7 @@ func TestBroker_CustomEventEmptyMessage(t *testing.T) {
 
 // TestBroker_PushToListenerSession verifies that messages sent to "alice" are also pushed to "alice-push" session (L5)
 func TestBroker_PushToListenerSession(t *testing.T) {
-	sockPath, _, cleanup := startTestBroker(t)
+	sockPath, b, cleanup := startTestBroker(t)
 	defer cleanup()
 
 	// Connect as "alice-push" (the persistent listener)
@@ -3070,6 +3103,7 @@ func TestBroker_PushToListenerSession(t *testing.T) {
 		Cmd:          "connect",
 		Name:         "alice-push",
 		PushListener: true,
+		PushToken:    b.PushToken(),
 	}
 	if _, err := listenerConn.Send(connectReq); err != nil {
 		t.Fatal(err)
@@ -3128,7 +3162,7 @@ func TestBroker_PushToListenerSession(t *testing.T) {
 
 // TestBroker_ListenReceivesPush verifies that waggle listen receives pushed messages (L1)
 func TestBroker_ListenReceivesPush(t *testing.T) {
-	sockPath, _, cleanup := startTestBroker(t)
+	sockPath, b, cleanup := startTestBroker(t)
 	defer cleanup()
 
 	// Connect listener using ReadMessages
@@ -3142,6 +3176,7 @@ func TestBroker_ListenReceivesPush(t *testing.T) {
 		Cmd:          "connect",
 		Name:         "bob-push",
 		PushListener: true,
+		PushToken:    b.PushToken(),
 	}
 	if _, err := listenerConn.Send(connectReq); err != nil {
 		t.Fatal(err)
@@ -3194,13 +3229,18 @@ func TestBroker_ListenReceivesPush(t *testing.T) {
 
 // TestClient_ReadMessagesFilters verifies that ReadMessages only emits message-type responses (L10)
 func TestClient_ReadMessagesFilters(t *testing.T) {
-	sockPath, _, cleanup := startTestBroker(t)
+	sockPath, b, cleanup := startTestBroker(t)
 	defer cleanup()
 
 	// Connect a listener as "filter-test-push"
 	listenerConn := connectClient(t, sockPath)
 	defer listenerConn.Close()
-	listenerConn.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "filter-test-push", PushListener: true})
+	listenerConn.Send(protocol.Request{
+		Cmd:          protocol.CmdConnect,
+		Name:         "filter-test-push",
+		PushListener: true,
+		PushToken:    b.PushToken(),
+	})
 
 	// Start ReadMessages — it now owns the scanner
 	msgCh, err := listenerConn.ReadMessages()
@@ -3243,12 +3283,17 @@ func TestClient_ReadMessagesFilters(t *testing.T) {
 }
 
 func TestPresence_StripsPushAndDeduplicates(t *testing.T) {
-	sockPath, _, cleanup := startTestBroker(t)
+	sockPath, b, cleanup := startTestBroker(t)
 	defer cleanup()
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice-push", PushListener: true})
+	c1.Send(protocol.Request{
+		Cmd:          protocol.CmdConnect,
+		Name:         "alice-push",
+		PushListener: true,
+		PushToken:    b.PushToken(),
+	})
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -3067,8 +3067,9 @@ func TestBroker_PushToListenerSession(t *testing.T) {
 	defer listenerConn.Close()
 
 	connectReq := protocol.Request{
-		Cmd:  "connect",
-		Name: "alice-push",
+		Cmd:          "connect",
+		Name:         "alice-push",
+		PushListener: true,
 	}
 	if _, err := listenerConn.Send(connectReq); err != nil {
 		t.Fatal(err)
@@ -3138,8 +3139,9 @@ func TestBroker_ListenReceivesPush(t *testing.T) {
 	defer listenerConn.Close()
 
 	connectReq := protocol.Request{
-		Cmd:  "connect",
-		Name: "bob-push",
+		Cmd:          "connect",
+		Name:         "bob-push",
+		PushListener: true,
 	}
 	if _, err := listenerConn.Send(connectReq); err != nil {
 		t.Fatal(err)
@@ -3198,7 +3200,7 @@ func TestClient_ReadMessagesFilters(t *testing.T) {
 	// Connect a listener as "filter-test-push"
 	listenerConn := connectClient(t, sockPath)
 	defer listenerConn.Close()
-	listenerConn.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "filter-test-push"})
+	listenerConn.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "filter-test-push", PushListener: true})
 
 	// Start ReadMessages — it now owns the scanner
 	msgCh, err := listenerConn.ReadMessages()
@@ -3246,7 +3248,7 @@ func TestPresence_StripsPushAndDeduplicates(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice-push"})
+	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice-push", PushListener: true})
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -317,9 +317,7 @@ func TestBroker_FullRoundTrip_CreateClaimComplete(t *testing.T) {
 		Cmd:    protocol.CmdTaskGet,
 		TaskID: taskIDStr,
 	})
-	var task struct {
-		State string `json:"State"`
-	}
+	var task struct{ State string `json:"State"` }
 	json.Unmarshal(resp.Data, &task)
 	if task.State != "completed" {
 		t.Errorf("state = %q, want completed", task.State)
@@ -541,9 +539,7 @@ func TestBroker_DisconnectUnsubscribesEvents(t *testing.T) {
 		t.Fatalf("status: %s", resp.Error)
 	}
 	// Status should show 0 subscribers after disconnect
-	var status struct {
-		Subscribers int `json:"subscribers"`
-	}
+	var status struct{ Subscribers int `json:"subscribers"` }
 	json.Unmarshal(resp.Data, &status)
 	if status.Subscribers != 0 {
 		t.Errorf("subscribers = %d, want 0 after disconnect", status.Subscribers)
@@ -614,6 +610,7 @@ func TestBroker_InvalidJSONReturnsError(t *testing.T) {
 	}
 }
 
+
 // Test: Worker A disconnects, Worker B's claimed task should NOT be re-queued
 func TestBroker_DisconnectOnlyRequeuesOwnTasks(t *testing.T) {
 	sockPath, _, cleanup := startTestBroker(t)
@@ -624,9 +621,7 @@ func TestBroker_DisconnectOnlyRequeuesOwnTasks(t *testing.T) {
 	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "worker-a"})
 	c1.Send(protocol.Request{Cmd: protocol.CmdTaskCreate, Payload: json.RawMessage(`{"desc":"task1"}`), Type: "test"})
 	resp1, _ := c1.Send(protocol.Request{Cmd: protocol.CmdTaskClaim})
-	var claim1 struct {
-		ID int64 `json:"ID"`
-	}
+	var claim1 struct{ ID int64 `json:"ID"` }
 	json.Unmarshal(resp1.Data, &claim1)
 
 	// Worker B connects and claims task 2
@@ -634,9 +629,7 @@ func TestBroker_DisconnectOnlyRequeuesOwnTasks(t *testing.T) {
 	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "worker-b"})
 	c2.Send(protocol.Request{Cmd: protocol.CmdTaskCreate, Payload: json.RawMessage(`{"desc":"task2"}`), Type: "test"})
 	resp2, _ := c2.Send(protocol.Request{Cmd: protocol.CmdTaskClaim})
-	var claim2 struct {
-		ID int64 `json:"ID"`
-	}
+	var claim2 struct{ ID int64 `json:"ID"` }
 	json.Unmarshal(resp2.Data, &claim2)
 
 	// Worker A disconnects
@@ -645,9 +638,7 @@ func TestBroker_DisconnectOnlyRequeuesOwnTasks(t *testing.T) {
 
 	// Verify Worker B's task is still claimed
 	resp, _ := c2.Send(protocol.Request{Cmd: protocol.CmdTaskGet, TaskID: fmt.Sprintf("%d", claim2.ID)})
-	var task struct {
-		State string `json:"State"`
-	}
+	var task struct{ State string `json:"State"` }
 	json.Unmarshal(resp.Data, &task)
 	if task.State != "claimed" {
 		t.Errorf("Worker B's task state = %q, want claimed (should NOT be re-queued when Worker A disconnects)", task.State)
@@ -812,6 +803,7 @@ func TestIsConnectionClosed_UnrelatedError(t *testing.T) {
 		t.Error("unrelated error should return false")
 	}
 }
+
 
 // ========== Direct Messaging Tests (Task 43) ==========
 
@@ -1398,31 +1390,6 @@ func TestBroker_DuplicateNameRejected(t *testing.T) {
 	json.Unmarshal(pushResp.Data, &pushData)
 	if pushData["body"] != "still alive" {
 		t.Errorf("push body = %q, want 'still alive'", pushData["body"])
-	}
-}
-
-func TestConnect_RejectsPushWithoutToken(t *testing.T) {
-	sockPath, _, cleanup := startTestBroker(t)
-	defer cleanup()
-
-	c := connectClient(t, sockPath)
-	defer c.Close()
-
-	resp, err := c.Send(protocol.Request{
-		Cmd:  protocol.CmdConnect,
-		Name: "alice-push",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp.OK {
-		t.Fatal("expected push listener connect without token to fail")
-	}
-	if resp.Code != protocol.ErrForbidden {
-		t.Fatalf("error code = %q, want %q", resp.Code, protocol.ErrForbidden)
-	}
-	if resp.Error != "invalid push listener token" {
-		t.Fatalf("error message = %q, want invalid push listener token", resp.Error)
 	}
 }
 
@@ -3089,7 +3056,7 @@ func TestBroker_CustomEventEmptyMessage(t *testing.T) {
 
 // TestBroker_PushToListenerSession verifies that messages sent to "alice" are also pushed to "alice-push" session (L5)
 func TestBroker_PushToListenerSession(t *testing.T) {
-	sockPath, b, cleanup := startTestBroker(t)
+	sockPath, _, cleanup := startTestBroker(t)
 	defer cleanup()
 
 	// Connect as "alice-push" (the persistent listener)
@@ -3103,7 +3070,6 @@ func TestBroker_PushToListenerSession(t *testing.T) {
 		Cmd:          "connect",
 		Name:         "alice-push",
 		PushListener: true,
-		PushToken:    b.PushToken(),
 	}
 	if _, err := listenerConn.Send(connectReq); err != nil {
 		t.Fatal(err)
@@ -3162,7 +3128,7 @@ func TestBroker_PushToListenerSession(t *testing.T) {
 
 // TestBroker_ListenReceivesPush verifies that waggle listen receives pushed messages (L1)
 func TestBroker_ListenReceivesPush(t *testing.T) {
-	sockPath, b, cleanup := startTestBroker(t)
+	sockPath, _, cleanup := startTestBroker(t)
 	defer cleanup()
 
 	// Connect listener using ReadMessages
@@ -3176,7 +3142,6 @@ func TestBroker_ListenReceivesPush(t *testing.T) {
 		Cmd:          "connect",
 		Name:         "bob-push",
 		PushListener: true,
-		PushToken:    b.PushToken(),
 	}
 	if _, err := listenerConn.Send(connectReq); err != nil {
 		t.Fatal(err)
@@ -3229,18 +3194,13 @@ func TestBroker_ListenReceivesPush(t *testing.T) {
 
 // TestClient_ReadMessagesFilters verifies that ReadMessages only emits message-type responses (L10)
 func TestClient_ReadMessagesFilters(t *testing.T) {
-	sockPath, b, cleanup := startTestBroker(t)
+	sockPath, _, cleanup := startTestBroker(t)
 	defer cleanup()
 
 	// Connect a listener as "filter-test-push"
 	listenerConn := connectClient(t, sockPath)
 	defer listenerConn.Close()
-	listenerConn.Send(protocol.Request{
-		Cmd:          protocol.CmdConnect,
-		Name:         "filter-test-push",
-		PushListener: true,
-		PushToken:    b.PushToken(),
-	})
+	listenerConn.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "filter-test-push", PushListener: true})
 
 	// Start ReadMessages — it now owns the scanner
 	msgCh, err := listenerConn.ReadMessages()
@@ -3283,17 +3243,12 @@ func TestClient_ReadMessagesFilters(t *testing.T) {
 }
 
 func TestPresence_StripsPushAndDeduplicates(t *testing.T) {
-	sockPath, b, cleanup := startTestBroker(t)
+	sockPath, _, cleanup := startTestBroker(t)
 	defer cleanup()
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{
-		Cmd:          protocol.CmdConnect,
-		Name:         "alice-push",
-		PushListener: true,
-		PushToken:    b.PushToken(),
-	})
+	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice-push", PushListener: true})
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -87,6 +87,20 @@ func pushTokenFromResponse(t *testing.T, resp *protocol.Response) string {
 	return payload.PushToken
 }
 
+func TestMustMarshal_PanicsOnMarshalError(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected mustMarshal to panic")
+		}
+		if !strings.Contains(fmt.Sprint(r), "mustMarshal:") {
+			t.Fatalf("panic = %v, want mustMarshal prefix", r)
+		}
+	}()
+
+	_ = mustMarshal(func() {})
+}
+
 // readStream starts reading events and fatals on error.
 func readStream(t *testing.T, c *client.Client) <-chan protocol.Event {
 	t.Helper()
@@ -3077,6 +3091,28 @@ func TestBroker_CustomEventEmptyMessage(t *testing.T) {
 }
 
 // TestBroker_PushToListenerSession verifies that messages sent to "alice" are also pushed to "alice-push" session (L5)
+func TestBroker_NonPushListenerCannotUsePushSuffix(t *testing.T) {
+	sockPath, _, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	c := connectClient(t, sockPath)
+	defer c.Close()
+
+	resp, err := c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice-push"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.OK {
+		t.Fatal("expected non-push listener connect to fail for -push suffix")
+	}
+	if resp.Code != protocol.ErrInvalidRequest {
+		t.Fatalf("response code = %q, want %q", resp.Code, protocol.ErrInvalidRequest)
+	}
+	if !strings.Contains(resp.Error, "reserved") {
+		t.Fatalf("expected reserved-suffix error, got %q", resp.Error)
+	}
+}
+
 func TestBroker_PushListenerRejectsMissingToken(t *testing.T) {
 	sockPath, b, cleanup := startTestBroker(t)
 	defer cleanup()
@@ -3107,6 +3143,30 @@ func TestBroker_PushListenerRejectsMissingToken(t *testing.T) {
 	}
 	if resp.OK {
 		t.Fatal("expected push listener connect without token to fail")
+	}
+	if resp.Code != protocol.ErrForbidden {
+		t.Fatalf("response code = %q, want %q", resp.Code, protocol.ErrForbidden)
+	}
+}
+
+func TestBroker_PushListenerRejectedWhenBaseNeverConnected(t *testing.T) {
+	sockPath, _, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	listener := connectClient(t, sockPath)
+	defer listener.Close()
+
+	resp, err := listener.Send(protocol.Request{
+		Cmd:          protocol.CmdConnect,
+		Name:         "alice-push",
+		PushListener: true,
+		PushToken:    "never-issued-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.OK {
+		t.Fatal("expected push listener connect to fail when base never connected")
 	}
 	if resp.Code != protocol.ErrForbidden {
 		t.Fatalf("response code = %q, want %q", resp.Code, protocol.ErrForbidden)
@@ -3187,6 +3247,209 @@ func TestBroker_PushListenerAcceptsValidToken(t *testing.T) {
 	}
 	if !resp.OK {
 		t.Fatalf("expected push listener connect with valid token to succeed: %s", resp.Error)
+	}
+}
+
+func TestBroker_PushListenerDisconnectedWhenBaseDisconnects(t *testing.T) {
+	sockPath, _, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	base := connectClient(t, sockPath)
+	defer base.Close()
+	baseResp, err := base.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !baseResp.OK {
+		t.Fatalf("base connect failed: %s", baseResp.Error)
+	}
+	pushToken := pushTokenFromResponse(t, baseResp)
+
+	listener := connectClient(t, sockPath)
+	defer listener.Close()
+	pushResp, err := listener.Send(protocol.Request{
+		Cmd:          protocol.CmdConnect,
+		Name:         "alice-push",
+		PushListener: true,
+		PushToken:    pushToken,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !pushResp.OK {
+		t.Fatalf("push listener connect failed: %s", pushResp.Error)
+	}
+
+	disconnectResp, err := base.Send(protocol.Request{Cmd: protocol.CmdDisconnect})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !disconnectResp.OK {
+		t.Fatalf("disconnect failed: %s", disconnectResp.Error)
+	}
+
+	if err := listener.SetDeadline(2 * time.Second); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+	_, err = listener.Receive()
+	if err == nil {
+		t.Fatal("expected push listener connection to close after base disconnect")
+	}
+	if !strings.Contains(err.Error(), "closed") && !strings.Contains(err.Error(), "EOF") {
+		t.Fatalf("expected closed-connection error, got %v", err)
+	}
+}
+
+func TestBroker_ListenerDoesNotBlockAgentCLI(t *testing.T) {
+	sockPath, b, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	pushToken, err := b.GeneratePushToken("alice")
+	if err != nil {
+		t.Fatalf("generate push token: %v", err)
+	}
+
+	pushListener := connectClient(t, sockPath)
+	defer pushListener.Close()
+	pushResp, err := pushListener.Send(protocol.Request{
+		Cmd:          protocol.CmdConnect,
+		Name:         "alice-push",
+		PushListener: true,
+		PushToken:    pushToken,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !pushResp.OK {
+		t.Fatalf("push listener connect failed: %s", pushResp.Error)
+	}
+
+	cli := connectClient(t, sockPath)
+	defer cli.Close()
+	cliResp, err := cli.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cliResp.OK {
+		t.Fatalf("cli connect failed while listener connected: %s", cliResp.Error)
+	}
+
+	disconnectResp, err := cli.Send(protocol.Request{Cmd: protocol.CmdDisconnect})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !disconnectResp.OK {
+		t.Fatalf("cli disconnect failed: %s", disconnectResp.Error)
+	}
+
+	sender := connectClient(t, sockPath)
+	defer sender.Close()
+	senderResp, err := sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "sender"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !senderResp.OK {
+		t.Fatalf("sender connect failed: %s", senderResp.Error)
+	}
+
+	sendResp, err := sender.Send(protocol.Request{
+		Cmd:     protocol.CmdSend,
+		Name:    "alice",
+		Message: "hello from sender",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sendResp.OK {
+		t.Fatalf("send failed: %s", sendResp.Error)
+	}
+
+	msg, err := pushListener.Receive()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !msg.OK {
+		t.Fatalf("push receive failed: %s", msg.Error)
+	}
+
+	inboxResp, err := pushListener.Send(protocol.Request{Cmd: protocol.CmdInbox})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !inboxResp.OK {
+		t.Fatalf("listener inbox failed: %s", inboxResp.Error)
+	}
+
+	var inbox []map[string]any
+	if err := json.Unmarshal(inboxResp.Data, &inbox); err != nil {
+		t.Fatal(err)
+	}
+	if len(inbox) != 1 {
+		t.Fatalf("inbox length = %d, want 1", len(inbox))
+	}
+	if inbox[0]["from"] != "sender" {
+		t.Fatalf("inbox sender = %v, want sender", inbox[0]["from"])
+	}
+}
+
+func TestBroker_GeneratePushTokenReusesExistingToken(t *testing.T) {
+	sockPath, b, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	c := connectClient(t, sockPath)
+	defer c.Close()
+
+	resp, err := c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("connect failed: %s", resp.Error)
+	}
+
+	want := pushTokenFromResponse(t, resp)
+	got, err := b.GeneratePushToken("alice")
+	if err != nil {
+		t.Fatalf("GeneratePushToken() error = %v", err)
+	}
+	if got != want {
+		t.Fatalf("GeneratePushToken() = %q, want %q", got, want)
+	}
+}
+
+func TestBroker_DeletePushTokenRevokesListenerToken(t *testing.T) {
+	sockPath, b, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	token, err := b.GeneratePushToken("alice")
+	if err != nil {
+		t.Fatalf("GeneratePushToken() error = %v", err)
+	}
+	if token == "" {
+		t.Fatal("expected non-empty push token")
+	}
+
+	b.DeletePushToken("alice")
+	if got := b.GetPushToken("alice"); got != "" {
+		t.Fatalf("GetPushToken() after delete = %q, want empty", got)
+	}
+
+	listener := connectClient(t, sockPath)
+	defer listener.Close()
+	resp, err := listener.Send(protocol.Request{
+		Cmd:          protocol.CmdConnect,
+		Name:         "alice-push",
+		PushListener: true,
+		PushToken:    token,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.OK {
+		t.Fatal("expected revoked push token to be rejected")
+	}
+	if resp.Code != protocol.ErrForbidden {
+		t.Fatalf("response code = %q, want %q", resp.Code, protocol.ErrForbidden)
 	}
 }
 
@@ -3281,6 +3544,71 @@ func TestBroker_PushToListenerSession(t *testing.T) {
 	}
 	if data["body"] != "test push to listener" {
 		t.Errorf("expected body='test push to listener', got %v", data["body"])
+	}
+}
+
+func TestBroker_SelfSendDoesNotPushToListener(t *testing.T) {
+	sockPath, _, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	baseConn, err := client.Connect(sockPath, 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer baseConn.Close()
+
+	baseResp, err := baseConn.Send(protocol.Request{
+		Cmd:  protocol.CmdConnect,
+		Name: "alice",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !baseResp.OK {
+		t.Fatalf("base connect failed: %s", baseResp.Error)
+	}
+	pushToken := pushTokenFromResponse(t, baseResp)
+
+	listenerConn, err := client.Connect(sockPath, 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listenerConn.Close()
+
+	pushResp, err := listenerConn.Send(protocol.Request{
+		Cmd:          protocol.CmdConnect,
+		Name:         "alice-push",
+		PushListener: true,
+		PushToken:    pushToken,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !pushResp.OK {
+		t.Fatalf("push listener connect failed: %s", pushResp.Error)
+	}
+
+	sendResp, err := baseConn.Send(protocol.Request{
+		Cmd:     protocol.CmdSend,
+		Name:    "alice",
+		Message: "self send should not push",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sendResp.OK {
+		t.Fatalf("self send failed: %s", sendResp.Error)
+	}
+
+	if err := listenerConn.SetDeadline(200 * time.Millisecond); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+	_, err = listenerConn.Receive()
+	if err == nil {
+		t.Fatal("expected self-send to avoid push delivery to alice-push")
+	}
+	if !strings.Contains(err.Error(), "i/o timeout") {
+		t.Fatalf("expected read timeout when no push is delivered, got %v", err)
 	}
 }
 

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -3239,3 +3239,38 @@ func TestClient_ReadMessagesFilters(t *testing.T) {
 		t.Fatal("timeout waiting for pushed message")
 	}
 }
+
+func TestPresence_StripsPushAndDeduplicates(t *testing.T) {
+	sockPath, _, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	c1 := connectClient(t, sockPath)
+	defer c1.Close()
+	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice-push"})
+
+	c2 := connectClient(t, sockPath)
+	defer c2.Close()
+	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+
+	c3 := connectClient(t, sockPath)
+	defer c3.Close()
+	c3.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "probe"})
+
+	resp, _ := c3.Send(protocol.Request{Cmd: protocol.CmdPresence})
+	var agents []map[string]string
+	json.Unmarshal(resp.Data, &agents)
+
+	names := make(map[string]bool)
+	for _, a := range agents {
+		if strings.HasSuffix(a["name"], "-push") {
+			t.Fatalf("name %q should not have -push suffix", a["name"])
+		}
+		names[a["name"]] = true
+	}
+	if !names["alice"] {
+		t.Fatal("expected alice (stripped from alice-push)")
+	}
+	if !names["bob"] {
+		t.Fatal("expected bob")
+	}
+}

--- a/internal/broker/router.go
+++ b/internal/broker/router.go
@@ -1,6 +1,7 @@
 package broker
 
 import (
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -85,6 +86,10 @@ func route(s *Session, req protocol.Request) protocol.Response {
 	}
 }
 
+type connectResponseData struct {
+	PushToken string `json:"push_token,omitempty"`
+}
+
 func handleConnect(s *Session, req protocol.Request) protocol.Response {
 	if req.Name == "" {
 		return protocol.ErrResponse(protocol.ErrInvalidRequest, "name required")
@@ -100,10 +105,27 @@ func handleConnect(s *Session, req protocol.Request) protocol.Response {
 		return protocol.ErrResponse(protocol.ErrAlreadyConnected, "already connected")
 	}
 
+	var pushToken string
 	s.broker.mu.Lock()
 	if existing, ok := s.broker.sessions[req.Name]; ok && existing != s {
 		s.broker.mu.Unlock()
 		return protocol.ErrResponse(protocol.ErrAlreadyConnected, "session name already in use")
+	}
+	if strings.HasSuffix(req.Name, "-push") {
+		baseName := strings.TrimSuffix(req.Name, "-push")
+		expectedToken := s.broker.pushTokens[baseName]
+		if req.PushToken == "" || subtle.ConstantTimeCompare([]byte(req.PushToken), []byte(expectedToken)) != 1 {
+			s.broker.mu.Unlock()
+			return protocol.ErrResponse(protocol.ErrForbidden, "invalid push listener token")
+		}
+	} else {
+		var err error
+		pushToken, err = newPushToken()
+		if err != nil {
+			s.broker.mu.Unlock()
+			return protocol.ErrResponse(protocol.ErrInternalError, err.Error())
+		}
+		s.broker.pushTokens[req.Name] = pushToken
 	}
 	s.name = req.Name
 	s.broker.sessions[s.name] = s
@@ -112,6 +134,13 @@ func handleConnect(s *Session, req protocol.Request) protocol.Response {
 	// Publish presence.online event
 	publishPresenceEvent(s.broker, "presence.online", s.name)
 
+	if pushToken != "" {
+		data, err := json.Marshal(connectResponseData{PushToken: pushToken})
+		if err != nil {
+			return protocol.ErrResponse(protocol.ErrInternalError, err.Error())
+		}
+		return protocol.OKResponse(data)
+	}
 	return protocol.OKResponse(nil)
 }
 
@@ -795,4 +824,3 @@ func handleSpawnUpdatePID(s *Session, req protocol.Request) protocol.Response {
 
 	return protocol.OKResponse(nil)
 }
-

--- a/internal/broker/router.go
+++ b/internal/broker/router.go
@@ -695,10 +695,25 @@ func handleAck(s *Session, req protocol.Request) protocol.Response {
 
 func handlePresence(s *Session) protocol.Response {
 	s.broker.mu.RLock()
+	// Collect all raw session names first
+	allNames := make(map[string]bool, len(s.broker.sessions))
+	for name := range s.broker.sessions {
+		allNames[name] = true
+	}
+	// Build presence list, hiding -push listeners only when the base agent exists
 	seen := make(map[string]bool)
 	agents := make([]map[string]string, 0, len(s.broker.sessions))
 	for name := range s.broker.sessions {
-		displayName := strings.TrimSuffix(name, "-push")
+		displayName := name
+		if base := strings.TrimSuffix(name, "-push"); base != name {
+			// This is a -push listener. Hide it if the base agent session exists.
+			if allNames[base] {
+				continue
+			}
+			// Base agent not connected — show the -push listener under the base name
+			// so the agent is still discoverable.
+			displayName = base
+		}
 		if seen[displayName] {
 			continue
 		}

--- a/internal/broker/router.go
+++ b/internal/broker/router.go
@@ -92,6 +92,10 @@ func handleConnect(s *Session, req protocol.Request) protocol.Response {
 	if len(req.Name) > config.Defaults.MaxFieldLength {
 		return protocol.ErrResponse(protocol.ErrInvalidRequest, fmt.Sprintf("name too long (max %d chars)", config.Defaults.MaxFieldLength))
 	}
+	// Reserve -push suffix for push listeners — prevents routing collisions
+	if strings.HasSuffix(req.Name, "-push") && !req.PushListener {
+		return protocol.ErrResponse(protocol.ErrInvalidRequest, `names ending in "-push" are reserved; set push_listener: true to connect as a push listener`)
+	}
 	if s.name != "" {
 		return protocol.ErrResponse(protocol.ErrAlreadyConnected, "already connected")
 	}
@@ -573,9 +577,14 @@ func handleSend(s *Session, req protocol.Request) protocol.Response {
 		s.broker.ackWaitersMu.Unlock()
 	}
 
-	// Push to recipient if connected
+	// Push to recipient if connected — fall back to name-push listener
 	s.broker.mu.RLock()
 	recipient, online := s.broker.sessions[req.Name]
+	usedPushFallback := false
+	if !online {
+		recipient, online = s.broker.sessions[req.Name+"-push"]
+		usedPushFallback = online
+	}
 	s.broker.mu.RUnlock()
 
 	// CLASS 2 FIX (B3): Skip push delivery when sending to self to prevent protocol corruption
@@ -604,13 +613,14 @@ func handleSend(s *Session, req protocol.Request) protocol.Response {
 		}
 	}
 
-	// Also push to persistent listener (<name>-push) if connected
+	// Also push to persistent listener (<name>-push) if connected.
+	// Skip if fallback already sent to -push above (prevents double-push).
 	pushName := req.Name + "-push"
 	s.broker.mu.RLock()
 	pushRecipient, pushOnline := s.broker.sessions[pushName]
 	s.broker.mu.RUnlock()
 
-	if pushOnline && pushRecipient != s {
+	if pushOnline && pushRecipient != s && !usedPushFallback {
 		pushResp := protocol.Response{
 			OK: true,
 			Data: mustMarshal(map[string]any{
@@ -657,7 +667,9 @@ func handleSend(s *Session, req protocol.Request) protocol.Response {
 }
 
 func handleInbox(s *Session, req protocol.Request) protocol.Response {
-	messages, err := s.broker.msgStore.Inbox(s.name)
+	// Strip -push suffix so push listeners see the base agent's inbox
+	caller := strings.TrimSuffix(s.name, "-push")
+	messages, err := s.broker.msgStore.Inbox(caller)
 	if err != nil {
 		return protocol.ErrResponse(protocol.ErrInternalError, err.Error())
 	}
@@ -669,7 +681,9 @@ func handleAck(s *Session, req protocol.Request) protocol.Response {
 		return protocol.ErrResponse(protocol.ErrInvalidRequest, "message_id required")
 	}
 
-	err := s.broker.msgStore.Ack(req.MessageID, s.name)
+	// Strip -push suffix so push listeners can ack their base agent's messages
+	caller := strings.TrimSuffix(s.name, "-push")
+	err := s.broker.msgStore.Ack(req.MessageID, caller)
 	if err != nil {
 		if errors.Is(err, messages.ErrMessageNotFound) {
 			return protocol.ErrResponse(protocol.ErrMessageNotFound, err.Error())

--- a/internal/broker/router.go
+++ b/internal/broker/router.go
@@ -92,9 +92,9 @@ func handleConnect(s *Session, req protocol.Request) protocol.Response {
 	if len(req.Name) > config.Defaults.MaxFieldLength {
 		return protocol.ErrResponse(protocol.ErrInvalidRequest, fmt.Sprintf("name too long (max %d chars)", config.Defaults.MaxFieldLength))
 	}
-	// Reserve -push suffix for push listeners — prevents routing collisions
-	if strings.HasSuffix(req.Name, "-push") && !req.PushListener {
-		return protocol.ErrResponse(protocol.ErrInvalidRequest, `names ending in "-push" are reserved; set push_listener: true to connect as a push listener`)
+	// Reserve -push suffix for authenticated push listeners to prevent routing collisions.
+	if strings.HasSuffix(req.Name, "-push") && req.PushToken != s.broker.pushToken {
+		return protocol.ErrResponse(protocol.ErrForbidden, "invalid push listener token")
 	}
 	if s.name != "" {
 		return protocol.ErrResponse(protocol.ErrAlreadyConnected, "already connected")
@@ -795,4 +795,3 @@ func handleSpawnUpdatePID(s *Session, req protocol.Request) protocol.Response {
 
 	return protocol.OKResponse(nil)
 }
-

--- a/internal/broker/router.go
+++ b/internal/broker/router.go
@@ -695,13 +695,18 @@ func handleAck(s *Session, req protocol.Request) protocol.Response {
 
 func handlePresence(s *Session) protocol.Response {
 	s.broker.mu.RLock()
+	seen := make(map[string]bool)
 	agents := make([]map[string]string, 0, len(s.broker.sessions))
 	for name := range s.broker.sessions {
-		agents = append(agents, map[string]string{"name": name, "state": "online"})
+		displayName := strings.TrimSuffix(name, "-push")
+		if seen[displayName] {
+			continue
+		}
+		seen[displayName] = true
+		agents = append(agents, map[string]string{"name": displayName, "state": "online"})
 	}
 	s.broker.mu.RUnlock()
 
-	// Sort by name for deterministic output
 	sort.Slice(agents, func(i, j int) bool { return agents[i]["name"] < agents[j]["name"] })
 
 	return protocol.OKResponse(mustMarshal(agents))

--- a/internal/broker/router.go
+++ b/internal/broker/router.go
@@ -113,19 +113,24 @@ func handleConnect(s *Session, req protocol.Request) protocol.Response {
 	}
 	if strings.HasSuffix(req.Name, "-push") {
 		baseName := strings.TrimSuffix(req.Name, "-push")
-		expectedToken := s.broker.pushTokens[baseName]
-		if req.PushToken == "" || subtle.ConstantTimeCompare([]byte(req.PushToken), []byte(expectedToken)) != 1 {
+		expectedToken, exists := s.broker.pushTokens[baseName]
+		if !exists || req.PushToken == "" || subtle.ConstantTimeCompare([]byte(req.PushToken), []byte(expectedToken)) != 1 {
 			s.broker.mu.Unlock()
 			return protocol.ErrResponse(protocol.ErrForbidden, "invalid push listener token")
 		}
 	} else {
-		var err error
-		pushToken, err = newPushToken()
-		if err != nil {
-			s.broker.mu.Unlock()
-			return protocol.ErrResponse(protocol.ErrInternalError, err.Error())
+		if existingToken, exists := s.broker.pushTokens[req.Name]; exists {
+			pushToken = existingToken
+		} else {
+			var err error
+			pushToken, err = newPushToken()
+			if err != nil {
+				s.broker.mu.Unlock()
+				return protocol.ErrResponse(protocol.ErrInternalError, err.Error())
+			}
+			s.broker.pushTokens[req.Name] = pushToken
+			s.ownsPushToken = true
 		}
-		s.broker.pushTokens[req.Name] = pushToken
 	}
 	s.name = req.Name
 	s.broker.sessions[s.name] = s
@@ -557,7 +562,10 @@ func publishTaskEvent(b *Broker, event string, task *tasks.Task) {
 }
 
 func mustMarshal(v interface{}) json.RawMessage {
-	data, _ := json.Marshal(v)
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(fmt.Sprintf("mustMarshal: %v", err))
+	}
 	return data
 }
 
@@ -633,11 +641,11 @@ func handleSend(s *Session, req protocol.Request) protocol.Response {
 		if err := recipient.enc.Encode(pushMsg); err != nil {
 			recipient.writeMu.Unlock()
 			// Don't mark as pushed if delivery failed
-			log.Printf("session %s: failed to push message %d to %s: %v", s.name, msg.ID, req.Name, err)
+			log.Printf("session %q: failed to push message %d to %q: %v", s.name, msg.ID, req.Name, err)
 		} else {
 			recipient.writeMu.Unlock()
 			if err := s.broker.msgStore.MarkPushed(msg.ID); err != nil {
-				log.Printf("session %s: failed to mark message %d as pushed: %v", s.name, msg.ID, err)
+				log.Printf("session %q: failed to mark message %d as pushed: %v", s.name, msg.ID, err)
 			}
 		}
 	}
@@ -645,11 +653,12 @@ func handleSend(s *Session, req protocol.Request) protocol.Response {
 	// Also push to persistent listener (<name>-push) if connected.
 	// Skip if fallback already sent to -push above (prevents double-push).
 	pushName := req.Name + "-push"
+	senderName := strings.TrimSuffix(s.name, "-push")
 	s.broker.mu.RLock()
 	pushRecipient, pushOnline := s.broker.sessions[pushName]
 	s.broker.mu.RUnlock()
 
-	if pushOnline && pushRecipient != s && !usedPushFallback {
+	if pushOnline && pushRecipient != s && !usedPushFallback && req.Name != senderName {
 		pushResp := protocol.Response{
 			OK: true,
 			Data: mustMarshal(map[string]any{
@@ -663,7 +672,7 @@ func handleSend(s *Session, req protocol.Request) protocol.Response {
 		pushRecipient.writeMu.Lock()
 		if err := pushRecipient.enc.Encode(pushResp); err != nil {
 			pushRecipient.writeMu.Unlock()
-			log.Printf("session %s: failed to push message %d to %s: %v", s.name, msg.ID, pushName, err)
+			log.Printf("session %q: failed to push message %d to %q: %v", s.name, msg.ID, pushName, err)
 		} else {
 			pushRecipient.writeMu.Unlock()
 		}
@@ -696,7 +705,6 @@ func handleSend(s *Session, req protocol.Request) protocol.Response {
 }
 
 func handleInbox(s *Session, req protocol.Request) protocol.Response {
-	// Strip -push suffix so push listeners see the base agent's inbox
 	caller := strings.TrimSuffix(s.name, "-push")
 	messages, err := s.broker.msgStore.Inbox(caller)
 	if err != nil {
@@ -710,7 +718,6 @@ func handleAck(s *Session, req protocol.Request) protocol.Response {
 		return protocol.ErrResponse(protocol.ErrInvalidRequest, "message_id required")
 	}
 
-	// Strip -push suffix so push listeners can ack their base agent's messages
 	caller := strings.TrimSuffix(s.name, "-push")
 	err := s.broker.msgStore.Ack(req.MessageID, caller)
 	if err != nil {

--- a/internal/broker/router.go
+++ b/internal/broker/router.go
@@ -92,9 +92,9 @@ func handleConnect(s *Session, req protocol.Request) protocol.Response {
 	if len(req.Name) > config.Defaults.MaxFieldLength {
 		return protocol.ErrResponse(protocol.ErrInvalidRequest, fmt.Sprintf("name too long (max %d chars)", config.Defaults.MaxFieldLength))
 	}
-	// Reserve -push suffix for authenticated push listeners to prevent routing collisions.
-	if strings.HasSuffix(req.Name, "-push") && req.PushToken != s.broker.pushToken {
-		return protocol.ErrResponse(protocol.ErrForbidden, "invalid push listener token")
+	// Reserve -push suffix for push listeners — prevents routing collisions
+	if strings.HasSuffix(req.Name, "-push") && !req.PushListener {
+		return protocol.ErrResponse(protocol.ErrInvalidRequest, `names ending in "-push" are reserved; set push_listener: true to connect as a push listener`)
 	}
 	if s.name != "" {
 		return protocol.ErrResponse(protocol.ErrAlreadyConnected, "already connected")
@@ -795,3 +795,4 @@ func handleSpawnUpdatePID(s *Session, req protocol.Request) protocol.Response {
 
 	return protocol.OKResponse(nil)
 }
+

--- a/internal/broker/session.go
+++ b/internal/broker/session.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log"
 	"net"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -124,6 +125,9 @@ func (s *Session) doCleanup() {
 		s.broker.mu.Lock()
 		if s.broker.sessions[s.name] == s {
 			delete(s.broker.sessions, s.name)
+			if !strings.HasSuffix(s.name, "-push") {
+				delete(s.broker.pushTokens, s.name)
+			}
 			shouldPublish = true
 		}
 		s.broker.mu.Unlock()
@@ -139,5 +143,3 @@ func (s *Session) doCleanup() {
 
 	s.conn.Close()
 }
-
-

--- a/internal/broker/session.go
+++ b/internal/broker/session.go
@@ -21,6 +21,7 @@ type Session struct {
 	enc             *json.Encoder
 	scan            *bufio.Scanner
 	broker          *Broker
+	ownsPushToken   bool
 	cleanDisconnect bool // Set to true when disconnect command is received
 	cleanupOnce     sync.Once
 	writeMu         sync.Mutex // protects enc writes
@@ -99,6 +100,7 @@ func (s *Session) cleanup() {
 }
 
 func (s *Session) doCleanup() {
+	var pushListener *Session
 	if s.name != "" {
 		// Release all locks
 		s.broker.lockMgr.ReleaseAll(s.name)
@@ -125,12 +127,20 @@ func (s *Session) doCleanup() {
 		s.broker.mu.Lock()
 		if s.broker.sessions[s.name] == s {
 			delete(s.broker.sessions, s.name)
-			if !strings.HasSuffix(s.name, "-push") {
-				delete(s.broker.pushTokens, s.name)
-			}
 			shouldPublish = true
+			if !strings.HasSuffix(s.name, "-push") && s.ownsPushToken {
+				delete(s.broker.pushTokens, s.name)
+				pushListener = s.broker.sessions[s.name+"-push"]
+			}
 		}
 		s.broker.mu.Unlock()
+
+		// Base agent disconnects should tear down the paired push listener, too.
+		// Close it outside broker.mu so its cleanup can safely mutate broker state.
+		if pushListener != nil {
+			pushListener.cleanDisconnect = true
+			pushListener.cleanup()
+		}
 
 		// Publish presence event OUTSIDE the lock to avoid deadlock
 		// If any event subscriber tries to read broker.sessions, publishing inside

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -214,7 +214,9 @@ func NewPaths(projectID string) Paths {
 	}
 
 	f := fnv.New64a()
-	_, _ = f.Write([]byte(projectID))
+	if _, err := f.Write([]byte(projectID)); err != nil {
+		panic(fmt.Sprintf("hash project ID: %v", err))
+	}
 	hash := fmt.Sprintf("%012x", f.Sum64()&0xffffffffffff)
 
 	dataDir := filepath.Join(home, Defaults.DirName, "data", hash)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,6 +66,8 @@ var Defaults = struct {
 	RuntimePIDFile          string
 	RuntimeLogFile          string
 	RuntimeStateFile        string
+	SignalDirName           string
+	SignalMaxBytes          int64
 
 	ShutdownTimeout                       time.Duration
 	RuntimeNotificationTimeout            time.Duration
@@ -131,6 +133,8 @@ var Defaults = struct {
 	RuntimePIDFile:          "runtime.pid",
 	RuntimeLogFile:          "runtime.log",
 	RuntimeStateFile:        "state.json",
+	SignalDirName:           "signals",
+	SignalMaxBytes:          65536,
 
 	ShutdownTimeout:                       5 * time.Second,
 	RuntimeNotificationTimeout:            2 * time.Second,
@@ -190,6 +194,7 @@ type Paths struct {
 	RuntimeLog          string
 	RuntimeState        string
 	RuntimeStartLockDir string
+	RuntimeSignalDir    string
 	DB                  string
 	PID                 string
 	Lock                string
@@ -225,6 +230,7 @@ func NewPaths(projectID string) Paths {
 		RuntimeLog:          filepath.Join(runtimeDir, Defaults.RuntimeLogFile),
 		RuntimeState:        filepath.Join(runtimeDir, Defaults.RuntimeStateFile),
 		RuntimeStartLockDir: filepath.Join(runtimeDir, Defaults.RuntimeStartLockDirName),
+		RuntimeSignalDir:    filepath.Join(runtimeDir, Defaults.SignalDirName),
 		DB:                  filepath.Join(dataDir, Defaults.DBFile),
 		PID:                 filepath.Join(dataDir, Defaults.PIDFile),
 		Lock:                filepath.Join(dataDir, Defaults.LockFile),

--- a/internal/fsutil/safe_path.go
+++ b/internal/fsutil/safe_path.go
@@ -1,0 +1,35 @@
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// HasAncestorSymlink checks whether any directory component between root and path
+// is a symlink. Only checks components below root to avoid false positives on
+// system-level symlinks (for example, /var -> /private/var on macOS).
+func HasAncestorSymlink(path, root string) bool {
+	root = filepath.Clean(root)
+	path = filepath.Clean(path)
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	if strings.HasPrefix(rel, "..") {
+		return true
+	}
+
+	current := root
+	for _, part := range strings.Split(filepath.Dir(rel), string(filepath.Separator)) {
+		if part == "." {
+			continue
+		}
+		current = filepath.Join(current, part)
+		if info, err := os.Lstat(current); err == nil && info.Mode()&os.ModeSymlink != 0 {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/install/adversarial_test.go
+++ b/internal/install/adversarial_test.go
@@ -239,7 +239,8 @@ func TestAdversarial_OwnedFile_ConcurrentInstall(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// SymlinkProtection — symlink waggle.md must not overwrite target
+// SymlinkProtection — symlink waggle.md must not overwrite target, and the
+// installer should replace the symlink with a canonical owned file.
 // ---------------------------------------------------------------------------
 func TestAdversarial_OwnedFile_SymlinkProtection(t *testing.T) {
 	tmpHome := t.TempDir()
@@ -259,9 +260,8 @@ func TestAdversarial_OwnedFile_SymlinkProtection(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Atomic write replaces the symlink directory entry without following it
 	if err := installAuggie(tmpHome); err != nil {
-		t.Fatalf("install should succeed (atomic write replaces symlink): %v", err)
+		t.Fatalf("install should replace leaf symlink: %v", err)
 	}
 
 	// Target must be untouched
@@ -270,13 +270,21 @@ func TestAdversarial_OwnedFile_SymlinkProtection(t *testing.T) {
 		t.Fatalf("symlink attack succeeded — target modified to: %q", string(data))
 	}
 
-	// waggle.md must now be a regular file
+	// waggle.md must now be a regular file with canonical content.
 	info, err := os.Lstat(rulesPath)
 	if err != nil {
 		t.Fatalf("lstat waggle.md: %v", err)
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
-		t.Fatal("waggle.md is still a symlink after install")
+		t.Fatal("waggle.md should no longer be a symlink after replacement")
+	}
+
+	got, err := os.ReadFile(rulesPath)
+	if err != nil {
+		t.Fatalf("read waggle.md: %v", err)
+	}
+	if string(got) != canonicalAuggieFileForTest(t) {
+		t.Fatal("waggle.md should be restored to canonical content")
 	}
 }
 

--- a/internal/install/auggie.go
+++ b/internal/install/auggie.go
@@ -156,7 +156,15 @@ func installAuggie(homeDir string) error {
 	}
 
 	// Atomic write: detaches hard links, replaces leaf symlinks
-	return safeWriteFile(rulesPath, []byte(content), 0644)
+	if err := safeWriteFile(rulesPath, []byte(content), 0644); err != nil {
+		return err
+	}
+
+	if err := installShellHook(homeDir); err != nil {
+		return fmt.Errorf("installing shell hook: %w", err)
+	}
+
+	return nil
 }
 
 func uninstallAuggie(homeDir string) error {

--- a/internal/install/auggie.go
+++ b/internal/install/auggie.go
@@ -8,96 +8,6 @@ import (
 	"strings"
 )
 
-// safeWriteFile writes content to path atomically by writing to a temp file
-// in the same directory and renaming. This prevents symlink-following writes
-// and hard-link inode mutation.
-func safeWriteFile(path string, content []byte, perm os.FileMode) error {
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, ".waggle-*.tmp")
-	if err != nil {
-		return fmt.Errorf("creating temp file: %w", err)
-	}
-	tmpPath := tmp.Name()
-
-	// Clean up temp file on any failure
-	defer func() {
-		if tmpPath != "" {
-			os.Remove(tmpPath)
-		}
-	}()
-
-	if _, err := tmp.Write(content); err != nil {
-		tmp.Close()
-		return fmt.Errorf("writing temp file: %w", err)
-	}
-	if err := tmp.Chmod(perm); err != nil {
-		tmp.Close()
-		return fmt.Errorf("setting permissions: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("closing temp file: %w", err)
-	}
-
-	if err := os.Rename(tmpPath, path); err != nil {
-		return fmt.Errorf("renaming temp file: %w", err)
-	}
-	tmpPath = "" // prevent deferred cleanup
-	return nil
-}
-
-// validateAncestorPath checks that the directory path resolves to the expected
-// location under homeDir. This prevents ancestor-symlink attacks where
-// ~/.augment/ or ~/.augment/rules/ is a symlink to an attacker-controlled
-// directory.
-func validateAncestorPath(dir, homeDir string) error {
-	resolvedHome, err := filepath.EvalSymlinks(homeDir)
-	if err != nil {
-		return fmt.Errorf("resolving home dir: %w", err)
-	}
-
-	// Build expected resolved path using the resolved homeDir
-	expectedResolved := filepath.Join(resolvedHome, ".augment", "rules")
-
-	// Find the longest existing prefix of dir to resolve
-	resolved, err := resolveExistingPrefix(dir)
-	if err != nil {
-		return fmt.Errorf("resolving path %s: %w", dir, err)
-	}
-
-	// The resolved existing prefix must be a prefix of expectedResolved
-	// (or equal to it). This ensures no symlink diverts the path.
-	if resolved != expectedResolved && !strings.HasPrefix(expectedResolved, resolved+string(filepath.Separator)) {
-		return fmt.Errorf("directory %s resolves to %s (expected under %s); possible symlink in ancestor path", dir, resolved, expectedResolved)
-	}
-	return nil
-}
-
-// resolveExistingPrefix walks up the directory tree from path until it finds
-// an existing directory, resolves symlinks on that prefix, then appends the
-// remaining unresolved components. This lets us validate paths where some
-// trailing components don't exist yet.
-func resolveExistingPrefix(path string) (string, error) {
-	resolved, err := filepath.EvalSymlinks(path)
-	if err == nil {
-		return resolved, nil
-	}
-	if !os.IsNotExist(err) {
-		return "", err
-	}
-
-	parent := filepath.Dir(path)
-	if parent == path {
-		return path, nil // reached root
-	}
-
-	resolvedParent, err := resolveExistingPrefix(parent)
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Join(resolvedParent, filepath.Base(path)), nil
-}
-
 //go:embed all:auggie
 var auggieFiles embed.FS
 
@@ -140,15 +50,19 @@ func rejectNonRegularFile(path string) error {
 func installAuggie(homeDir string) error {
 	rulesDir := filepath.Join(homeDir, ".augment", "rules")
 
-	// Validate ancestor path before creating directories
-	if err := validateAncestorPath(rulesDir, homeDir); err != nil {
-		return err
-	}
-
-	if err := os.MkdirAll(rulesDir, 0755); err != nil {
+	if err := safeMkdirAll(rulesDir, homeDir, 0o755); err != nil {
 		return fmt.Errorf("creating Auggie rules dir: %w", err)
 	}
 	rulesPath := filepath.Join(rulesDir, "waggle.md")
+	if info, err := os.Lstat(rulesPath); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			if err := os.Remove(rulesPath); err != nil {
+				return fmt.Errorf("removing existing symlink %s: %w", rulesPath, err)
+			}
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("lstat %s: %w", rulesPath, err)
+	}
 
 	content, err := canonicalAuggieFile()
 	if err != nil {
@@ -156,7 +70,7 @@ func installAuggie(homeDir string) error {
 	}
 
 	// Atomic write: detaches hard links, replaces leaf symlinks
-	if err := safeWriteFile(rulesPath, []byte(content), 0644); err != nil {
+	if err := safeWriteFile(rulesPath, []byte(content), 0o644, homeDir); err != nil {
 		return err
 	}
 
@@ -169,18 +83,12 @@ func installAuggie(homeDir string) error {
 
 func uninstallAuggie(homeDir string) error {
 	rulesPath := filepath.Join(homeDir, ".augment", "rules", "waggle.md")
-	rulesDir := filepath.Dir(rulesPath)
-
-	// Validate ancestor path
-	if err := validateAncestorPath(rulesDir, homeDir); err != nil {
-		return err
-	}
 
 	if err := rejectNonRegularFile(rulesPath); err != nil {
 		return err
 	}
 
-	err := os.Remove(rulesPath)
+	err := safeRemove(rulesPath, homeDir)
 	if os.IsNotExist(err) {
 		return nil
 	}

--- a/internal/install/auggie/RULE-block.md
+++ b/internal/install/auggie/RULE-block.md
@@ -2,6 +2,6 @@
 
 At the start of every session, run:
 
-  waggle adapter bootstrap auggie --format markdown
+  WAGGLE_AGENT_PPID=$PPID waggle adapter bootstrap auggie --format markdown
 
 If waggle is not installed or the command fails, continue normally. Use the agent name from the output for any subsequent waggle commands in this session.

--- a/internal/install/auggie_test.go
+++ b/internal/install/auggie_test.go
@@ -293,10 +293,8 @@ func TestInstallAuggie_ReplacesLeafSymlink(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Atomic write replaces the symlink directory entry, doesn't follow it
-	err := installAuggie(tmpHome)
-	if err != nil {
-		t.Fatalf("install should succeed (atomic write replaces symlink): %v", err)
+	if err := installAuggie(tmpHome); err != nil {
+		t.Fatalf("install should replace leaf symlink: %v", err)
 	}
 
 	// Target must be unchanged
@@ -305,18 +303,21 @@ func TestInstallAuggie_ReplacesLeafSymlink(t *testing.T) {
 		t.Fatalf("target file was modified through symlink: %q", string(data))
 	}
 
-	// waggle.md should now be a regular file with canonical content
+	// waggle.md should now be a regular managed file with canonical content.
 	info, err := os.Lstat(rulesPath)
 	if err != nil {
 		t.Fatalf("lstat waggle.md: %v", err)
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
-		t.Fatal("waggle.md is still a symlink after install")
+		t.Fatal("waggle.md should no longer be a symlink after install")
 	}
-	waggleData, _ := os.ReadFile(rulesPath)
-	canonical := canonicalAuggieFileForTest(t)
-	if string(waggleData) != canonical {
-		t.Fatalf("waggle.md content wrong after replacing symlink")
+
+	got, err := os.ReadFile(rulesPath)
+	if err != nil {
+		t.Fatalf("read waggle.md: %v", err)
+	}
+	if string(got) != canonicalAuggieFileForTest(t) {
+		t.Fatal("waggle.md should be restored to canonical content")
 	}
 }
 

--- a/internal/install/augment.go
+++ b/internal/install/augment.go
@@ -37,7 +37,7 @@ func UninstallAugment() error {
 func installAugment(homeDir string) error {
 	augmentDir := filepath.Join(homeDir, ".augment")
 	skillDir := filepath.Join(augmentDir, "skills")
-	if err := os.MkdirAll(skillDir, 0755); err != nil {
+	if err := safeMkdirAll(skillDir, homeDir, 0o755); err != nil {
 		return fmt.Errorf("creating Augment skill dir: %w", err)
 	}
 
@@ -45,7 +45,7 @@ func installAugment(homeDir string) error {
 	if err != nil {
 		return fmt.Errorf("reading embedded Augment block: %w", err)
 	}
-	if err := upsertManagedBlock(filepath.Join(skillDir, "waggle.md"), augmentBlockBegin, augmentBlockEnd, string(blockData)); err != nil {
+	if err := upsertManagedBlock(filepath.Join(skillDir, "waggle.md"), augmentBlockBegin, augmentBlockEnd, string(blockData), homeDir); err != nil {
 		return fmt.Errorf("updating Augment waggle.md: %w", err)
 	}
 
@@ -60,7 +60,7 @@ func uninstallAugment(homeDir string) error {
 	augmentDir := filepath.Join(homeDir, ".augment")
 	skillPath := filepath.Join(augmentDir, "skills", "waggle.md")
 
-	if err := removeManagedBlock(skillPath, augmentBlockBegin, augmentBlockEnd); err != nil {
+	if err := removeManagedBlock(skillPath, augmentBlockBegin, augmentBlockEnd, homeDir); err != nil {
 		return fmt.Errorf("removing managed block from Augment waggle.md: %w", err)
 	}
 

--- a/internal/install/augment.go
+++ b/internal/install/augment.go
@@ -49,6 +49,10 @@ func installAugment(homeDir string) error {
 		return fmt.Errorf("updating Augment waggle.md: %w", err)
 	}
 
+	if err := installShellHook(homeDir); err != nil {
+		return fmt.Errorf("installing shell hook: %w", err)
+	}
+
 	return nil
 }
 

--- a/internal/install/augment/SKILL-block.md
+++ b/internal/install/augment/SKILL-block.md
@@ -2,7 +2,7 @@
 
 At the start of every session, run:
 
-    waggle adapter bootstrap augment --format markdown
+    WAGGLE_AGENT_PPID=$PPID waggle adapter bootstrap augment --format markdown
 
 What to do with the result:
 

--- a/internal/install/claude-code/hook.sh
+++ b/internal/install/claude-code/hook.sh
@@ -29,7 +29,7 @@ fi
 
 # Bootstrap this Claude session into the waggle mesh.
 # The adapter bootstrap command is the single authoritative path for tool registration.
-OUTPUT=$($TIMEOUT_CMD 3 waggle adapter bootstrap claude-code --format markdown 2>/dev/null) || OUTPUT=""
+OUTPUT=$($TIMEOUT_CMD 3 env WAGGLE_AGENT_PPID=$PPID waggle adapter bootstrap claude-code --format markdown 2>/dev/null) || OUTPUT=""
 if [ -n "$OUTPUT" ]; then
     echo ""
     echo "$OUTPUT"

--- a/internal/install/claude-code/waggle-push.js
+++ b/internal/install/claude-code/waggle-push.js
@@ -29,21 +29,37 @@ try {
 
     const now = new Date();
     try { fs.utimesSync(sessionFile, now, now); } catch {}
+    try { fs.utimesSync(pointerFile, now, now); } catch {}
 
-    const sigFile = path.join(rtDir, 'signals', project, agent);
-    if (!fs.existsSync(sigFile)) process.exit(0);
+    const signalDir = path.join(rtDir, 'signals', project);
+    const sigFile = path.join(signalDir, agent);
+    const chunks = [];
 
-    // Atomic: rename then read (daemon writes to original path are safe)
-    const tmpFile = sigFile + '.c-' + process.pid;
-    try { fs.renameSync(sigFile, tmpFile); } catch { process.exit(0); }
+    try {
+        for (const entry of fs.readdirSync(signalDir)) {
+            if (!entry.startsWith(agent + '.c-')) continue;
+            const orphanFile = path.join(signalDir, entry);
+            const orphanContent = fs.readFileSync(orphanFile, 'utf8').trim();
+            try { fs.unlinkSync(orphanFile); } catch {}
+            if (orphanContent) chunks.push(orphanContent);
+        }
+    } catch {}
 
-    const content = fs.readFileSync(tmpFile, 'utf8').trim();
-    try { fs.unlinkSync(tmpFile); } catch {}
+    if (fs.existsSync(sigFile)) {
+        // Atomic: rename then read (daemon writes to original path are safe)
+        const tmpFile = sigFile + '.c-' + process.pid;
+        try {
+            fs.renameSync(sigFile, tmpFile);
+            const content = fs.readFileSync(tmpFile, 'utf8').trim();
+            try { fs.unlinkSync(tmpFile); } catch {}
+            if (content) chunks.push(content);
+        } catch {}
+    }
 
-    if (!content) process.exit(0);
+    if (chunks.length === 0) process.exit(0);
 
     console.log(JSON.stringify({
-        additionalContext: '\n' + content +
+        additionalContext: '\n' + chunks.join('\n') +
             '\nRespond to waggle messages using: ' +
             'WAGGLE_AGENT_NAME="' + agent + '" waggle send <sender> "<reply>"\n'
     }));

--- a/internal/install/claude-code/waggle-push.js
+++ b/internal/install/claude-code/waggle-push.js
@@ -29,23 +29,6 @@ try {
 
     const now = new Date();
     try { fs.utimesSync(sessionFile, now, now); } catch {}
-    try { fs.utimesSync(pointerFile, now, now); } catch {}
-
-    let orphanContent = '';
-    try {
-        const sigDirPath = path.join(rtDir, 'signals', project);
-        const entries = fs.readdirSync(sigDirPath);
-        for (const f of entries) {
-            if (f.startsWith(agent + '.c-')) {
-                const orphanPath = path.join(sigDirPath, f);
-                try {
-                    const data = fs.readFileSync(orphanPath, 'utf8').trim();
-                    if (data) orphanContent += (orphanContent ? '\n' : '') + data;
-                    fs.unlinkSync(orphanPath);
-                } catch {}
-            }
-        }
-    } catch {}
 
     const sigFile = path.join(rtDir, 'signals', project, agent);
     if (!fs.existsSync(sigFile)) process.exit(0);
@@ -57,11 +40,10 @@ try {
     const content = fs.readFileSync(tmpFile, 'utf8').trim();
     try { fs.unlinkSync(tmpFile); } catch {}
 
-    const allContent = [orphanContent, content].filter(Boolean).join('\n');
-    if (!allContent) process.exit(0);
+    if (!content) process.exit(0);
 
     console.log(JSON.stringify({
-        additionalContext: '\n' + allContent +
+        additionalContext: '\n' + content +
             '\nRespond to waggle messages using: ' +
             'WAGGLE_AGENT_NAME="' + agent + '" waggle send <sender> "<reply>"\n'
     }));

--- a/internal/install/claude-code/waggle-push.js
+++ b/internal/install/claude-code/waggle-push.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // waggle-push.js — PreToolUse hook for Claude Code.
-// Reads signal files via PPID mapping. Atomic consume via rename.
+// Reads signal files via PPID pointer + session mapping. Atomic consume via rename.
 // WAGGLE_PPID env var provides the real agent PID (set by hook command).
 const fs = require('fs');
 const path = require('path');
@@ -11,15 +11,24 @@ if (!home) process.exit(0);
 const rtDir = path.join(home, '.waggle', 'runtime');
 // Use WAGGLE_PPID (agent PID) not process.ppid (intermediate shell PID)
 const ppid = process.env.WAGGLE_PPID || String(process.ppid);
-const mapFile = path.join(rtDir, 'agent-ppid-' + ppid);
+const pointerFile = path.join(rtDir, 'agent-ppid-' + ppid);
 
 try {
-    if (!fs.existsSync(mapFile)) process.exit(0);
+    if (!fs.existsSync(pointerFile)) process.exit(0);
 
-    const lines = fs.readFileSync(mapFile, 'utf8').trim().split('\n');
+    const nonce = fs.readFileSync(pointerFile, 'utf8').trim();
+    if (!nonce) process.exit(0);
+
+    const sessionFile = path.join(rtDir, 'agent-session-' + nonce);
+    if (!fs.existsSync(sessionFile)) process.exit(0);
+
+    const lines = fs.readFileSync(sessionFile, 'utf8').trim().split('\n');
     const agent = lines[0];
     const project = lines[1] || '';
     if (!agent) process.exit(0);
+
+    const now = new Date();
+    try { fs.utimesSync(sessionFile, now, now); } catch {}
 
     const sigFile = path.join(rtDir, 'signals', project, agent);
     if (!fs.existsSync(sigFile)) process.exit(0);

--- a/internal/install/claude-code/waggle-push.js
+++ b/internal/install/claude-code/waggle-push.js
@@ -11,6 +11,7 @@ if (!home) process.exit(0);
 const rtDir = path.join(home, '.waggle', 'runtime');
 // Use WAGGLE_PPID (agent PID) not process.ppid (intermediate shell PID)
 const ppid = process.env.WAGGLE_PPID || String(process.ppid);
+if (!/^\d+$/.test(ppid)) process.exit(0);
 const pointerFile = path.join(rtDir, 'agent-ppid-' + ppid);
 
 try {
@@ -25,7 +26,9 @@ try {
     const lines = fs.readFileSync(sessionFile, 'utf8').trim().split('\n');
     const agent = lines[0];
     const project = lines[1] || '';
+    const tokenPattern = /^[a-zA-Z0-9_-]+$/;
     if (!agent) process.exit(0);
+    if (!tokenPattern.test(agent) || !tokenPattern.test(project)) process.exit(0);
 
     const now = new Date();
     try { fs.utimesSync(sessionFile, now, now); } catch {}

--- a/internal/install/claude-code/waggle-push.js
+++ b/internal/install/claude-code/waggle-push.js
@@ -16,10 +16,12 @@ const mapFile = path.join(rtDir, 'agent-ppid-' + ppid);
 try {
     if (!fs.existsSync(mapFile)) process.exit(0);
 
-    const agent = fs.readFileSync(mapFile, 'utf8').trim().split('\n')[0];
+    const lines = fs.readFileSync(mapFile, 'utf8').trim().split('\n');
+    const agent = lines[0];
+    const project = lines[1] || '';
     if (!agent) process.exit(0);
 
-    const sigFile = path.join(rtDir, 'signals', agent);
+    const sigFile = path.join(rtDir, 'signals', project, agent);
     if (!fs.existsSync(sigFile)) process.exit(0);
 
     // Atomic: rename then read (daemon writes to original path are safe)

--- a/internal/install/claude-code/waggle-push.js
+++ b/internal/install/claude-code/waggle-push.js
@@ -29,6 +29,23 @@ try {
 
     const now = new Date();
     try { fs.utimesSync(sessionFile, now, now); } catch {}
+    try { fs.utimesSync(pointerFile, now, now); } catch {}
+
+    let orphanContent = '';
+    try {
+        const sigDirPath = path.join(rtDir, 'signals', project);
+        const entries = fs.readdirSync(sigDirPath);
+        for (const f of entries) {
+            if (f.startsWith(agent + '.c-')) {
+                const orphanPath = path.join(sigDirPath, f);
+                try {
+                    const data = fs.readFileSync(orphanPath, 'utf8').trim();
+                    if (data) orphanContent += (orphanContent ? '\n' : '') + data;
+                    fs.unlinkSync(orphanPath);
+                } catch {}
+            }
+        }
+    } catch {}
 
     const sigFile = path.join(rtDir, 'signals', project, agent);
     if (!fs.existsSync(sigFile)) process.exit(0);
@@ -40,10 +57,11 @@ try {
     const content = fs.readFileSync(tmpFile, 'utf8').trim();
     try { fs.unlinkSync(tmpFile); } catch {}
 
-    if (!content) process.exit(0);
+    const allContent = [orphanContent, content].filter(Boolean).join('\n');
+    if (!allContent) process.exit(0);
 
     console.log(JSON.stringify({
-        additionalContext: '\n' + content +
+        additionalContext: '\n' + allContent +
             '\nRespond to waggle messages using: ' +
             'WAGGLE_AGENT_NAME="' + agent + '" waggle send <sender> "<reply>"\n'
     }));

--- a/internal/install/claude-code/waggle-push.js
+++ b/internal/install/claude-code/waggle-push.js
@@ -1,45 +1,41 @@
 #!/usr/bin/env node
-// waggle-push.js — PreToolUse hook
-// Reads pushed messages from waggle listener and injects via additionalContext
-
+// waggle-push.js — PreToolUse hook for Claude Code.
+// Reads signal files via PPID mapping. Atomic consume via rename.
+// WAGGLE_PPID env var provides the real agent PID (set by hook command).
 const fs = require('fs');
+const path = require('path');
 
-const agentName = process.env.WAGGLE_AGENT_NAME;
-if (!agentName) process.exit(0);
+const home = process.env.HOME;
+if (!home) process.exit(0);
 
-const listenFile = process.env.WAGGLE_LISTEN_FILE || `/tmp/waggle-${agentName}.jsonl`;
+const rtDir = path.join(home, '.waggle', 'runtime');
+// Use WAGGLE_PPID (agent PID) not process.ppid (intermediate shell PID)
+const ppid = process.env.WAGGLE_PPID || String(process.ppid);
+const mapFile = path.join(rtDir, 'agent-ppid-' + ppid);
 
 try {
-    if (!fs.existsSync(listenFile)) process.exit(0);
+    if (!fs.existsSync(mapFile)) process.exit(0);
 
-    const content = fs.readFileSync(listenFile, 'utf8').trim();
+    const agent = fs.readFileSync(mapFile, 'utf8').trim().split('\n')[0];
+    if (!agent) process.exit(0);
+
+    const sigFile = path.join(rtDir, 'signals', agent);
+    if (!fs.existsSync(sigFile)) process.exit(0);
+
+    // Atomic: rename then read (daemon writes to original path are safe)
+    const tmpFile = sigFile + '.c-' + process.pid;
+    try { fs.renameSync(sigFile, tmpFile); } catch { process.exit(0); }
+
+    const content = fs.readFileSync(tmpFile, 'utf8').trim();
+    try { fs.unlinkSync(tmpFile); } catch {}
+
     if (!content) process.exit(0);
 
-    // Clear the file immediately (atomic: write empty, not unlink)
-    fs.writeFileSync(listenFile, '');
-
-    // Parse messages
-    const messages = content.split('\n')
-        .filter(line => line.trim())
-        .map(line => {
-            try { return JSON.parse(line); }
-            catch { return null; }
-        })
-        .filter(Boolean);
-
-    if (messages.length === 0) process.exit(0);
-
-    // Format for injection
-    const formatted = messages.map(m =>
-        `[waggle] Message from ${m.from}: ${m.body}`
-    ).join('\n');
-
-    // Output additionalContext
     console.log(JSON.stringify({
-        additionalContext: `\n📨 Waggle: ${messages.length} new message(s):\n${formatted}\n`
+        additionalContext: '\n' + content +
+            '\nRespond to waggle messages using: ' +
+            'WAGGLE_AGENT_NAME="' + agent + '" waggle send <sender> "<reply>"\n'
     }));
-} catch (e) {
-    // Silent failure — don't block tool calls
+} catch {
     process.exit(0);
 }
-

--- a/internal/install/claude_code.go
+++ b/internal/install/claude_code.go
@@ -61,7 +61,7 @@ func installClaudeCode(homeDir string) error {
 
 	// 1. Copy hook files (from single source of truth: hookFiles)
 	hookDir := filepath.Join(claudeDir, "hooks")
-	if err := os.MkdirAll(hookDir, 0755); err != nil {
+	if err := safeMkdirAll(hookDir, homeDir, 0o755); err != nil {
 		return fmt.Errorf("creating hooks dir: %w", err)
 	}
 	for _, hf := range hookFiles {
@@ -69,14 +69,14 @@ func installClaudeCode(homeDir string) error {
 		if err != nil {
 			return fmt.Errorf("reading embedded %s: %w", hf.embedded, err)
 		}
-		if err := os.WriteFile(filepath.Join(hookDir, hf.installed), data, hf.perm); err != nil {
+		if err := safeWriteFile(filepath.Join(hookDir, hf.installed), data, hf.perm, homeDir); err != nil {
 			return fmt.Errorf("writing %s: %w", hf.installed, err)
 		}
 	}
 
 	// 2. Copy skills
 	skillDir := filepath.Join(claudeDir, "skills", "waggle")
-	if err := os.MkdirAll(skillDir, 0755); err != nil {
+	if err := safeMkdirAll(skillDir, homeDir, 0o755); err != nil {
 		return fmt.Errorf("creating skills dir: %w", err)
 	}
 	skillFiles := []string{"waggle.md", "send.md", "inbox.md", "ack.md", "status.md", "claim.md", "done.md", "presence.md"}
@@ -85,7 +85,7 @@ func installClaudeCode(homeDir string) error {
 		if err != nil {
 			return fmt.Errorf("reading embedded skill %s: %w", name, err)
 		}
-		if err := os.WriteFile(filepath.Join(skillDir, name), data, 0644); err != nil {
+		if err := safeWriteFile(filepath.Join(skillDir, name), data, 0o644, homeDir); err != nil {
 			return fmt.Errorf("writing skill %s: %w", name, err)
 		}
 	}
@@ -113,13 +113,13 @@ func uninstallClaudeCode(homeDir string) error {
 
 	// Remove hook files (from single source of truth: hookFiles)
 	for _, hf := range hookFiles {
-		if err := os.Remove(filepath.Join(claudeDir, "hooks", hf.installed)); err != nil && !os.IsNotExist(err) {
+		if err := safeRemove(filepath.Join(claudeDir, "hooks", hf.installed), homeDir); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("removing %s: %w", hf.installed, err)
 		}
 	}
 
 	// Remove skill directory
-	if err := os.RemoveAll(filepath.Join(claudeDir, "skills", "waggle")); err != nil && !os.IsNotExist(err) {
+	if err := safeRemoveAll(filepath.Join(claudeDir, "skills", "waggle"), homeDir); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("removing skills directory: %w", err)
 	}
 
@@ -154,6 +154,7 @@ func readSettingsJSON(path string) (map[string]interface{}, error) {
 // Uses JSON parsing to safely merge without overwriting existing hooks.
 func registerSessionStartHook(claudeDir string) error {
 	settingsPath := filepath.Join(claudeDir, "settings.json")
+	root := filepath.Dir(claudeDir)
 
 	// Read existing settings
 	settings, _ := readSettingsJSON(settingsPath)
@@ -203,12 +204,13 @@ func registerSessionStartHook(claudeDir string) error {
 		return fmt.Errorf("marshaling settings: %w", err)
 	}
 
-	return os.WriteFile(settingsPath, out, 0644)
+	return safeWriteFile(settingsPath, out, 0o644, root)
 }
 
 // deregisterSessionStartHook removes the waggle hook from settings.json.
 func deregisterSessionStartHook(claudeDir string) error {
 	settingsPath := filepath.Join(claudeDir, "settings.json")
+	root := filepath.Dir(claudeDir)
 
 	settings, _ := readSettingsJSON(settingsPath)
 
@@ -252,12 +254,13 @@ func deregisterSessionStartHook(claudeDir string) error {
 		return fmt.Errorf("marshaling settings: %w", err)
 	}
 
-	return os.WriteFile(settingsPath, out, 0644)
+	return safeWriteFile(settingsPath, out, 0o644, root)
 }
 
 // registerPreToolUseHook adds the waggle push hook to settings.json PreToolUse array.
 func registerPreToolUseHook(claudeDir string) error {
 	settingsPath := filepath.Join(claudeDir, "settings.json")
+	root := filepath.Dir(claudeDir)
 	settings, _ := readSettingsJSON(settingsPath)
 
 	hooks, _ := settings["hooks"].(map[string]interface{})
@@ -292,12 +295,13 @@ func registerPreToolUseHook(claudeDir string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(settingsPath, out, 0644)
+	return safeWriteFile(settingsPath, out, 0o644, root)
 }
 
 // deregisterPreToolUseHook removes the waggle push hook from settings.json.
 func deregisterPreToolUseHook(claudeDir string) error {
 	settingsPath := filepath.Join(claudeDir, "settings.json")
+	root := filepath.Dir(claudeDir)
 	settings, _ := readSettingsJSON(settingsPath)
 
 	hooks, _ := settings["hooks"].(map[string]interface{})
@@ -338,5 +342,5 @@ func deregisterPreToolUseHook(claudeDir string) error {
 	if err != nil {
 		return fmt.Errorf("marshaling settings: %w", err)
 	}
-	return os.WriteFile(settingsPath, out, 0644)
+	return safeWriteFile(settingsPath, out, 0o644, root)
 }

--- a/internal/install/claude_code.go
+++ b/internal/install/claude_code.go
@@ -99,7 +99,7 @@ func installClaudeCode(homeDir string) error {
 		return fmt.Errorf("registering push hook: %w", err)
 	}
 
-	// 6. Install universal shell hook
+	// 4. Install universal shell hook
 	if err := installShellHook(homeDir); err != nil {
 		return fmt.Errorf("installing shell hook: %w", err)
 	}

--- a/internal/install/claude_code.go
+++ b/internal/install/claude_code.go
@@ -19,7 +19,6 @@ const wagglePushCommand = "WAGGLE_PPID=$PPID node $HOME/.claude/hooks/waggle-pus
 
 // The canonical Claude Code integration assets live in integrations/claude-code/.
 // This mirrored copy exists in-package so go:embed can bundle them for install.
-//
 //go:embed all:claude-code
 var claudeCodeFiles embed.FS
 
@@ -28,7 +27,7 @@ var claudeCodeFiles embed.FS
 // Used by both install and uninstall to prevent orphaned files.
 var hookFiles = []struct {
 	embedded, installed string
-	perm                os.FileMode
+	perm               os.FileMode
 }{
 	{"claude-code/hook.sh", "waggle-connect.sh", 0o755},
 	{"claude-code/heartbeat.sh", "waggle-heartbeat.sh", 0o755},
@@ -70,14 +69,7 @@ func installClaudeCode(homeDir string) error {
 		if err != nil {
 			return fmt.Errorf("reading embedded %s: %w", hf.embedded, err)
 		}
-		destPath := filepath.Join(hookDir, hf.installed)
-		if info, err := os.Lstat(destPath); err == nil && info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("refusing to overwrite symlink: %s", destPath)
-		}
-		if hasAncestorSymlink(destPath, homeDir) {
-			return fmt.Errorf("refusing to write through ancestor symlink: %s", destPath)
-		}
-		if err := atomicWriteFile(destPath, data, hf.perm); err != nil {
+		if err := os.WriteFile(filepath.Join(hookDir, hf.installed), data, hf.perm); err != nil {
 			return fmt.Errorf("writing %s: %w", hf.installed, err)
 		}
 	}
@@ -93,14 +85,7 @@ func installClaudeCode(homeDir string) error {
 		if err != nil {
 			return fmt.Errorf("reading embedded skill %s: %w", name, err)
 		}
-		skillPath := filepath.Join(skillDir, name)
-		if info, err := os.Lstat(skillPath); err == nil && info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("refusing to overwrite symlink: %s", skillPath)
-		}
-		if hasAncestorSymlink(skillPath, homeDir) {
-			return fmt.Errorf("refusing to write through ancestor symlink: %s", skillPath)
-		}
-		if err := atomicWriteFile(skillPath, data, 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(skillDir, name), data, 0644); err != nil {
 			return fmt.Errorf("writing skill %s: %w", name, err)
 		}
 	}
@@ -218,7 +203,7 @@ func registerSessionStartHook(claudeDir string) error {
 		return fmt.Errorf("marshaling settings: %w", err)
 	}
 
-	return atomicWriteFile(settingsPath, out, 0644)
+	return os.WriteFile(settingsPath, out, 0644)
 }
 
 // deregisterSessionStartHook removes the waggle hook from settings.json.
@@ -267,7 +252,7 @@ func deregisterSessionStartHook(claudeDir string) error {
 		return fmt.Errorf("marshaling settings: %w", err)
 	}
 
-	return atomicWriteFile(settingsPath, out, 0644)
+	return os.WriteFile(settingsPath, out, 0644)
 }
 
 // registerPreToolUseHook adds the waggle push hook to settings.json PreToolUse array.
@@ -307,7 +292,7 @@ func registerPreToolUseHook(claudeDir string) error {
 	if err != nil {
 		return err
 	}
-	return atomicWriteFile(settingsPath, out, 0644)
+	return os.WriteFile(settingsPath, out, 0644)
 }
 
 // deregisterPreToolUseHook removes the waggle push hook from settings.json.
@@ -353,5 +338,5 @@ func deregisterPreToolUseHook(claudeDir string) error {
 	if err != nil {
 		return fmt.Errorf("marshaling settings: %w", err)
 	}
-	return atomicWriteFile(settingsPath, out, 0644)
+	return os.WriteFile(settingsPath, out, 0644)
 }

--- a/internal/install/claude_code.go
+++ b/internal/install/claude_code.go
@@ -19,6 +19,7 @@ const wagglePushCommand = "WAGGLE_PPID=$PPID node $HOME/.claude/hooks/waggle-pus
 
 // The canonical Claude Code integration assets live in integrations/claude-code/.
 // This mirrored copy exists in-package so go:embed can bundle them for install.
+//
 //go:embed all:claude-code
 var claudeCodeFiles embed.FS
 
@@ -27,7 +28,7 @@ var claudeCodeFiles embed.FS
 // Used by both install and uninstall to prevent orphaned files.
 var hookFiles = []struct {
 	embedded, installed string
-	perm               os.FileMode
+	perm                os.FileMode
 }{
 	{"claude-code/hook.sh", "waggle-connect.sh", 0o755},
 	{"claude-code/heartbeat.sh", "waggle-heartbeat.sh", 0o755},
@@ -69,7 +70,14 @@ func installClaudeCode(homeDir string) error {
 		if err != nil {
 			return fmt.Errorf("reading embedded %s: %w", hf.embedded, err)
 		}
-		if err := os.WriteFile(filepath.Join(hookDir, hf.installed), data, hf.perm); err != nil {
+		destPath := filepath.Join(hookDir, hf.installed)
+		if info, err := os.Lstat(destPath); err == nil && info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to overwrite symlink: %s", destPath)
+		}
+		if hasAncestorSymlink(destPath, homeDir) {
+			return fmt.Errorf("refusing to write through ancestor symlink: %s", destPath)
+		}
+		if err := atomicWriteFile(destPath, data, hf.perm); err != nil {
 			return fmt.Errorf("writing %s: %w", hf.installed, err)
 		}
 	}
@@ -85,7 +93,14 @@ func installClaudeCode(homeDir string) error {
 		if err != nil {
 			return fmt.Errorf("reading embedded skill %s: %w", name, err)
 		}
-		if err := os.WriteFile(filepath.Join(skillDir, name), data, 0644); err != nil {
+		skillPath := filepath.Join(skillDir, name)
+		if info, err := os.Lstat(skillPath); err == nil && info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to overwrite symlink: %s", skillPath)
+		}
+		if hasAncestorSymlink(skillPath, homeDir) {
+			return fmt.Errorf("refusing to write through ancestor symlink: %s", skillPath)
+		}
+		if err := atomicWriteFile(skillPath, data, 0644); err != nil {
 			return fmt.Errorf("writing skill %s: %w", name, err)
 		}
 	}
@@ -203,7 +218,7 @@ func registerSessionStartHook(claudeDir string) error {
 		return fmt.Errorf("marshaling settings: %w", err)
 	}
 
-	return os.WriteFile(settingsPath, out, 0644)
+	return atomicWriteFile(settingsPath, out, 0644)
 }
 
 // deregisterSessionStartHook removes the waggle hook from settings.json.
@@ -252,7 +267,7 @@ func deregisterSessionStartHook(claudeDir string) error {
 		return fmt.Errorf("marshaling settings: %w", err)
 	}
 
-	return os.WriteFile(settingsPath, out, 0644)
+	return atomicWriteFile(settingsPath, out, 0644)
 }
 
 // registerPreToolUseHook adds the waggle push hook to settings.json PreToolUse array.
@@ -292,7 +307,7 @@ func registerPreToolUseHook(claudeDir string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(settingsPath, out, 0644)
+	return atomicWriteFile(settingsPath, out, 0644)
 }
 
 // deregisterPreToolUseHook removes the waggle push hook from settings.json.
@@ -338,5 +353,5 @@ func deregisterPreToolUseHook(claudeDir string) error {
 	if err != nil {
 		return fmt.Errorf("marshaling settings: %w", err)
 	}
-	return os.WriteFile(settingsPath, out, 0644)
+	return atomicWriteFile(settingsPath, out, 0644)
 }

--- a/internal/install/claude_code.go
+++ b/internal/install/claude_code.go
@@ -22,6 +22,18 @@ const wagglePushCommand = "WAGGLE_PPID=$PPID node $HOME/.claude/hooks/waggle-pus
 //go:embed all:claude-code
 var claudeCodeFiles embed.FS
 
+// hookFiles is the single source of truth for hook file installation.
+// Maps embedded asset name → installed filename under ~/.claude/hooks/.
+// Used by both install and uninstall to prevent orphaned files.
+var hookFiles = []struct {
+	embedded, installed string
+	perm               os.FileMode
+}{
+	{"claude-code/hook.sh", "waggle-connect.sh", 0o755},
+	{"claude-code/heartbeat.sh", "waggle-heartbeat.sh", 0o755},
+	{"claude-code/waggle-push.js", "waggle-push.js", 0o755},
+}
+
 // InstallClaudeCode installs waggle integration for Claude Code.
 // Copies hook, heartbeat, and skills to ~/.claude/ and registers the hook in settings.json.
 func InstallClaudeCode() error {
@@ -47,29 +59,22 @@ func UninstallClaudeCode() error {
 func installClaudeCode(homeDir string) error {
 	claudeDir := filepath.Join(homeDir, ".claude")
 
-	// 1. Copy hook
+	// 1. Copy hook files (from single source of truth: hookFiles)
 	hookDir := filepath.Join(claudeDir, "hooks")
 	if err := os.MkdirAll(hookDir, 0755); err != nil {
 		return fmt.Errorf("creating hooks dir: %w", err)
 	}
-	hookData, err := claudeCodeFiles.ReadFile("claude-code/hook.sh")
-	if err != nil {
-		return fmt.Errorf("reading embedded hook.sh: %w", err)
-	}
-	if err := os.WriteFile(filepath.Join(hookDir, "waggle-connect.sh"), hookData, 0755); err != nil {
-		return fmt.Errorf("writing hook: %w", err)
-	}
-
-	// 2. Copy heartbeat script
-	heartbeatData, err := claudeCodeFiles.ReadFile("claude-code/heartbeat.sh")
-	if err != nil {
-		return fmt.Errorf("reading embedded heartbeat.sh: %w", err)
-	}
-	if err := os.WriteFile(filepath.Join(hookDir, "waggle-heartbeat.sh"), heartbeatData, 0755); err != nil {
-		return fmt.Errorf("writing heartbeat: %w", err)
+	for _, hf := range hookFiles {
+		data, err := claudeCodeFiles.ReadFile(hf.embedded)
+		if err != nil {
+			return fmt.Errorf("reading embedded %s: %w", hf.embedded, err)
+		}
+		if err := os.WriteFile(filepath.Join(hookDir, hf.installed), data, hf.perm); err != nil {
+			return fmt.Errorf("writing %s: %w", hf.installed, err)
+		}
 	}
 
-	// 3. Copy skills
+	// 2. Copy skills
 	skillDir := filepath.Join(claudeDir, "skills", "waggle")
 	if err := os.MkdirAll(skillDir, 0755); err != nil {
 		return fmt.Errorf("creating skills dir: %w", err)
@@ -85,16 +90,7 @@ func installClaudeCode(homeDir string) error {
 		}
 	}
 
-	// 4. Copy PreToolUse push hook
-	pushData, err := claudeCodeFiles.ReadFile("claude-code/waggle-push.js")
-	if err != nil {
-		return fmt.Errorf("reading waggle-push.js: %w", err)
-	}
-	if err := os.WriteFile(filepath.Join(hookDir, "waggle-push.js"), pushData, 0755); err != nil {
-		return fmt.Errorf("writing push hook: %w", err)
-	}
-
-	// 5. Register hooks in settings.json
+	// 3. Register hooks in settings.json
 	if err := registerSessionStartHook(claudeDir); err != nil {
 		return fmt.Errorf("registering hook: %w", err)
 	}
@@ -115,10 +111,10 @@ func installClaudeCode(homeDir string) error {
 func uninstallClaudeCode(homeDir string) error {
 	claudeDir := filepath.Join(homeDir, ".claude")
 
-	// Remove hook files
-	for _, name := range []string{"waggle-connect.sh", "waggle-heartbeat.sh", "waggle-push.js"} {
-		if err := os.Remove(filepath.Join(claudeDir, "hooks", name)); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("removing %s: %w", name, err)
+	// Remove hook files (from single source of truth: hookFiles)
+	for _, hf := range hookFiles {
+		if err := os.Remove(filepath.Join(claudeDir, "hooks", hf.installed)); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("removing %s: %w", hf.installed, err)
 		}
 	}
 

--- a/internal/install/claude_code.go
+++ b/internal/install/claude_code.go
@@ -12,6 +12,11 @@ import (
 // Used by install, uninstall, and health checks. Single source of truth.
 const waggleHookCommand = "bash $HOME/.claude/hooks/waggle-connect.sh"
 
+// wagglePushCommand is the PreToolUse hook command for signal file delivery.
+// WAGGLE_PPID=$PPID passes Claude Code's PID (expanded by the shell that runs
+// the hook), avoiding the intermediate-shell PPID problem.
+const wagglePushCommand = "WAGGLE_PPID=$PPID node $HOME/.claude/hooks/waggle-push.js"
+
 // The canonical Claude Code integration assets live in integrations/claude-code/.
 // This mirrored copy exists in-package so go:embed can bundle them for install.
 //go:embed all:claude-code
@@ -80,12 +85,25 @@ func installClaudeCode(homeDir string) error {
 		}
 	}
 
-	// 4. Register hook in settings.json
+	// 4. Copy PreToolUse push hook
+	pushData, err := claudeCodeFiles.ReadFile("claude-code/waggle-push.js")
+	if err != nil {
+		return fmt.Errorf("reading waggle-push.js: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(hookDir, "waggle-push.js"), pushData, 0755); err != nil {
+		return fmt.Errorf("writing push hook: %w", err)
+	}
+
+	// 5. Register hooks in settings.json
 	if err := registerSessionStartHook(claudeDir); err != nil {
 		return fmt.Errorf("registering hook: %w", err)
 	}
 
-	// 5. Install universal shell hook
+	if err := registerPreToolUseHook(claudeDir); err != nil {
+		return fmt.Errorf("registering push hook: %w", err)
+	}
+
+	// 6. Install universal shell hook
 	if err := installShellHook(homeDir); err != nil {
 		return fmt.Errorf("installing shell hook: %w", err)
 	}
@@ -98,7 +116,7 @@ func uninstallClaudeCode(homeDir string) error {
 	claudeDir := filepath.Join(homeDir, ".claude")
 
 	// Remove hook files
-	for _, name := range []string{"waggle-connect.sh", "waggle-heartbeat.sh"} {
+	for _, name := range []string{"waggle-connect.sh", "waggle-heartbeat.sh", "waggle-push.js"} {
 		if err := os.Remove(filepath.Join(claudeDir, "hooks", name)); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("removing %s: %w", name, err)
 		}
@@ -109,9 +127,13 @@ func uninstallClaudeCode(homeDir string) error {
 		return fmt.Errorf("removing skills directory: %w", err)
 	}
 
-	// Deregister hook from settings.json
+	// Deregister hooks from settings.json
 	if err := deregisterSessionStartHook(claudeDir); err != nil {
 		return fmt.Errorf("deregistering hook: %w", err)
+	}
+
+	if err := deregisterPreToolUseHook(claudeDir); err != nil {
+		return fmt.Errorf("deregistering push hook: %w", err)
 	}
 
 	return nil
@@ -234,5 +256,91 @@ func deregisterSessionStartHook(claudeDir string) error {
 		return fmt.Errorf("marshaling settings: %w", err)
 	}
 
+	return os.WriteFile(settingsPath, out, 0644)
+}
+
+// registerPreToolUseHook adds the waggle push hook to settings.json PreToolUse array.
+func registerPreToolUseHook(claudeDir string) error {
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	settings, _ := readSettingsJSON(settingsPath)
+
+	hooks, _ := settings["hooks"].(map[string]interface{})
+	if hooks == nil {
+		hooks = make(map[string]interface{})
+	}
+
+	preToolUse, _ := hooks["PreToolUse"].([]interface{})
+	for _, entry := range preToolUse {
+		em, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		hs, _ := em["hooks"].([]interface{})
+		for _, h := range hs {
+			hm, _ := h.(map[string]interface{})
+			if cmd, _ := hm["command"].(string); cmd == wagglePushCommand {
+				return nil // already registered
+			}
+		}
+	}
+
+	preToolUse = append(preToolUse, map[string]interface{}{
+		"hooks": []interface{}{
+			map[string]interface{}{"type": "command", "command": wagglePushCommand},
+		},
+	})
+	hooks["PreToolUse"] = preToolUse
+	settings["hooks"] = hooks
+
+	out, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(settingsPath, out, 0644)
+}
+
+// deregisterPreToolUseHook removes the waggle push hook from settings.json.
+func deregisterPreToolUseHook(claudeDir string) error {
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	settings, _ := readSettingsJSON(settingsPath)
+
+	hooks, _ := settings["hooks"].(map[string]interface{})
+	if hooks == nil {
+		return nil
+	}
+
+	preToolUse, _ := hooks["PreToolUse"].([]interface{})
+	if preToolUse == nil {
+		return nil
+	}
+
+	var filtered []interface{}
+	for _, entry := range preToolUse {
+		entryMap, ok := entry.(map[string]interface{})
+		if !ok {
+			filtered = append(filtered, entry)
+			continue
+		}
+		entryHooks, _ := entryMap["hooks"].([]interface{})
+		isWaggle := false
+		for _, h := range entryHooks {
+			hMap, _ := h.(map[string]interface{})
+			if cmd, _ := hMap["command"].(string); cmd == wagglePushCommand {
+				isWaggle = true
+				break
+			}
+		}
+		if !isWaggle {
+			filtered = append(filtered, entry)
+		}
+	}
+
+	hooks["PreToolUse"] = filtered
+	settings["hooks"] = hooks
+
+	out, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling settings: %w", err)
+	}
 	return os.WriteFile(settingsPath, out, 0644)
 }

--- a/internal/install/claude_code.go
+++ b/internal/install/claude_code.go
@@ -85,6 +85,11 @@ func installClaudeCode(homeDir string) error {
 		return fmt.Errorf("registering hook: %w", err)
 	}
 
+	// 5. Install universal shell hook
+	if err := installShellHook(homeDir); err != nil {
+		return fmt.Errorf("installing shell hook: %w", err)
+	}
+
 	return nil
 }
 

--- a/internal/install/claude_code_test.go
+++ b/internal/install/claude_code_test.go
@@ -312,6 +312,28 @@ func TestInstall_PushHookCreated(t *testing.T) {
 	}
 }
 
+func TestInstall_PushHookRecoversOrphansAndRefreshesBothMappings(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	if err := installClaudeCode(tmpHome); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	pushPath := filepath.Join(tmpHome, ".claude", "hooks", "waggle-push.js")
+	data, err := os.ReadFile(pushPath)
+	if err != nil {
+		t.Fatalf("read push hook: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "fs.utimesSync(pointerFile, now, now)") {
+		t.Fatal("push hook should refresh pointer mapping alongside session mapping")
+	}
+	if !strings.Contains(content, "fs.readdirSync(") {
+		t.Fatal("push hook should recover orphaned consumed signal files")
+	}
+}
+
 func TestInstall_PreToolUseHookRegistered(t *testing.T) {
 	tmpHome := t.TempDir()
 

--- a/internal/install/claude_code_test.go
+++ b/internal/install/claude_code_test.go
@@ -107,31 +107,6 @@ func TestInstall_Idempotent(t *testing.T) {
 	}
 }
 
-func TestInstallClaudeCode_RejectsAncestorSymlink(t *testing.T) {
-	tmpHome := t.TempDir()
-	claudeDir := filepath.Join(tmpHome, ".claude")
-	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	realHooksDir := filepath.Join(tmpHome, "real-hooks")
-	if err := os.MkdirAll(realHooksDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Symlink(realHooksDir, filepath.Join(claudeDir, "hooks")); err != nil {
-		t.Fatal(err)
-	}
-
-	err := installClaudeCode(tmpHome)
-	if err == nil {
-		t.Fatal("expected error for ancestor symlink, got nil")
-	}
-	if !strings.Contains(err.Error(), "symlink") {
-		t.Fatalf("expected symlink error, got: %v", err)
-	}
-}
-
 func TestInstall_HookRegistered(t *testing.T) {
 	tmpHome := t.TempDir()
 
@@ -334,37 +309,6 @@ func TestInstall_PushHookCreated(t *testing.T) {
 	}
 	if !strings.Contains(content, "additionalContext") {
 		t.Error("push hook missing additionalContext output")
-	}
-}
-
-func TestInstall_PushHookTouchesPointerAndRecoversOrphans(t *testing.T) {
-	tmpHome := t.TempDir()
-
-	if err := installClaudeCode(tmpHome); err != nil {
-		t.Fatalf("install failed: %v", err)
-	}
-
-	pushPath := filepath.Join(tmpHome, ".claude", "hooks", "waggle-push.js")
-	data, err := os.ReadFile(pushPath)
-	if err != nil {
-		t.Fatalf("read push hook: %v", err)
-	}
-
-	content := string(data)
-	if !strings.Contains(content, "fs.utimesSync(pointerFile, now, now)") {
-		t.Fatal("push hook missing pointer file touch")
-	}
-	if !strings.Contains(content, "let orphanContent = '';") {
-		t.Fatal("push hook missing orphan recovery buffer")
-	}
-	if !strings.Contains(content, "if (f.startsWith(agent + '.c-'))") {
-		t.Fatal("push hook missing orphan recovery scan")
-	}
-	if !strings.Contains(content, "const allContent = [orphanContent, content].filter(Boolean).join('\\n');") {
-		t.Fatal("push hook missing combined orphan and signal content")
-	}
-	if !strings.Contains(content, "additionalContext: '\\n' + allContent +") {
-		t.Fatal("push hook missing combined output usage")
 	}
 }
 

--- a/internal/install/claude_code_test.go
+++ b/internal/install/claude_code_test.go
@@ -310,6 +310,9 @@ func TestInstall_PushHookCreated(t *testing.T) {
 	if !strings.Contains(content, "additionalContext") {
 		t.Error("push hook missing additionalContext output")
 	}
+	if !strings.Contains(content, `if (!/^\d+$/.test(ppid)) process.exit(0);`) {
+		t.Error("push hook missing non-numeric PPID early exit")
+	}
 }
 
 func TestInstall_PushHookRecoversOrphansAndRefreshesBothMappings(t *testing.T) {
@@ -331,6 +334,44 @@ func TestInstall_PushHookRecoversOrphansAndRefreshesBothMappings(t *testing.T) {
 	}
 	if !strings.Contains(content, "fs.readdirSync(") {
 		t.Fatal("push hook should recover orphaned consumed signal files")
+	}
+}
+
+func TestInstall_PushHookValidatesSessionTokens(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	if err := installClaudeCode(tmpHome); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	pushPath := filepath.Join(tmpHome, ".claude", "hooks", "waggle-push.js")
+	data, err := os.ReadFile(pushPath)
+	if err != nil {
+		t.Fatalf("read push hook: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "const tokenPattern = /^[a-zA-Z0-9_-]+$/;") {
+		t.Fatal("push hook should define session token validation regex")
+	}
+	if !strings.Contains(content, "if (!tokenPattern.test(agent) || !tokenPattern.test(project)) process.exit(0);") {
+		t.Fatal("push hook should reject invalid agent/project tokens from session file")
+	}
+}
+
+func TestPushHookSourcesStayIdentical(t *testing.T) {
+	installCopy, err := os.ReadFile(filepath.Join("claude-code", "waggle-push.js"))
+	if err != nil {
+		t.Fatalf("read install copy: %v", err)
+	}
+
+	integrationCopy, err := os.ReadFile(filepath.Join("..", "..", "integrations", "claude-code", "waggle-push.js"))
+	if err != nil {
+		t.Fatalf("read integration copy: %v", err)
+	}
+
+	if string(installCopy) != string(integrationCopy) {
+		t.Fatal("waggle-push.js copies diverged")
 	}
 }
 

--- a/internal/install/claude_code_test.go
+++ b/internal/install/claude_code_test.go
@@ -280,6 +280,125 @@ func TestInstall_CreatesSettingsIfMissing(t *testing.T) {
 	}
 }
 
+func TestInstall_PushHookCreated(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	if err := installClaudeCode(tmpHome); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	pushPath := filepath.Join(tmpHome, ".claude", "hooks", "waggle-push.js")
+	info, err := os.Stat(pushPath)
+	if err != nil {
+		t.Fatalf("push hook not created: %v", err)
+	}
+
+	// Check executable
+	if info.Mode().Perm()&0111 == 0 {
+		t.Errorf("push hook not executable: %o", info.Mode().Perm())
+	}
+
+	// Verify content uses WAGGLE_PPID env var
+	data, _ := os.ReadFile(pushPath)
+	content := string(data)
+	if !strings.Contains(content, "WAGGLE_PPID") {
+		t.Error("push hook missing WAGGLE_PPID env var usage")
+	}
+	if !strings.Contains(content, "agent-ppid-") {
+		t.Error("push hook missing agent-ppid- map file reference")
+	}
+	if !strings.Contains(content, "additionalContext") {
+		t.Error("push hook missing additionalContext output")
+	}
+}
+
+func TestInstall_PreToolUseHookRegistered(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	if err := installClaudeCode(tmpHome); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	settingsPath := filepath.Join(tmpHome, ".claude", "settings.json")
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("settings.json not created: %v", err)
+	}
+
+	var settings map[string]interface{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	hooks, ok := settings["hooks"].(map[string]interface{})
+	if !ok {
+		t.Fatal("hooks section missing")
+	}
+
+	preToolUse, ok := hooks["PreToolUse"].([]interface{})
+	if !ok {
+		t.Fatal("PreToolUse array missing")
+	}
+
+	found := false
+	for _, entry := range preToolUse {
+		entryMap, _ := entry.(map[string]interface{})
+		entryHooks, _ := entryMap["hooks"].([]interface{})
+		for _, h := range entryHooks {
+			hMap, _ := h.(map[string]interface{})
+			if cmd, _ := hMap["command"].(string); cmd == wagglePushCommand {
+				found = true
+				break
+			}
+		}
+	}
+
+	if !found {
+		t.Error("waggle push hook not registered in PreToolUse")
+	}
+
+	// Verify the command uses WAGGLE_PPID=$PPID prefix
+	if !strings.Contains(wagglePushCommand, "WAGGLE_PPID=$PPID") {
+		t.Error("wagglePushCommand missing WAGGLE_PPID=$PPID prefix")
+	}
+}
+
+func TestInstall_PreToolUseNoDuplicate(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	// Install twice
+	if err := installClaudeCode(tmpHome); err != nil {
+		t.Fatalf("first install failed: %v", err)
+	}
+	if err := installClaudeCode(tmpHome); err != nil {
+		t.Fatalf("second install failed: %v", err)
+	}
+
+	settingsPath := filepath.Join(tmpHome, ".claude", "settings.json")
+	data, _ := os.ReadFile(settingsPath)
+	var settings map[string]interface{}
+	json.Unmarshal(data, &settings)
+
+	hooks := settings["hooks"].(map[string]interface{})
+	preToolUse := hooks["PreToolUse"].([]interface{})
+
+	count := 0
+	for _, entry := range preToolUse {
+		entryMap, _ := entry.(map[string]interface{})
+		entryHooks, _ := entryMap["hooks"].([]interface{})
+		for _, h := range entryHooks {
+			hMap, _ := h.(map[string]interface{})
+			if cmd, _ := hMap["command"].(string); cmd == wagglePushCommand {
+				count++
+			}
+		}
+	}
+
+	if count != 1 {
+		t.Errorf("expected 1 PreToolUse waggle entry, got %d", count)
+	}
+}
+
 func TestUninstall_Clean(t *testing.T) {
 	tmpHome := t.TempDir()
 
@@ -302,6 +421,11 @@ func TestUninstall_Clean(t *testing.T) {
 	heartbeatPath := filepath.Join(tmpHome, ".claude", "hooks", "waggle-heartbeat.sh")
 	if _, err := os.Stat(heartbeatPath); !os.IsNotExist(err) {
 		t.Error("heartbeat still exists after uninstall")
+	}
+
+	pushPath := filepath.Join(tmpHome, ".claude", "hooks", "waggle-push.js")
+	if _, err := os.Stat(pushPath); !os.IsNotExist(err) {
+		t.Error("push hook still exists after uninstall")
 	}
 
 	skillDir := filepath.Join(tmpHome, ".claude", "skills", "waggle")
@@ -335,19 +459,28 @@ func TestUninstall_DeregistersHook(t *testing.T) {
 		return
 	}
 
-	sessionStart, ok := hooks["SessionStart"].([]interface{})
-	if !ok {
-		return
-	}
-
-	// Check no waggle entry
+	// Check no SessionStart waggle entry
+	sessionStart, _ := hooks["SessionStart"].([]interface{})
 	for _, entry := range sessionStart {
 		entryMap, _ := entry.(map[string]interface{})
 		entryHooks, _ := entryMap["hooks"].([]interface{})
 		for _, h := range entryHooks {
 			hMap, _ := h.(map[string]interface{})
-			if cmd, _ := hMap["command"].(string); cmd == "bash $HOME/.claude/hooks/waggle-connect.sh" {
-				t.Error("waggle hook still in settings.json after uninstall")
+			if cmd, _ := hMap["command"].(string); cmd == waggleHookCommand {
+				t.Error("waggle SessionStart hook still in settings.json after uninstall")
+			}
+		}
+	}
+
+	// Check no PreToolUse waggle entry
+	preToolUse, _ := hooks["PreToolUse"].([]interface{})
+	for _, entry := range preToolUse {
+		entryMap, _ := entry.(map[string]interface{})
+		entryHooks, _ := entryMap["hooks"].([]interface{})
+		for _, h := range entryHooks {
+			hMap, _ := h.(map[string]interface{})
+			if cmd, _ := hMap["command"].(string); cmd == wagglePushCommand {
+				t.Error("waggle PreToolUse hook still in settings.json after uninstall")
 			}
 		}
 	}

--- a/internal/install/claude_code_test.go
+++ b/internal/install/claude_code_test.go
@@ -107,6 +107,31 @@ func TestInstall_Idempotent(t *testing.T) {
 	}
 }
 
+func TestInstallClaudeCode_RejectsAncestorSymlink(t *testing.T) {
+	tmpHome := t.TempDir()
+	claudeDir := filepath.Join(tmpHome, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	realHooksDir := filepath.Join(tmpHome, "real-hooks")
+	if err := os.MkdirAll(realHooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Symlink(realHooksDir, filepath.Join(claudeDir, "hooks")); err != nil {
+		t.Fatal(err)
+	}
+
+	err := installClaudeCode(tmpHome)
+	if err == nil {
+		t.Fatal("expected error for ancestor symlink, got nil")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink error, got: %v", err)
+	}
+}
+
 func TestInstall_HookRegistered(t *testing.T) {
 	tmpHome := t.TempDir()
 
@@ -309,6 +334,37 @@ func TestInstall_PushHookCreated(t *testing.T) {
 	}
 	if !strings.Contains(content, "additionalContext") {
 		t.Error("push hook missing additionalContext output")
+	}
+}
+
+func TestInstall_PushHookTouchesPointerAndRecoversOrphans(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	if err := installClaudeCode(tmpHome); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	pushPath := filepath.Join(tmpHome, ".claude", "hooks", "waggle-push.js")
+	data, err := os.ReadFile(pushPath)
+	if err != nil {
+		t.Fatalf("read push hook: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "fs.utimesSync(pointerFile, now, now)") {
+		t.Fatal("push hook missing pointer file touch")
+	}
+	if !strings.Contains(content, "let orphanContent = '';") {
+		t.Fatal("push hook missing orphan recovery buffer")
+	}
+	if !strings.Contains(content, "if (f.startsWith(agent + '.c-'))") {
+		t.Fatal("push hook missing orphan recovery scan")
+	}
+	if !strings.Contains(content, "const allContent = [orphanContent, content].filter(Boolean).join('\\n');") {
+		t.Fatal("push hook missing combined orphan and signal content")
+	}
+	if !strings.Contains(content, "additionalContext: '\\n' + allContent +") {
+		t.Fatal("push hook missing combined output usage")
 	}
 }
 

--- a/internal/install/codex.go
+++ b/internal/install/codex.go
@@ -37,7 +37,7 @@ func UninstallCodex() error {
 func installCodex(homeDir string) error {
 	codexDir := filepath.Join(homeDir, ".codex")
 	skillDir := filepath.Join(codexDir, "skills", "waggle-runtime")
-	if err := os.MkdirAll(skillDir, 0755); err != nil {
+	if err := safeMkdirAll(skillDir, homeDir, 0o755); err != nil {
 		return fmt.Errorf("creating Codex skill dir: %w", err)
 	}
 
@@ -45,7 +45,7 @@ func installCodex(homeDir string) error {
 	if err != nil {
 		return fmt.Errorf("reading embedded Codex skill: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), skillData, 0644); err != nil {
+	if err := safeWriteFile(filepath.Join(skillDir, "SKILL.md"), skillData, 0o644, homeDir); err != nil {
 		return fmt.Errorf("writing Codex skill: %w", err)
 	}
 
@@ -53,7 +53,7 @@ func installCodex(homeDir string) error {
 	if err != nil {
 		return fmt.Errorf("reading embedded Codex AGENTS block: %w", err)
 	}
-	if err := upsertManagedBlock(filepath.Join(codexDir, "AGENTS.md"), codexBlockBegin, codexBlockEnd, string(blockData)); err != nil {
+	if err := upsertManagedBlock(filepath.Join(codexDir, "AGENTS.md"), codexBlockBegin, codexBlockEnd, string(blockData), homeDir); err != nil {
 		return fmt.Errorf("updating Codex AGENTS.md: %w", err)
 	}
 
@@ -67,11 +67,11 @@ func installCodex(homeDir string) error {
 func uninstallCodex(homeDir string) error {
 	codexDir := filepath.Join(homeDir, ".codex")
 
-	if err := os.RemoveAll(filepath.Join(codexDir, "skills", "waggle-runtime")); err != nil && !os.IsNotExist(err) {
+	if err := safeRemoveAll(filepath.Join(codexDir, "skills", "waggle-runtime"), homeDir); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("removing Codex skill directory: %w", err)
 	}
 
-	if err := removeManagedBlock(filepath.Join(codexDir, "AGENTS.md"), codexBlockBegin, codexBlockEnd); err != nil {
+	if err := removeManagedBlock(filepath.Join(codexDir, "AGENTS.md"), codexBlockBegin, codexBlockEnd, homeDir); err != nil {
 		return fmt.Errorf("updating Codex AGENTS.md: %w", err)
 	}
 

--- a/internal/install/codex.go
+++ b/internal/install/codex.go
@@ -57,6 +57,10 @@ func installCodex(homeDir string) error {
 		return fmt.Errorf("updating Codex AGENTS.md: %w", err)
 	}
 
+	if err := installShellHook(homeDir); err != nil {
+		return fmt.Errorf("installing shell hook: %w", err)
+	}
+
 	return nil
 }
 

--- a/internal/install/codex/AGENTS-block.md
+++ b/internal/install/codex/AGENTS-block.md
@@ -2,6 +2,6 @@
 
 At the start of every session, run:
 
-  waggle adapter bootstrap codex --format markdown
+  WAGGLE_AGENT_PPID=$PPID waggle adapter bootstrap codex --format markdown
 
 Do not skip this step. If the command fails or waggle is not installed, continue normally. Use the agent name from the output for any subsequent waggle commands in this session.

--- a/internal/install/gemini.go
+++ b/internal/install/gemini.go
@@ -36,7 +36,7 @@ func UninstallGemini() error {
 
 func installGemini(homeDir string) error {
 	geminiDir := filepath.Join(homeDir, ".gemini")
-	if err := os.MkdirAll(geminiDir, 0755); err != nil {
+	if err := safeMkdirAll(geminiDir, homeDir, 0o755); err != nil {
 		return fmt.Errorf("creating Gemini dir: %w", err)
 	}
 
@@ -44,7 +44,7 @@ func installGemini(homeDir string) error {
 	if err != nil {
 		return fmt.Errorf("reading embedded Gemini block: %w", err)
 	}
-	if err := upsertManagedBlock(filepath.Join(geminiDir, "GEMINI.md"), geminiBlockBegin, geminiBlockEnd, string(blockData)); err != nil {
+	if err := upsertManagedBlock(filepath.Join(geminiDir, "GEMINI.md"), geminiBlockBegin, geminiBlockEnd, string(blockData), homeDir); err != nil {
 		return fmt.Errorf("updating Gemini GEMINI.md: %w", err)
 	}
 
@@ -58,7 +58,7 @@ func installGemini(homeDir string) error {
 func uninstallGemini(homeDir string) error {
 	geminiDir := filepath.Join(homeDir, ".gemini")
 
-	if err := removeManagedBlock(filepath.Join(geminiDir, "GEMINI.md"), geminiBlockBegin, geminiBlockEnd); err != nil {
+	if err := removeManagedBlock(filepath.Join(geminiDir, "GEMINI.md"), geminiBlockBegin, geminiBlockEnd, homeDir); err != nil {
 		return fmt.Errorf("updating Gemini GEMINI.md: %w", err)
 	}
 

--- a/internal/install/gemini.go
+++ b/internal/install/gemini.go
@@ -48,6 +48,10 @@ func installGemini(homeDir string) error {
 		return fmt.Errorf("updating Gemini GEMINI.md: %w", err)
 	}
 
+	if err := installShellHook(homeDir); err != nil {
+		return fmt.Errorf("installing shell hook: %w", err)
+	}
+
 	return nil
 }
 

--- a/internal/install/gemini/GEMINI-block.md
+++ b/internal/install/gemini/GEMINI-block.md
@@ -2,6 +2,6 @@
 
 At the start of every session, run:
 
-    waggle adapter bootstrap gemini --format markdown
+    WAGGLE_AGENT_PPID=$PPID waggle adapter bootstrap gemini --format markdown
 
 Do not skip this step. If waggle is not installed, the command will fail silently — continue normally. Use the agent name from the output for any subsequent waggle commands in this session.

--- a/internal/install/health.go
+++ b/internal/install/health.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/seungpyoson/waggle/internal/fsutil"
 )
 
 // AdapterState represents the installation state of an adapter.
@@ -297,7 +299,7 @@ func CheckAuggie(homeDir string) ([]HealthIssue, AdapterState) {
 
 	// Validate ancestor path — symlinked parent directories are broken.
 	rulesDir := filepath.Dir(rulesPath)
-	if hasAncestorSymlink(rulesPath, homeDir) {
+	if fsutil.HasAncestorSymlink(rulesPath, homeDir) {
 		return []HealthIssue{{
 			Asset:   rulesDir,
 			Problem: "symlink in ancestor path: refusing to use path with ancestor symlink",

--- a/internal/install/health.go
+++ b/internal/install/health.go
@@ -296,13 +296,11 @@ func CheckAuggie(homeDir string) ([]HealthIssue, AdapterState) {
 	const repairCmd = "waggle install auggie"
 
 	// Validate ancestor path — symlinked parent directories are broken.
-	// Uses the same validateAncestorPath as install/uninstall to ensure
-	// consistent classification regardless of whether rules/ exists yet.
 	rulesDir := filepath.Dir(rulesPath)
-	if err := validateAncestorPath(rulesDir, homeDir); err != nil {
+	if hasAncestorSymlink(rulesPath, homeDir) {
 		return []HealthIssue{{
 			Asset:   rulesDir,
-			Problem: "symlink in ancestor path: " + err.Error(),
+			Problem: "symlink in ancestor path: refusing to use path with ancestor symlink",
 			Repair:  "rm the symlink and re-run " + repairCmd,
 		}}, StateBroken
 	}

--- a/internal/install/managed_block.go
+++ b/internal/install/managed_block.go
@@ -65,7 +65,7 @@ func validateMarkerTopology(content, begin, end string) error {
 	return nil
 }
 
-func upsertManagedBlock(path, begin, end, body string) error {
+func upsertManagedBlock(path, begin, end, body, root string) error {
 	current, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("reading %s: %w", path, err)
@@ -84,15 +84,15 @@ func upsertManagedBlock(path, begin, end, body string) error {
 			// Begin without end — replace everything from begin to EOF with canonical block.
 			// This self-heals truncated files (e.g., OS crash during write).
 			replaced := content[:idx] + block
-			return os.WriteFile(path, managedBlockBytes(replaced, true), 0644)
+			return safeWriteFile(path, managedBlockBytes(replaced, true), 0o644, root)
 		}
 		endAbs := idx + endIdx + len(end)
 		replaced := content[:idx] + block + content[endAbs:]
-		return os.WriteFile(path, managedBlockBytes(replaced, content[endAbs:] == ""), 0644)
+		return safeWriteFile(path, managedBlockBytes(replaced, content[endAbs:] == ""), 0o644, root)
 	}
 
 	if content == "" {
-		return os.WriteFile(path, managedBlockBytes(block, true), 0644)
+		return safeWriteFile(path, managedBlockBytes(block, true), 0o644, root)
 	}
 
 	// Separator: if the existing file doesn't end with a newline, we add one
@@ -107,10 +107,10 @@ func upsertManagedBlock(path, begin, end, body string) error {
 	}
 
 	merged := content + separator + block
-	return os.WriteFile(path, managedBlockBytes(merged, true), 0644)
+	return safeWriteFile(path, managedBlockBytes(merged, true), 0o644, root)
 }
 
-func removeManagedBlock(path, begin, end string) error {
+func removeManagedBlock(path, begin, end, root string) error {
 	current, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -133,7 +133,7 @@ func removeManagedBlock(path, begin, end string) error {
 		// Begin without end — remove everything from begin to EOF.
 		// This self-heals truncated files.
 		updated := content[:idx]
-		return os.WriteFile(path, []byte(updated), 0644)
+		return safeWriteFile(path, []byte(updated), 0o644, root)
 	}
 	endAbs := idx + endIdx + len(end)
 	after := content[endAbs:]
@@ -144,7 +144,7 @@ func removeManagedBlock(path, begin, end string) error {
 	}
 
 	updated := content[:idx] + after
-	return os.WriteFile(path, []byte(updated), 0644)
+	return safeWriteFile(path, []byte(updated), 0o644, root)
 }
 
 func canonicalManagedBlock(begin, end, body string) string {

--- a/internal/install/managed_block_test.go
+++ b/internal/install/managed_block_test.go
@@ -24,7 +24,7 @@ func TestUpsertRejectsOrphanedEndMarker(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := upsertManagedBlock(path, testBegin, testEnd, testBody)
+	err := upsertManagedBlock(path, testBegin, testEnd, testBody, filepath.Dir(path))
 	if err == nil {
 		t.Fatal("expected error for orphaned end marker, got nil")
 	}
@@ -47,7 +47,7 @@ func TestUpsertRejectsDuplicateMarkers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := upsertManagedBlock(path, testBegin, testEnd, testBody)
+	err := upsertManagedBlock(path, testBegin, testEnd, testBody, filepath.Dir(path))
 	if err == nil {
 		t.Fatal("expected error for duplicate markers, got nil")
 	}
@@ -70,7 +70,7 @@ func TestRemoveRejectsOrphanedEndMarker(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := removeManagedBlock(path, testBegin, testEnd)
+	err := removeManagedBlock(path, testBegin, testEnd, filepath.Dir(path))
 	if err == nil {
 		t.Fatal("expected error for orphaned end marker, got nil")
 	}
@@ -93,7 +93,7 @@ func TestRemoveRejectsDuplicateMarkers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := removeManagedBlock(path, testBegin, testEnd)
+	err := removeManagedBlock(path, testBegin, testEnd, filepath.Dir(path))
 	if err == nil {
 		t.Fatal("expected error for duplicate markers, got nil")
 	}
@@ -117,7 +117,7 @@ func TestUpsertRejectsGluedBeginMarker(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := upsertManagedBlock(path, testBegin, testEnd, testBody)
+	err := upsertManagedBlock(path, testBegin, testEnd, testBody, filepath.Dir(path))
 	if err == nil {
 		t.Fatal("expected error for glued begin marker, got nil")
 	}
@@ -141,7 +141,7 @@ func TestUpsertRejectsGluedEndMarker(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := upsertManagedBlock(path, testBegin, testEnd, testBody)
+	err := upsertManagedBlock(path, testBegin, testEnd, testBody, filepath.Dir(path))
 	if err == nil {
 		t.Fatal("expected error for glued end marker, got nil")
 	}
@@ -167,7 +167,7 @@ func TestUpsertAcceptsBeginAtFileStart(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := upsertManagedBlock(path, testBegin, testEnd, testBody)
+	err := upsertManagedBlock(path, testBegin, testEnd, testBody, filepath.Dir(path))
 	if err != nil {
 		t.Fatalf("unexpected error for valid topology: %v", err)
 	}
@@ -183,7 +183,7 @@ func TestUpsertAcceptsEndAtEOF(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := upsertManagedBlock(path, testBegin, testEnd, testBody)
+	err := upsertManagedBlock(path, testBegin, testEnd, testBody, filepath.Dir(path))
 	if err != nil {
 		t.Fatalf("unexpected error for valid topology: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestUpsertAcceptsBeginOnlyWithLineStart(t *testing.T) {
 	}
 
 	// Should self-heal: replace from begin to EOF with canonical block
-	err := upsertManagedBlock(path, testBegin, testEnd, testBody)
+	err := upsertManagedBlock(path, testBegin, testEnd, testBody, filepath.Dir(path))
 	if err != nil {
 		t.Fatalf("expected self-heal for begin-without-end, got error: %v", err)
 	}
@@ -220,7 +220,7 @@ func TestUpsertSelfHealsBeginWithoutEnd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := upsertManagedBlock(path, testBegin, testEnd, testBody)
+	err := upsertManagedBlock(path, testBegin, testEnd, testBody, filepath.Dir(path))
 	if err != nil {
 		t.Fatalf("expected self-heal, got error: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestRemoveSelfHealsBeginWithoutEnd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := removeManagedBlock(path, testBegin, testEnd)
+	err := removeManagedBlock(path, testBegin, testEnd, filepath.Dir(path))
 	if err != nil {
 		t.Fatalf("expected self-heal, got error: %v", err)
 	}
@@ -276,7 +276,7 @@ func TestUpsertRejectsReversedMarkers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := upsertManagedBlock(path, testBegin, testEnd, testBody)
+	err := upsertManagedBlock(path, testBegin, testEnd, testBody, filepath.Dir(path))
 	if err == nil {
 		t.Fatal("expected error for reversed markers, got nil")
 	}
@@ -299,7 +299,7 @@ func TestRemoveRejectsReversedMarkers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := removeManagedBlock(path, testBegin, testEnd)
+	err := removeManagedBlock(path, testBegin, testEnd, filepath.Dir(path))
 	if err == nil {
 		t.Fatal("expected error for reversed markers, got nil")
 	}
@@ -325,10 +325,10 @@ func TestRoundTripNewlineBehavior(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := upsertManagedBlock(path, testBegin, testEnd, testBody); err != nil {
+		if err := upsertManagedBlock(path, testBegin, testEnd, testBody, filepath.Dir(path)); err != nil {
 			t.Fatalf("install failed: %v", err)
 		}
-		if err := removeManagedBlock(path, testBegin, testEnd); err != nil {
+		if err := removeManagedBlock(path, testBegin, testEnd, filepath.Dir(path)); err != nil {
 			t.Fatalf("uninstall failed: %v", err)
 		}
 
@@ -347,10 +347,10 @@ func TestRoundTripNewlineBehavior(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := upsertManagedBlock(path, testBegin, testEnd, testBody); err != nil {
+		if err := upsertManagedBlock(path, testBegin, testEnd, testBody, filepath.Dir(path)); err != nil {
 			t.Fatalf("install failed: %v", err)
 		}
-		if err := removeManagedBlock(path, testBegin, testEnd); err != nil {
+		if err := removeManagedBlock(path, testBegin, testEnd, filepath.Dir(path)); err != nil {
 			t.Fatalf("uninstall failed: %v", err)
 		}
 
@@ -378,7 +378,7 @@ func TestUpsertAcceptsCRLFLineEndings(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := upsertManagedBlock(path, testBegin, testEnd, testBody)
+	err := upsertManagedBlock(path, testBegin, testEnd, testBody, filepath.Dir(path))
 	if err != nil {
 		t.Fatalf("CRLF file should be accepted: %v", err)
 	}
@@ -410,7 +410,7 @@ func TestRemoveAcceptsCRLFLineEndings(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := removeManagedBlock(path, testBegin, testEnd)
+	err := removeManagedBlock(path, testBegin, testEnd, filepath.Dir(path))
 	if err != nil {
 		t.Fatalf("CRLF file should be accepted: %v", err)
 	}
@@ -433,7 +433,7 @@ func TestTopologyRejectsGluedBeginEvenWithCR(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := upsertManagedBlock(path, testBegin, testEnd, testBody)
+	err := upsertManagedBlock(path, testBegin, testEnd, testBody, filepath.Dir(path))
 	if err == nil {
 		t.Fatal("expected error for begin marker after bare \\r, got nil")
 	}

--- a/internal/install/safe_io.go
+++ b/internal/install/safe_io.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
+
+	"github.com/seungpyoson/waggle/internal/fsutil"
 )
 
 func safeWriteFile(path string, data []byte, perm os.FileMode, root string) error {
-	if hasAncestorSymlink(path, root) {
+	if fsutil.HasAncestorSymlink(path, root) {
 		return fmt.Errorf("refusing to write through ancestor symlink: %s", path)
 	}
 	if info, err := os.Lstat(path); err == nil {
@@ -25,7 +26,7 @@ func safeWriteFile(path string, data []byte, perm os.FileMode, root string) erro
 }
 
 func safeRemove(path string, root string) error {
-	if hasAncestorSymlink(path, root) {
+	if fsutil.HasAncestorSymlink(path, root) {
 		return fmt.Errorf("refusing to remove through ancestor symlink: %s", path)
 	}
 	if info, err := os.Lstat(path); err == nil {
@@ -39,7 +40,7 @@ func safeRemove(path string, root string) error {
 }
 
 func safeRemoveAll(path string, root string) error {
-	if hasAncestorSymlink(path, root) {
+	if fsutil.HasAncestorSymlink(path, root) {
 		return fmt.Errorf("refusing to remove through ancestor symlink: %s", path)
 	}
 	if info, err := os.Lstat(path); err == nil {
@@ -53,7 +54,7 @@ func safeRemoveAll(path string, root string) error {
 }
 
 func safeMkdirAll(path string, root string, perm os.FileMode) error {
-	if hasAncestorSymlink(path, root) {
+	if fsutil.HasAncestorSymlink(path, root) {
 		return fmt.Errorf("refusing to create path with ancestor symlink: %s", path)
 	}
 	return os.MkdirAll(path, perm)
@@ -70,6 +71,7 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	tmpName := tmp.Name()
 	defer func() {
 		if tmpName != "" {
+			// Best-effort cleanup: the temp path is unreachable once the write returns.
 			os.Remove(tmpName)
 		}
 	}()
@@ -93,30 +95,4 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	}
 	tmpName = ""
 	return nil
-}
-
-// hasAncestorSymlink checks whether any directory component between root and path
-// is a symlink. Only checks components below root to avoid false positives on
-// system-level symlinks (e.g., /var → /private/var on macOS).
-func hasAncestorSymlink(path, root string) bool {
-	root = filepath.Clean(root)
-	path = filepath.Clean(path)
-	rel, err := filepath.Rel(root, path)
-	if err != nil {
-		return false
-	}
-	if strings.HasPrefix(rel, "..") {
-		return true
-	}
-	current := root
-	for _, part := range strings.Split(filepath.Dir(rel), string(filepath.Separator)) {
-		if part == "." {
-			continue
-		}
-		current = filepath.Join(current, part)
-		if info, err := os.Lstat(current); err == nil && info.Mode()&os.ModeSymlink != 0 {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/install/safe_io.go
+++ b/internal/install/safe_io.go
@@ -1,0 +1,122 @@
+package install
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func safeWriteFile(path string, data []byte, perm os.FileMode, root string) error {
+	if hasAncestorSymlink(path, root) {
+		return fmt.Errorf("refusing to write through ancestor symlink: %s", path)
+	}
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to overwrite symlink: %s", path)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("lstat %s: %w", path, err)
+	}
+	if err := atomicWriteFile(path, data, perm); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func safeRemove(path string, root string) error {
+	if hasAncestorSymlink(path, root) {
+		return fmt.Errorf("refusing to remove through ancestor symlink: %s", path)
+	}
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to remove symlink: %s", path)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("lstat %s: %w", path, err)
+	}
+	return os.Remove(path)
+}
+
+func safeRemoveAll(path string, root string) error {
+	if hasAncestorSymlink(path, root) {
+		return fmt.Errorf("refusing to remove through ancestor symlink: %s", path)
+	}
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to remove symlink: %s", path)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("lstat %s: %w", path, err)
+	}
+	return os.RemoveAll(path)
+}
+
+func safeMkdirAll(path string, root string, perm os.FileMode) error {
+	if hasAncestorSymlink(path, root) {
+		return fmt.Errorf("refusing to create path with ancestor symlink: %s", path)
+	}
+	return os.MkdirAll(path, perm)
+}
+
+// atomicWriteFile writes data to path atomically via temp+rename.
+// Prevents TOCTOU attacks where the target is swapped between check and write.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".waggle-tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		if tmpName != "" {
+			os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("sync temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		return fmt.Errorf("chmod temp: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename temp: %w", err)
+	}
+	tmpName = ""
+	return nil
+}
+
+// hasAncestorSymlink checks whether any directory component between root and path
+// is a symlink. Only checks components below root to avoid false positives on
+// system-level symlinks (e.g., /var → /private/var on macOS).
+func hasAncestorSymlink(path, root string) bool {
+	root = filepath.Clean(root)
+	path = filepath.Clean(path)
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	if strings.HasPrefix(rel, "..") {
+		return true
+	}
+	current := root
+	for _, part := range strings.Split(filepath.Dir(rel), string(filepath.Separator)) {
+		if part == "." {
+			continue
+		}
+		current = filepath.Join(current, part)
+		if info, err := os.Lstat(current); err == nil && info.Mode()&os.ModeSymlink != 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/install/shell-hook/shell-hook.sh
+++ b/internal/install/shell-hook/shell-hook.sh
@@ -1,20 +1,29 @@
 # waggle shell-hook — surfaces messages on every agent command.
 # Sourced from .zshenv/.bashrc. Each agent tool call = new shell = fresh source.
-# Cost when no messages: 1 file stat (~ns). Guarded by PPID mapping.
+# Uses WAGGLE_AGENT_PPID (set by agent process, inherited by child shells) for
+# session identity; falls back to $PPID (correct when agent spawns shells directly).
 __waggle_check() {
     local _wd="$HOME/.waggle/runtime"
-    local _wm="$_wd/agent-ppid-$PPID"
-    [ -f "$_wm" ] || return 0
+    local _apid="${WAGGLE_AGENT_PPID:-$PPID}"
+    local _pm="$_wd/agent-ppid-$_apid"
+    [ -f "$_pm" ] || return 0
+    local _nonce
+    read -r _nonce < "$_pm" 2>/dev/null || return 0
+    [ -n "$_nonce" ] || return 0
+    local _sm="$_wd/agent-session-$_nonce"
+    [ -f "$_sm" ] || return 0
     local _wa _wp
-    { read -r _wa; read -r _wp; } < "$_wm" 2>/dev/null || return 0
+    { read -r _wa; read -r _wp; } < "$_sm" 2>/dev/null || return 0
     [ -n "$_wa" ] || return 0
     local _ws="$_wd/signals/$_wp/$_wa"
-    [ -f "$_ws" ] || return 0
-    # Atomic: rename then read. If daemon writes after mv, new file at original path.
-    local _wt="$_ws.c-$$"
-    mv "$_ws" "$_wt" 2>/dev/null || return 0
-    cat "$_wt" >&2 2>/dev/null
-    rm -f "$_wt" 2>/dev/null
-    touch "$_wm" 2>/dev/null
+    if [ -f "$_ws" ]; then
+        # Atomic: rename then read. If daemon writes after mv, new file at original path.
+        local _wt="$_ws.c-$$"
+        if mv "$_ws" "$_wt" 2>/dev/null; then
+            cat "$_wt" >&2 2>/dev/null
+            rm -f "$_wt" 2>/dev/null
+        fi
+    fi
+    touch "$_sm" 2>/dev/null
 }
 __waggle_check

--- a/internal/install/shell-hook/shell-hook.sh
+++ b/internal/install/shell-hook/shell-hook.sh
@@ -16,6 +16,15 @@ __waggle_check() {
     { read -r _wa; read -r _wp; } < "$_sm" 2>/dev/null || return 0
     [ -n "$_wa" ] || return 0
     local _ws="$_wd/signals/$_wp/$_wa"
+    if [ -n "${ZSH_VERSION-}" ]; then
+        setopt localoptions nonomatch
+    fi
+    local _orphan
+    for _orphan in "$_ws".c-*; do
+        [ -f "$_orphan" ] || continue
+        cat "$_orphan" >&2 2>/dev/null
+        rm -f "$_orphan" 2>/dev/null
+    done
     if [ -f "$_ws" ]; then
         # Atomic: rename then read. If daemon writes after mv, new file at original path.
         local _wt="$_ws.c-$$"
@@ -24,6 +33,7 @@ __waggle_check() {
             rm -f "$_wt" 2>/dev/null
         fi
     fi
-    touch "$_sm" 2>/dev/null
+    touch "$_sm" "$_pm" 2>/dev/null
 }
 __waggle_check
+unset -f __waggle_check 2>/dev/null

--- a/internal/install/shell-hook/shell-hook.sh
+++ b/internal/install/shell-hook/shell-hook.sh
@@ -5,15 +5,16 @@ __waggle_check() {
     local _wd="$HOME/.waggle/runtime"
     local _wm="$_wd/agent-ppid-$PPID"
     [ -f "$_wm" ] || return 0
-    local _wa
-    read -r _wa < "$_wm" 2>/dev/null || return 0
+    local _wa _wp
+    { read -r _wa; read -r _wp; } < "$_wm" 2>/dev/null || return 0
     [ -n "$_wa" ] || return 0
-    local _ws="$_wd/signals/$_wa"
+    local _ws="$_wd/signals/$_wp/$_wa"
     [ -f "$_ws" ] || return 0
     # Atomic: rename then read. If daemon writes after mv, new file at original path.
     local _wt="$_ws.c-$$"
     mv "$_ws" "$_wt" 2>/dev/null || return 0
     cat "$_wt" >&2 2>/dev/null
     rm -f "$_wt" 2>/dev/null
+    touch "$_wm" 2>/dev/null
 }
 __waggle_check

--- a/internal/install/shell-hook/shell-hook.sh
+++ b/internal/install/shell-hook/shell-hook.sh
@@ -5,6 +5,7 @@
 __waggle_check() {
     local _wd="$HOME/.waggle/runtime"
     local _apid="${WAGGLE_AGENT_PPID:-$PPID}"
+    case "$_apid" in *[!0-9]*) return 0 ;; esac
     local _pm="$_wd/agent-ppid-$_apid"
     [ -f "$_pm" ] || return 0
     local _nonce
@@ -15,6 +16,9 @@ __waggle_check() {
     local _wa _wp
     { read -r _wa; read -r _wp; } < "$_sm" 2>/dev/null || return 0
     [ -n "$_wa" ] || return 0
+    [ -n "$_wp" ] || return 0
+    case "$_wa" in *[!A-Za-z0-9_-]*) return 0 ;; esac
+    case "$_wp" in *[!A-Za-z0-9_-]*) return 0 ;; esac
     local _ws="$_wd/signals/$_wp/$_wa"
     if [ -n "${ZSH_VERSION-}" ]; then
         setopt localoptions nonomatch

--- a/internal/install/shell-hook/shell-hook.sh
+++ b/internal/install/shell-hook/shell-hook.sh
@@ -16,6 +16,12 @@ __waggle_check() {
     { read -r _wa; read -r _wp; } < "$_sm" 2>/dev/null || return 0
     [ -n "$_wa" ] || return 0
     local _ws="$_wd/signals/$_wp/$_wa"
+    # Recover orphaned .c-* files from crashed consumers
+    for _orphan in "$_ws".c-*; do
+        [ -f "$_orphan" ] || continue
+        cat "$_orphan" >&2 2>/dev/null
+        rm -f "$_orphan" 2>/dev/null
+    done
     if [ -f "$_ws" ]; then
         # Atomic: rename then read. If daemon writes after mv, new file at original path.
         local _wt="$_ws.c-$$"
@@ -24,6 +30,6 @@ __waggle_check() {
             rm -f "$_wt" 2>/dev/null
         fi
     fi
-    touch "$_sm" 2>/dev/null
+    touch "$_sm" "$_pm" 2>/dev/null
 }
 __waggle_check

--- a/internal/install/shell-hook/shell-hook.sh
+++ b/internal/install/shell-hook/shell-hook.sh
@@ -16,12 +16,6 @@ __waggle_check() {
     { read -r _wa; read -r _wp; } < "$_sm" 2>/dev/null || return 0
     [ -n "$_wa" ] || return 0
     local _ws="$_wd/signals/$_wp/$_wa"
-    # Recover orphaned .c-* files from crashed consumers
-    for _orphan in "$_ws".c-*; do
-        [ -f "$_orphan" ] || continue
-        cat "$_orphan" >&2 2>/dev/null
-        rm -f "$_orphan" 2>/dev/null
-    done
     if [ -f "$_ws" ]; then
         # Atomic: rename then read. If daemon writes after mv, new file at original path.
         local _wt="$_ws.c-$$"
@@ -30,6 +24,6 @@ __waggle_check() {
             rm -f "$_wt" 2>/dev/null
         fi
     fi
-    touch "$_sm" "$_pm" 2>/dev/null
+    touch "$_sm" 2>/dev/null
 }
 __waggle_check

--- a/internal/install/shell-hook/shell-hook.sh
+++ b/internal/install/shell-hook/shell-hook.sh
@@ -1,0 +1,19 @@
+# waggle shell-hook — surfaces messages on every agent command.
+# Sourced from .zshenv/.bashrc. Each agent tool call = new shell = fresh source.
+# Cost when no messages: 1 file stat (~ns). Guarded by PPID mapping.
+__waggle_check() {
+    local _wd="$HOME/.waggle/runtime"
+    local _wm="$_wd/agent-ppid-$PPID"
+    [ -f "$_wm" ] || return 0
+    local _wa
+    read -r _wa < "$_wm" 2>/dev/null || return 0
+    [ -n "$_wa" ] || return 0
+    local _ws="$_wd/signals/$_wa"
+    [ -f "$_ws" ] || return 0
+    # Atomic: rename then read. If daemon writes after mv, new file at original path.
+    local _wt="$_ws.c-$$"
+    mv "$_ws" "$_wt" 2>/dev/null || return 0
+    cat "$_wt" >&2 2>/dev/null
+    rm -f "$_wt" 2>/dev/null
+}
+__waggle_check

--- a/internal/install/shell_hook.go
+++ b/internal/install/shell_hook.go
@@ -1,0 +1,107 @@
+package install
+
+import (
+	"embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+//go:embed shell-hook/shell-hook.sh
+var shellHookFS embed.FS
+
+const (
+	shellHookBegin = "# <!-- WAGGLE-SHELL-HOOK-BEGIN -->"
+	shellHookEnd   = "# <!-- WAGGLE-SHELL-HOOK-END -->"
+)
+
+var shellHookBlock = strings.Join([]string{
+	shellHookBegin,
+	`[ -f "$HOME/.waggle/shell-hook.sh" ] && source "$HOME/.waggle/shell-hook.sh"`,
+	`export BASH_ENV="$HOME/.waggle/shell-hook.sh"`,
+	shellHookEnd,
+}, "\n")
+
+// InstallShellHook installs the universal shell hook.
+func InstallShellHook() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	return installShellHook(home)
+}
+
+// UninstallShellHook removes the shell hook.
+func UninstallShellHook() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	return uninstallShellHook(home)
+}
+
+func installShellHook(homeDir string) error {
+	waggleDir := filepath.Join(homeDir, ".waggle")
+	if err := os.MkdirAll(waggleDir, 0o700); err != nil {
+		return fmt.Errorf("create dir: %w", err)
+	}
+	hookData, err := shellHookFS.ReadFile("shell-hook/shell-hook.sh")
+	if err != nil {
+		return fmt.Errorf("read embedded hook: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(waggleDir, "shell-hook.sh"), hookData, 0o644); err != nil {
+		return fmt.Errorf("write hook: %w", err)
+	}
+	for _, rc := range []string{".zshenv", ".bashrc"} {
+		if err := upsertShellHookBlock(filepath.Join(homeDir, rc)); err != nil {
+			return fmt.Errorf("update %s: %w", rc, err)
+		}
+	}
+	return nil
+}
+
+func uninstallShellHook(homeDir string) error {
+	for _, rc := range []string{".zshenv", ".bashrc"} {
+		removeShellHookBlock(filepath.Join(homeDir, rc))
+	}
+	os.Remove(filepath.Join(homeDir, ".waggle", "shell-hook.sh"))
+	return nil
+}
+
+func upsertShellHookBlock(path string) error {
+	existing, _ := os.ReadFile(path)
+	content := string(existing)
+	if strings.Contains(content, shellHookBegin) {
+		return nil // already present
+	}
+	if len(content) > 0 && !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	content += shellHookBlock + "\n"
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+func removeShellHookBlock(path string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	lines := strings.Split(string(data), "\n")
+	var filtered []string
+	inBlock := false
+	for _, line := range lines {
+		if strings.Contains(line, "WAGGLE-SHELL-HOOK-BEGIN") {
+			inBlock = true
+			continue
+		}
+		if strings.Contains(line, "WAGGLE-SHELL-HOOK-END") {
+			inBlock = false
+			continue
+		}
+		if !inBlock {
+			filtered = append(filtered, line)
+		}
+	}
+	os.WriteFile(path, []byte(strings.Join(filtered, "\n")), 0o644)
+}

--- a/internal/install/shell_hook.go
+++ b/internal/install/shell_hook.go
@@ -3,9 +3,12 @@ package install
 import (
 	"embed"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/seungpyoson/waggle/internal/fsutil"
 )
 
 //go:embed shell-hook/shell-hook.sh
@@ -64,9 +67,14 @@ func installShellHook(homeDir string) error {
 
 func uninstallShellHook(homeDir string) error {
 	for _, rc := range []string{".zshenv", ".bashrc"} {
-		removeShellHookBlock(filepath.Join(homeDir, rc), homeDir)
+		path := filepath.Join(homeDir, rc)
+		if err := removeShellHookBlock(path, homeDir); err != nil {
+			log.Printf("warning: remove shell hook block from %q: %v", path, err)
+		}
 	}
-	_ = safeRemove(filepath.Join(homeDir, ".waggle", "shell-hook.sh"), homeDir)
+	if err := safeRemove(filepath.Join(homeDir, ".waggle", "shell-hook.sh"), homeDir); err != nil && !os.IsNotExist(err) {
+		log.Printf("warning: remove shell hook script: %v", err)
+	}
 	return nil
 }
 
@@ -75,11 +83,14 @@ func upsertShellHookBlock(path, homeDir string) error {
 	if linfo, err := os.Lstat(path); err == nil && linfo.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("refusing to modify symlink: %s", path)
 	}
-	if hasAncestorSymlink(path, homeDir) {
+	if fsutil.HasAncestorSymlink(path, homeDir) {
 		return fmt.Errorf("refusing to modify path with ancestor symlink: %s", path)
 	}
 
-	existing, _ := os.ReadFile(path)
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
 	content := string(existing)
 	if strings.Contains(content, shellHookBegin) {
 		return nil // already present
@@ -98,25 +109,30 @@ func upsertShellHookBlock(path, homeDir string) error {
 	return safeWriteFile(path, []byte(content), perm, homeDir)
 }
 
-func removeShellHookBlock(path, homeDir string) {
+func removeShellHookBlock(path, homeDir string) error {
 	// Refuse to follow symlinks.
 	if linfo, err := os.Lstat(path); err == nil && linfo.Mode()&os.ModeSymlink != 0 {
-		return
+		return fmt.Errorf("refusing to modify symlink: %s", path)
 	}
-	if hasAncestorSymlink(path, homeDir) {
-		return
+	if fsutil.HasAncestorSymlink(path, homeDir) {
+		return fmt.Errorf("refusing to modify path with ancestor symlink: %s", path)
 	}
 
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read %s: %w", path, err)
 	}
 
 	// Preserve original file permissions.
 	perm := os.FileMode(0o644)
-	if info, err := os.Stat(path); err == nil {
-		perm = info.Mode().Perm()
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", path, err)
 	}
+	perm = info.Mode().Perm()
 
 	lines := strings.Split(string(data), "\n")
 	var filtered []string
@@ -134,5 +150,7 @@ func removeShellHookBlock(path, homeDir string) {
 			filtered = append(filtered, line)
 		}
 	}
-	_ = safeWriteFile(path, []byte(strings.Join(filtered, "\n")), perm, homeDir)
+	// Uninstall stays best-effort: if rewriting the filtered file fails, leave the
+	// user's rc file untouched and continue removing the rest of the hook artifacts.
+	return safeWriteFile(path, []byte(strings.Join(filtered, "\n")), perm, homeDir)
 }

--- a/internal/install/shell_hook.go
+++ b/internal/install/shell_hook.go
@@ -18,6 +18,7 @@ const (
 
 var shellHookBlock = strings.Join([]string{
 	shellHookBegin,
+	`export WAGGLE_AGENT_PPID="${WAGGLE_AGENT_PPID:-$PPID}"`,
 	`[ -f "$HOME/.waggle/shell-hook.sh" ] && source "$HOME/.waggle/shell-hook.sh"`,
 	`export BASH_ENV="$HOME/.waggle/shell-hook.sh"`,
 	shellHookEnd,

--- a/internal/install/shell_hook.go
+++ b/internal/install/shell_hook.go
@@ -70,23 +70,47 @@ func uninstallShellHook(homeDir string) error {
 }
 
 func upsertShellHookBlock(path string) error {
+	// Refuse to follow symlinks — prevents write-through attacks.
+	if linfo, err := os.Lstat(path); err == nil && linfo.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to modify symlink: %s", path)
+	}
+
 	existing, _ := os.ReadFile(path)
 	content := string(existing)
 	if strings.Contains(content, shellHookBegin) {
 		return nil // already present
 	}
+
+	// Preserve original file permissions; default 0644 for new files.
+	perm := os.FileMode(0o644)
+	if info, err := os.Stat(path); err == nil {
+		perm = info.Mode().Perm()
+	}
+
 	if len(content) > 0 && !strings.HasSuffix(content, "\n") {
 		content += "\n"
 	}
 	content += shellHookBlock + "\n"
-	return os.WriteFile(path, []byte(content), 0o644)
+	return os.WriteFile(path, []byte(content), perm)
 }
 
 func removeShellHookBlock(path string) {
+	// Refuse to follow symlinks.
+	if linfo, err := os.Lstat(path); err == nil && linfo.Mode()&os.ModeSymlink != 0 {
+		return
+	}
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return
 	}
+
+	// Preserve original file permissions.
+	perm := os.FileMode(0o644)
+	if info, err := os.Stat(path); err == nil {
+		perm = info.Mode().Perm()
+	}
+
 	lines := strings.Split(string(data), "\n")
 	var filtered []string
 	inBlock := false
@@ -103,5 +127,5 @@ func removeShellHookBlock(path string) {
 			filtered = append(filtered, line)
 		}
 	}
-	os.WriteFile(path, []byte(strings.Join(filtered, "\n")), 0o644)
+	os.WriteFile(path, []byte(strings.Join(filtered, "\n")), perm)
 }

--- a/internal/install/shell_hook.go
+++ b/internal/install/shell_hook.go
@@ -18,6 +18,7 @@ const (
 
 var shellHookBlock = strings.Join([]string{
 	shellHookBegin,
+	`export WAGGLE_AGENT_PPID="${WAGGLE_AGENT_PPID:-$PPID}"`,
 	`[ -f "$HOME/.waggle/shell-hook.sh" ] && source "$HOME/.waggle/shell-hook.sh"`,
 	`export BASH_ENV="$HOME/.waggle/shell-hook.sh"`,
 	shellHookEnd,
@@ -54,11 +55,14 @@ func installShellHook(homeDir string) error {
 	if info, err := os.Lstat(hookPath); err == nil && info.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("refusing to overwrite symlink: %s", hookPath)
 	}
-	if err := os.WriteFile(hookPath, hookData, 0o644); err != nil {
+	if hasAncestorSymlink(hookPath, homeDir) {
+		return fmt.Errorf("refusing to write through ancestor symlink: %s", hookPath)
+	}
+	if err := atomicWriteFile(hookPath, hookData, 0o644); err != nil {
 		return fmt.Errorf("write hook: %w", err)
 	}
 	for _, rc := range []string{".zshenv", ".bashrc"} {
-		if err := upsertShellHookBlock(filepath.Join(homeDir, rc)); err != nil {
+		if err := upsertShellHookBlock(filepath.Join(homeDir, rc), homeDir); err != nil {
 			return fmt.Errorf("update %s: %w", rc, err)
 		}
 	}
@@ -67,16 +71,19 @@ func installShellHook(homeDir string) error {
 
 func uninstallShellHook(homeDir string) error {
 	for _, rc := range []string{".zshenv", ".bashrc"} {
-		removeShellHookBlock(filepath.Join(homeDir, rc))
+		removeShellHookBlock(filepath.Join(homeDir, rc), homeDir)
 	}
 	os.Remove(filepath.Join(homeDir, ".waggle", "shell-hook.sh"))
 	return nil
 }
 
-func upsertShellHookBlock(path string) error {
+func upsertShellHookBlock(path, homeDir string) error {
 	// Refuse to follow symlinks — prevents write-through attacks.
 	if linfo, err := os.Lstat(path); err == nil && linfo.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("refusing to modify symlink: %s", path)
+	}
+	if hasAncestorSymlink(path, homeDir) {
+		return fmt.Errorf("refusing to modify path with ancestor symlink: %s", path)
 	}
 
 	existing, _ := os.ReadFile(path)
@@ -95,12 +102,15 @@ func upsertShellHookBlock(path string) error {
 		content += "\n"
 	}
 	content += shellHookBlock + "\n"
-	return os.WriteFile(path, []byte(content), perm)
+	return atomicWriteFile(path, []byte(content), perm)
 }
 
-func removeShellHookBlock(path string) {
+func removeShellHookBlock(path, homeDir string) {
 	// Refuse to follow symlinks.
 	if linfo, err := os.Lstat(path); err == nil && linfo.Mode()&os.ModeSymlink != 0 {
+		return
+	}
+	if hasAncestorSymlink(path, homeDir) {
 		return
 	}
 
@@ -131,5 +141,68 @@ func removeShellHookBlock(path string) {
 			filtered = append(filtered, line)
 		}
 	}
-	os.WriteFile(path, []byte(strings.Join(filtered, "\n")), perm)
+	_ = atomicWriteFile(path, []byte(strings.Join(filtered, "\n")), perm)
+}
+
+// atomicWriteFile writes data to path atomically via temp+rename.
+// Prevents TOCTOU attacks where the target is swapped between check and write.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".waggle-tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		if tmpName != "" {
+			os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("sync temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		return fmt.Errorf("chmod temp: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename temp: %w", err)
+	}
+	tmpName = "" // success — don't remove in defer
+	return nil
+}
+
+// hasAncestorSymlink checks whether any directory component between root and path
+// is a symlink. Only checks components below root to avoid false positives on
+// system-level symlinks (e.g., /var → /private/var on macOS).
+func hasAncestorSymlink(path, root string) bool {
+	root = filepath.Clean(root)
+	path = filepath.Clean(path)
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	// Reject paths that escape root via ".." components.
+	if strings.HasPrefix(rel, "..") {
+		return true
+	}
+	current := root
+	for _, part := range strings.Split(filepath.Dir(rel), string(filepath.Separator)) {
+		if part == "." {
+			continue
+		}
+		current = filepath.Join(current, part)
+		if info, err := os.Lstat(current); err == nil && info.Mode()&os.ModeSymlink != 0 {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/install/shell_hook.go
+++ b/internal/install/shell_hook.go
@@ -18,7 +18,6 @@ const (
 
 var shellHookBlock = strings.Join([]string{
 	shellHookBegin,
-	`export WAGGLE_AGENT_PPID="${WAGGLE_AGENT_PPID:-$PPID}"`,
 	`[ -f "$HOME/.waggle/shell-hook.sh" ] && source "$HOME/.waggle/shell-hook.sh"`,
 	`export BASH_ENV="$HOME/.waggle/shell-hook.sh"`,
 	shellHookEnd,
@@ -44,7 +43,7 @@ func UninstallShellHook() error {
 
 func installShellHook(homeDir string) error {
 	waggleDir := filepath.Join(homeDir, ".waggle")
-	if err := os.MkdirAll(waggleDir, 0o700); err != nil {
+	if err := safeMkdirAll(waggleDir, homeDir, 0o700); err != nil {
 		return fmt.Errorf("create dir: %w", err)
 	}
 	hookData, err := shellHookFS.ReadFile("shell-hook/shell-hook.sh")
@@ -52,13 +51,7 @@ func installShellHook(homeDir string) error {
 		return fmt.Errorf("read embedded hook: %w", err)
 	}
 	hookPath := filepath.Join(waggleDir, "shell-hook.sh")
-	if info, err := os.Lstat(hookPath); err == nil && info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("refusing to overwrite symlink: %s", hookPath)
-	}
-	if hasAncestorSymlink(hookPath, homeDir) {
-		return fmt.Errorf("refusing to write through ancestor symlink: %s", hookPath)
-	}
-	if err := atomicWriteFile(hookPath, hookData, 0o644); err != nil {
+	if err := safeWriteFile(hookPath, hookData, 0o644, homeDir); err != nil {
 		return fmt.Errorf("write hook: %w", err)
 	}
 	for _, rc := range []string{".zshenv", ".bashrc"} {
@@ -73,7 +66,7 @@ func uninstallShellHook(homeDir string) error {
 	for _, rc := range []string{".zshenv", ".bashrc"} {
 		removeShellHookBlock(filepath.Join(homeDir, rc), homeDir)
 	}
-	os.Remove(filepath.Join(homeDir, ".waggle", "shell-hook.sh"))
+	_ = safeRemove(filepath.Join(homeDir, ".waggle", "shell-hook.sh"), homeDir)
 	return nil
 }
 
@@ -102,7 +95,7 @@ func upsertShellHookBlock(path, homeDir string) error {
 		content += "\n"
 	}
 	content += shellHookBlock + "\n"
-	return atomicWriteFile(path, []byte(content), perm)
+	return safeWriteFile(path, []byte(content), perm, homeDir)
 }
 
 func removeShellHookBlock(path, homeDir string) {
@@ -141,68 +134,5 @@ func removeShellHookBlock(path, homeDir string) {
 			filtered = append(filtered, line)
 		}
 	}
-	_ = atomicWriteFile(path, []byte(strings.Join(filtered, "\n")), perm)
-}
-
-// atomicWriteFile writes data to path atomically via temp+rename.
-// Prevents TOCTOU attacks where the target is swapped between check and write.
-func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, ".waggle-tmp-*")
-	if err != nil {
-		return fmt.Errorf("create temp: %w", err)
-	}
-	tmpName := tmp.Name()
-	defer func() {
-		if tmpName != "" {
-			os.Remove(tmpName)
-		}
-	}()
-
-	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		return fmt.Errorf("write temp: %w", err)
-	}
-	if err := tmp.Sync(); err != nil {
-		tmp.Close()
-		return fmt.Errorf("sync temp: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("close temp: %w", err)
-	}
-	if err := os.Chmod(tmpName, perm); err != nil {
-		return fmt.Errorf("chmod temp: %w", err)
-	}
-	if err := os.Rename(tmpName, path); err != nil {
-		return fmt.Errorf("rename temp: %w", err)
-	}
-	tmpName = "" // success — don't remove in defer
-	return nil
-}
-
-// hasAncestorSymlink checks whether any directory component between root and path
-// is a symlink. Only checks components below root to avoid false positives on
-// system-level symlinks (e.g., /var → /private/var on macOS).
-func hasAncestorSymlink(path, root string) bool {
-	root = filepath.Clean(root)
-	path = filepath.Clean(path)
-	rel, err := filepath.Rel(root, path)
-	if err != nil {
-		return false
-	}
-	// Reject paths that escape root via ".." components.
-	if strings.HasPrefix(rel, "..") {
-		return true
-	}
-	current := root
-	for _, part := range strings.Split(filepath.Dir(rel), string(filepath.Separator)) {
-		if part == "." {
-			continue
-		}
-		current = filepath.Join(current, part)
-		if info, err := os.Lstat(current); err == nil && info.Mode()&os.ModeSymlink != 0 {
-			return true
-		}
-	}
-	return false
+	_ = safeWriteFile(path, []byte(strings.Join(filtered, "\n")), perm, homeDir)
 }

--- a/internal/install/shell_hook.go
+++ b/internal/install/shell_hook.go
@@ -50,7 +50,11 @@ func installShellHook(homeDir string) error {
 	if err != nil {
 		return fmt.Errorf("read embedded hook: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(waggleDir, "shell-hook.sh"), hookData, 0o644); err != nil {
+	hookPath := filepath.Join(waggleDir, "shell-hook.sh")
+	if info, err := os.Lstat(hookPath); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to overwrite symlink: %s", hookPath)
+	}
+	if err := os.WriteFile(hookPath, hookData, 0o644); err != nil {
 		return fmt.Errorf("write hook: %w", err)
 	}
 	for _, rc := range []string{".zshenv", ".bashrc"} {

--- a/internal/install/shell_hook.go
+++ b/internal/install/shell_hook.go
@@ -18,7 +18,6 @@ const (
 
 var shellHookBlock = strings.Join([]string{
 	shellHookBegin,
-	`export WAGGLE_AGENT_PPID="${WAGGLE_AGENT_PPID:-$PPID}"`,
 	`[ -f "$HOME/.waggle/shell-hook.sh" ] && source "$HOME/.waggle/shell-hook.sh"`,
 	`export BASH_ENV="$HOME/.waggle/shell-hook.sh"`,
 	shellHookEnd,

--- a/internal/install/shell_hook_test.go
+++ b/internal/install/shell_hook_test.go
@@ -83,3 +83,118 @@ func TestUninstallShellHook_PreservesOtherContent(t *testing.T) {
 		t.Fatal("lost existing content")
 	}
 }
+
+func TestInstallShellHook_RejectsAncestorSymlink(t *testing.T) {
+	home := t.TempDir()
+	realDir := filepath.Join(home, ".waggle-real")
+	os.MkdirAll(realDir, 0o700)
+	os.Symlink(realDir, filepath.Join(home, ".waggle"))
+
+	err := installShellHook(home)
+	if err == nil {
+		t.Fatal("expected error for ancestor symlink, got nil")
+	}
+	if !strings.Contains(err.Error(), "ancestor symlink") {
+		t.Fatalf("expected ancestor symlink error, got: %v", err)
+	}
+}
+
+func TestAtomicWriteFile_BasicRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.txt")
+	content := []byte("hello world\n")
+	if err := atomicWriteFile(path, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("got %q, want %q", got, content)
+	}
+	info, _ := os.Stat(path)
+	if perm := info.Mode().Perm(); perm != 0o644 {
+		t.Fatalf("perm = %o, want 644", perm)
+	}
+}
+
+func TestAtomicWriteFile_NoTempLeftBehind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.txt")
+	atomicWriteFile(path, []byte("data"), 0o644)
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".waggle-tmp") {
+			t.Fatalf("temp file left behind: %s", e.Name())
+		}
+	}
+}
+
+func TestHasAncestorSymlink_DetectsSymlinkedParent(t *testing.T) {
+	base := t.TempDir()
+	realDir := filepath.Join(base, "real")
+	os.MkdirAll(realDir, 0o700)
+	linkDir := filepath.Join(base, "link")
+	os.Symlink(realDir, linkDir)
+
+	if !hasAncestorSymlink(filepath.Join(linkDir, "file.txt"), base) {
+		t.Fatal("should detect symlinked parent")
+	}
+}
+
+func TestHasAncestorSymlink_NoSymlink(t *testing.T) {
+	base := t.TempDir()
+	dir := filepath.Join(base, "subdir")
+	os.MkdirAll(dir, 0o700)
+	if hasAncestorSymlink(filepath.Join(dir, "file.txt"), base) {
+		t.Fatal("should not detect symlink in real dir")
+	}
+}
+
+func TestHasAncestorSymlink_RejectsPathEscapingRoot(t *testing.T) {
+	base := t.TempDir()
+	escaped := filepath.Join(base, "..", "etc", "passwd")
+	if !hasAncestorSymlink(escaped, base) {
+		t.Fatal("should reject path escaping root via ..")
+	}
+}
+
+func TestHasAncestorSymlink_DeeplyNestedSymlink(t *testing.T) {
+	base := t.TempDir()
+	realDir := filepath.Join(base, "real", "deep")
+	os.MkdirAll(realDir, 0o700)
+	os.MkdirAll(filepath.Join(base, "a"), 0o700)
+	os.Symlink(realDir, filepath.Join(base, "a", "link"))
+	if !hasAncestorSymlink(filepath.Join(base, "a", "link", "file.txt"), base) {
+		t.Fatal("should detect deeply nested symlink")
+	}
+}
+
+func TestUpsertShellHookBlock_RejectsLeafSymlink(t *testing.T) {
+	home := t.TempDir()
+	realFile := filepath.Join(home, ".real-zshenv")
+	os.WriteFile(realFile, []byte("# real\n"), 0o644)
+	os.Symlink(realFile, filepath.Join(home, ".zshenv"))
+
+	err := upsertShellHookBlock(filepath.Join(home, ".zshenv"), home)
+	if err == nil {
+		t.Fatal("expected error for leaf symlink")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink error, got: %v", err)
+	}
+}
+
+func TestAtomicWriteFile_OverwritesExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.txt")
+	os.WriteFile(path, []byte("old"), 0o644)
+	if err := atomicWriteFile(path, []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != "new" {
+		t.Fatalf("got %q, want %q", got, "new")
+	}
+}

--- a/internal/install/shell_hook_test.go
+++ b/internal/install/shell_hook_test.go
@@ -1,0 +1,85 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallShellHook_WritesScript(t *testing.T) {
+	home := t.TempDir()
+	if err := installShellHook(home); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".waggle", "shell-hook.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "__waggle_check") {
+		t.Fatal("missing function")
+	}
+}
+
+func TestInstallShellHook_ZshenvWithMarkers(t *testing.T) {
+	home := t.TempDir()
+	os.WriteFile(filepath.Join(home, ".zshenv"), []byte("# existing\n"), 0o644)
+	installShellHook(home)
+	data, _ := os.ReadFile(filepath.Join(home, ".zshenv"))
+	s := string(data)
+	if !strings.Contains(s, "WAGGLE-SHELL-HOOK-BEGIN") {
+		t.Fatal("missing begin marker")
+	}
+	if !strings.Contains(s, "WAGGLE-SHELL-HOOK-END") {
+		t.Fatal("missing end marker")
+	}
+	if !strings.Contains(s, "shell-hook.sh") {
+		t.Fatal("missing source line")
+	}
+	if !strings.Contains(s, "# existing") {
+		t.Fatal("lost existing content")
+	}
+}
+
+func TestInstallShellHook_BashrcWithMarkers(t *testing.T) {
+	home := t.TempDir()
+	os.WriteFile(filepath.Join(home, ".bashrc"), []byte("# bash\n"), 0o644)
+	installShellHook(home)
+	data, _ := os.ReadFile(filepath.Join(home, ".bashrc"))
+	if !strings.Contains(string(data), "WAGGLE-SHELL-HOOK-BEGIN") {
+		t.Fatal("missing marker in .bashrc")
+	}
+}
+
+func TestInstallShellHook_Idempotent(t *testing.T) {
+	home := t.TempDir()
+	installShellHook(home)
+	installShellHook(home)
+	data, _ := os.ReadFile(filepath.Join(home, ".zshenv"))
+	if strings.Count(string(data), "WAGGLE-SHELL-HOOK-BEGIN") != 1 {
+		t.Fatal("marker duplicated")
+	}
+}
+
+func TestUninstallShellHook_RemovesBlock(t *testing.T) {
+	home := t.TempDir()
+	installShellHook(home)
+	uninstallShellHook(home)
+	for _, f := range []string{".zshenv", ".bashrc"} {
+		data, _ := os.ReadFile(filepath.Join(home, f))
+		if strings.Contains(string(data), "waggle") {
+			t.Fatalf("%s still has waggle content", f)
+		}
+	}
+}
+
+func TestUninstallShellHook_PreservesOtherContent(t *testing.T) {
+	home := t.TempDir()
+	os.WriteFile(filepath.Join(home, ".zshenv"), []byte("# keep this\n"), 0o644)
+	installShellHook(home)
+	uninstallShellHook(home)
+	data, _ := os.ReadFile(filepath.Join(home, ".zshenv"))
+	if !strings.Contains(string(data), "# keep this") {
+		t.Fatal("lost existing content")
+	}
+}

--- a/internal/install/shell_hook_test.go
+++ b/internal/install/shell_hook_test.go
@@ -21,6 +21,22 @@ func TestInstallShellHook_WritesScript(t *testing.T) {
 	}
 }
 
+func TestShellHookBlock_OnlyExportsBashEnv(t *testing.T) {
+	want := strings.Join([]string{
+		shellHookBegin,
+		`[ -f "$HOME/.waggle/shell-hook.sh" ] && source "$HOME/.waggle/shell-hook.sh"`,
+		`export BASH_ENV="$HOME/.waggle/shell-hook.sh"`,
+		shellHookEnd,
+	}, "\n")
+
+	if shellHookBlock != want {
+		t.Fatalf("shellHookBlock = %q, want %q", shellHookBlock, want)
+	}
+	if strings.Contains(shellHookBlock, "WAGGLE_AGENT_PPID") {
+		t.Fatal("shellHookBlock should not export WAGGLE_AGENT_PPID")
+	}
+}
+
 func TestInstallShellHook_ZshenvWithMarkers(t *testing.T) {
 	home := t.TempDir()
 	os.WriteFile(filepath.Join(home, ".zshenv"), []byte("# existing\n"), 0o644)
@@ -38,6 +54,26 @@ func TestInstallShellHook_ZshenvWithMarkers(t *testing.T) {
 	}
 	if !strings.Contains(s, "# existing") {
 		t.Fatal("lost existing content")
+	}
+}
+
+func TestInstallShellHook_ScriptRefreshesBothMappings(t *testing.T) {
+	home := t.TempDir()
+	if err := installShellHook(home); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, ".waggle", "shell-hook.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, `touch "$_sm" "$_pm"`) {
+		t.Fatal("shell hook should refresh both session and pointer mappings")
+	}
+	if !strings.Contains(content, ".c-") {
+		t.Fatal("shell hook should handle consumed orphan files")
 	}
 }
 
@@ -196,5 +232,57 @@ func TestAtomicWriteFile_OverwritesExisting(t *testing.T) {
 	got, _ := os.ReadFile(path)
 	if string(got) != "new" {
 		t.Fatalf("got %q, want %q", got, "new")
+	}
+}
+
+func TestSafeWriteFile_RejectsLeafSymlink(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "target.txt")
+	if err := os.WriteFile(target, []byte("original"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(base, "link.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	err := safeWriteFile(link, []byte("mutated"), 0o644, base)
+	if err == nil {
+		t.Fatal("expected symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink error, got %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "original" {
+		t.Fatalf("target content = %q, want %q", got, "original")
+	}
+}
+
+func TestSafeRemoveAll_RejectsLeafSymlink(t *testing.T) {
+	base := t.TempDir()
+	targetDir := filepath.Join(base, "target")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(base, "link")
+	if err := os.Symlink(targetDir, link); err != nil {
+		t.Fatal(err)
+	}
+
+	err := safeRemoveAll(link, base)
+	if err == nil {
+		t.Fatal("expected symlink rejection")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink error, got %v", err)
+	}
+
+	if _, err := os.Stat(targetDir); err != nil {
+		t.Fatalf("target dir should remain: %v", err)
 	}
 }

--- a/internal/install/shell_hook_test.go
+++ b/internal/install/shell_hook_test.go
@@ -1,10 +1,14 @@
 package install
 
 import (
+	"bytes"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/seungpyoson/waggle/internal/fsutil"
 )
 
 func TestInstallShellHook_WritesScript(t *testing.T) {
@@ -18,6 +22,12 @@ func TestInstallShellHook_WritesScript(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "__waggle_check") {
 		t.Fatal("missing function")
+	}
+	if !strings.Contains(string(data), `case "$_apid" in`) {
+		t.Fatal("missing numeric PPID guard case")
+	}
+	if !strings.Contains(string(data), `*[!0-9]*) return 0 ;;`) {
+		t.Fatal("missing non-numeric PPID early return")
 	}
 }
 
@@ -77,6 +87,25 @@ func TestInstallShellHook_ScriptRefreshesBothMappings(t *testing.T) {
 	}
 }
 
+func TestInstallShellHook_ValidatesSessionTokens(t *testing.T) {
+	home := t.TempDir()
+	if err := installShellHook(home); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, ".waggle", "shell-hook.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.Contains(content, `case "$_wa" in *[!A-Za-z0-9_-]*) return 0 ;; esac`) {
+		t.Fatal("shell hook should validate agent token from session file")
+	}
+	if !strings.Contains(content, `case "$_wp" in *[!A-Za-z0-9_-]*) return 0 ;; esac`) {
+		t.Fatal("shell hook should validate project token from session file")
+	}
+}
+
 func TestInstallShellHook_BashrcWithMarkers(t *testing.T) {
 	home := t.TempDir()
 	os.WriteFile(filepath.Join(home, ".bashrc"), []byte("# bash\n"), 0o644)
@@ -94,6 +123,38 @@ func TestInstallShellHook_Idempotent(t *testing.T) {
 	data, _ := os.ReadFile(filepath.Join(home, ".zshenv"))
 	if strings.Count(string(data), "WAGGLE-SHELL-HOOK-BEGIN") != 1 {
 		t.Fatal("marker duplicated")
+	}
+}
+
+func TestUpsertShellHookBlock_ReturnsErrorOnUnreadableFile(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".zshenv")
+	const content = "# existing\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	err := upsertShellHookBlock(path, home)
+
+	if restoreErr := os.Chmod(path, 0o600); restoreErr != nil {
+		t.Fatalf("restore perms: %v", restoreErr)
+	}
+	if err == nil {
+		t.Fatal("expected read error for unreadable file")
+	}
+	if !strings.Contains(err.Error(), "read "+path) {
+		t.Fatalf("expected read error mentioning path, got %v", err)
+	}
+
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != content {
+		t.Fatalf("file content changed: got %q want %q", got, content)
 	}
 }
 
@@ -117,6 +178,73 @@ func TestUninstallShellHook_PreservesOtherContent(t *testing.T) {
 	data, _ := os.ReadFile(filepath.Join(home, ".zshenv"))
 	if !strings.Contains(string(data), "# keep this") {
 		t.Fatal("lost existing content")
+	}
+}
+
+func TestRemoveShellHookBlock_ReturnsErrorOnRewriteFailure(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".zshenv")
+	content := strings.Join([]string{
+		"# keep this",
+		shellHookBlock,
+		"",
+	}, "\n")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(home, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(home, 0o700)
+	})
+
+	err := removeShellHookBlock(path, home)
+	if err == nil {
+		t.Fatal("expected rewrite error, got nil")
+	}
+	if !strings.Contains(err.Error(), "write "+path) {
+		t.Fatalf("expected write error mentioning path, got %v", err)
+	}
+}
+
+func TestUninstallShellHook_LogsSafeRemoveWarningAndContinues(t *testing.T) {
+	home := t.TempDir()
+	waggleReal := filepath.Join(home, ".waggle-real")
+	if err := os.MkdirAll(waggleReal, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".zshenv"), []byte("# keep this\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(waggleReal, "shell-hook.sh"), []byte("echo hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(waggleReal, filepath.Join(home, ".waggle")); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	oldWriter := log.Writer()
+	oldFlags := log.Flags()
+	oldPrefix := log.Prefix()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	log.SetPrefix("")
+	t.Cleanup(func() {
+		log.SetOutput(oldWriter)
+		log.SetFlags(oldFlags)
+		log.SetPrefix(oldPrefix)
+	})
+
+	if err := uninstallShellHook(home); err != nil {
+		t.Fatalf("uninstallShellHook returned error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "warning: remove shell hook script") {
+		t.Fatalf("expected safeRemove warning log, got %q", buf.String())
+	}
+	if _, err := os.Lstat(filepath.Join(home, ".waggle")); err != nil {
+		t.Fatalf("symlink should remain after best-effort uninstall: %v", err)
 	}
 }
 
@@ -174,7 +302,7 @@ func TestHasAncestorSymlink_DetectsSymlinkedParent(t *testing.T) {
 	linkDir := filepath.Join(base, "link")
 	os.Symlink(realDir, linkDir)
 
-	if !hasAncestorSymlink(filepath.Join(linkDir, "file.txt"), base) {
+	if !fsutil.HasAncestorSymlink(filepath.Join(linkDir, "file.txt"), base) {
 		t.Fatal("should detect symlinked parent")
 	}
 }
@@ -183,15 +311,35 @@ func TestHasAncestorSymlink_NoSymlink(t *testing.T) {
 	base := t.TempDir()
 	dir := filepath.Join(base, "subdir")
 	os.MkdirAll(dir, 0o700)
-	if hasAncestorSymlink(filepath.Join(dir, "file.txt"), base) {
+	if fsutil.HasAncestorSymlink(filepath.Join(dir, "file.txt"), base) {
 		t.Fatal("should not detect symlink in real dir")
+	}
+}
+
+func TestHasAncestorSymlink_AbsolutePathsNeverRelError(t *testing.T) {
+	base := t.TempDir()
+	dir := filepath.Join(base, "subdir")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "file.txt")
+
+	rel, err := filepath.Rel(base, path)
+	if err != nil {
+		t.Fatalf("filepath.Rel returned error for absolute paths: %v", err)
+	}
+	if rel != filepath.Join("subdir", "file.txt") {
+		t.Fatalf("rel = %q, want %q", rel, filepath.Join("subdir", "file.txt"))
+	}
+	if fsutil.HasAncestorSymlink(path, base) {
+		t.Fatal("absolute path under root should not be treated as a symlink escape")
 	}
 }
 
 func TestHasAncestorSymlink_RejectsPathEscapingRoot(t *testing.T) {
 	base := t.TempDir()
 	escaped := filepath.Join(base, "..", "etc", "passwd")
-	if !hasAncestorSymlink(escaped, base) {
+	if !fsutil.HasAncestorSymlink(escaped, base) {
 		t.Fatal("should reject path escaping root via ..")
 	}
 }
@@ -202,7 +350,7 @@ func TestHasAncestorSymlink_DeeplyNestedSymlink(t *testing.T) {
 	os.MkdirAll(realDir, 0o700)
 	os.MkdirAll(filepath.Join(base, "a"), 0o700)
 	os.Symlink(realDir, filepath.Join(base, "a", "link"))
-	if !hasAncestorSymlink(filepath.Join(base, "a", "link", "file.txt"), base) {
+	if !fsutil.HasAncestorSymlink(filepath.Join(base, "a", "link", "file.txt"), base) {
 		t.Fatal("should detect deeply nested symlink")
 	}
 }

--- a/internal/install/shell_hook_test.go
+++ b/internal/install/shell_hook_test.go
@@ -41,6 +41,20 @@ func TestInstallShellHook_ZshenvWithMarkers(t *testing.T) {
 	}
 }
 
+func TestInstallShellHook_ZshenvDoesNotExportAgentPPID(t *testing.T) {
+	home := t.TempDir()
+	if err := installShellHook(home); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".zshenv"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "export WAGGLE_AGENT_PPID") {
+		t.Fatal("unexpected WAGGLE_AGENT_PPID export in shell hook block")
+	}
+}
+
 func TestInstallShellHook_BashrcWithMarkers(t *testing.T) {
 	home := t.TempDir()
 	os.WriteFile(filepath.Join(home, ".bashrc"), []byte("# bash\n"), 0o644)
@@ -48,6 +62,24 @@ func TestInstallShellHook_BashrcWithMarkers(t *testing.T) {
 	data, _ := os.ReadFile(filepath.Join(home, ".bashrc"))
 	if !strings.Contains(string(data), "WAGGLE-SHELL-HOOK-BEGIN") {
 		t.Fatal("missing marker in .bashrc")
+	}
+}
+
+func TestInstallShellHook_ScriptTouchesPointerAndRecoversOrphans(t *testing.T) {
+	home := t.TempDir()
+	if err := installShellHook(home); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".waggle", "shell-hook.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.Contains(content, `for _orphan in "$_ws".c-*; do`) {
+		t.Fatal("missing orphan recovery loop")
+	}
+	if !strings.Contains(content, `touch "$_sm" "$_pm" 2>/dev/null`) {
+		t.Fatal("missing pointer file touch")
 	}
 }
 

--- a/internal/install/shell_hook_test.go
+++ b/internal/install/shell_hook_test.go
@@ -41,20 +41,6 @@ func TestInstallShellHook_ZshenvWithMarkers(t *testing.T) {
 	}
 }
 
-func TestInstallShellHook_ZshenvDoesNotExportAgentPPID(t *testing.T) {
-	home := t.TempDir()
-	if err := installShellHook(home); err != nil {
-		t.Fatal(err)
-	}
-	data, err := os.ReadFile(filepath.Join(home, ".zshenv"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.Contains(string(data), "export WAGGLE_AGENT_PPID") {
-		t.Fatal("unexpected WAGGLE_AGENT_PPID export in shell hook block")
-	}
-}
-
 func TestInstallShellHook_BashrcWithMarkers(t *testing.T) {
 	home := t.TempDir()
 	os.WriteFile(filepath.Join(home, ".bashrc"), []byte("# bash\n"), 0o644)
@@ -62,24 +48,6 @@ func TestInstallShellHook_BashrcWithMarkers(t *testing.T) {
 	data, _ := os.ReadFile(filepath.Join(home, ".bashrc"))
 	if !strings.Contains(string(data), "WAGGLE-SHELL-HOOK-BEGIN") {
 		t.Fatal("missing marker in .bashrc")
-	}
-}
-
-func TestInstallShellHook_ScriptTouchesPointerAndRecoversOrphans(t *testing.T) {
-	home := t.TempDir()
-	if err := installShellHook(home); err != nil {
-		t.Fatal(err)
-	}
-	data, err := os.ReadFile(filepath.Join(home, ".waggle", "shell-hook.sh"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	content := string(data)
-	if !strings.Contains(content, `for _orphan in "$_ws".c-*; do`) {
-		t.Fatal("missing orphan recovery loop")
-	}
-	if !strings.Contains(content, `touch "$_sm" "$_pm" 2>/dev/null`) {
-		t.Fatal("missing pointer file touch")
 	}
 }
 

--- a/internal/install/test_hookfiles_single_source.sh
+++ b/internal/install/test_hookfiles_single_source.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Proves finding e12e0196 is FIXED: hookFiles is the single source of truth
+# for both install and uninstall — no separate lists to drift.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+go test ./internal/install/ -count=1 -run "TestInstall|TestUninstall" -v

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -33,6 +33,7 @@ type Request struct {
 	AwaitAck        bool            `json:"await_ack,omitempty"`
 	Timeout         int             `json:"timeout,omitempty"`
 	PushListener    bool            `json:"push_listener,omitempty"`
+	PushToken       string          `json:"push_token,omitempty"`
 }
 
 // Response represents a broker → client response
@@ -67,4 +68,3 @@ func ErrResponse(code, message string) Response {
 		Error: message,
 	}
 }
-

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -8,32 +8,31 @@ type Request struct {
 	Cmd string `json:"cmd"`
 
 	// Optional fields (all omitempty)
-	Name           string          `json:"name,omitempty"`
-	Topic          string          `json:"topic,omitempty"`
-	Message        string          `json:"message,omitempty"`
-	Payload        json.RawMessage `json:"payload,omitempty"`
-	Type           string          `json:"type,omitempty"`
-	Tags           string          `json:"tags,omitempty"`
-	DependsOn      string          `json:"depends_on,omitempty"`
-	Priority       int             `json:"priority,omitempty"`
-	Lease          int             `json:"lease,omitempty"`
-	MaxRetries     int             `json:"max_retries,omitempty"`
-	IdempotencyKey string          `json:"idempotency_key,omitempty"`
-	Resource       string          `json:"resource,omitempty"`
-	TaskID         string          `json:"task_id,omitempty"`
-	ClaimToken     string          `json:"claim_token,omitempty"`
-	Result         json.RawMessage `json:"result,omitempty"`
-	Reason         string          `json:"reason,omitempty"`
-	Last           string          `json:"last,omitempty"`
-	State          string          `json:"state,omitempty"`
-	Owner          string          `json:"owner,omitempty"`
-	MessageID      int64           `json:"message_id,omitempty"`
-	MsgPriority    string          `json:"msg_priority,omitempty"`
-	TTL            int             `json:"ttl,omitempty"`
-	AwaitAck       bool            `json:"await_ack,omitempty"`
-	Timeout        int             `json:"timeout,omitempty"`
-	PushListener   bool            `json:"push_listener,omitempty"`
-	PushToken      string          `json:"push_token,omitempty"`
+	Name            string          `json:"name,omitempty"`
+	Topic           string          `json:"topic,omitempty"`
+	Message         string          `json:"message,omitempty"`
+	Payload         json.RawMessage `json:"payload,omitempty"`
+	Type            string          `json:"type,omitempty"`
+	Tags            string          `json:"tags,omitempty"`
+	DependsOn       string          `json:"depends_on,omitempty"`
+	Priority        int             `json:"priority,omitempty"`
+	Lease           int             `json:"lease,omitempty"`
+	MaxRetries      int             `json:"max_retries,omitempty"`
+	IdempotencyKey  string          `json:"idempotency_key,omitempty"`
+	Resource        string          `json:"resource,omitempty"`
+	TaskID          string          `json:"task_id,omitempty"`
+	ClaimToken      string          `json:"claim_token,omitempty"`
+	Result          json.RawMessage `json:"result,omitempty"`
+	Reason          string          `json:"reason,omitempty"`
+	Last            string          `json:"last,omitempty"`
+	State           string          `json:"state,omitempty"`
+	Owner           string          `json:"owner,omitempty"`
+	MessageID       int64           `json:"message_id,omitempty"`
+	MsgPriority     string          `json:"msg_priority,omitempty"`
+	TTL             int             `json:"ttl,omitempty"`
+	AwaitAck        bool            `json:"await_ack,omitempty"`
+	Timeout         int             `json:"timeout,omitempty"`
+	PushListener    bool            `json:"push_listener,omitempty"`
 }
 
 // Response represents a broker → client response
@@ -68,3 +67,4 @@ func ErrResponse(code, message string) Response {
 		Error: message,
 	}
 }
+

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -8,31 +8,32 @@ type Request struct {
 	Cmd string `json:"cmd"`
 
 	// Optional fields (all omitempty)
-	Name            string          `json:"name,omitempty"`
-	Topic           string          `json:"topic,omitempty"`
-	Message         string          `json:"message,omitempty"`
-	Payload         json.RawMessage `json:"payload,omitempty"`
-	Type            string          `json:"type,omitempty"`
-	Tags            string          `json:"tags,omitempty"`
-	DependsOn       string          `json:"depends_on,omitempty"`
-	Priority        int             `json:"priority,omitempty"`
-	Lease           int             `json:"lease,omitempty"`
-	MaxRetries      int             `json:"max_retries,omitempty"`
-	IdempotencyKey  string          `json:"idempotency_key,omitempty"`
-	Resource        string          `json:"resource,omitempty"`
-	TaskID          string          `json:"task_id,omitempty"`
-	ClaimToken      string          `json:"claim_token,omitempty"`
-	Result          json.RawMessage `json:"result,omitempty"`
-	Reason          string          `json:"reason,omitempty"`
-	Last            string          `json:"last,omitempty"`
-	State           string          `json:"state,omitempty"`
-	Owner           string          `json:"owner,omitempty"`
-	MessageID       int64           `json:"message_id,omitempty"`
-	MsgPriority     string          `json:"msg_priority,omitempty"`
-	TTL             int             `json:"ttl,omitempty"`
-	AwaitAck        bool            `json:"await_ack,omitempty"`
-	Timeout         int             `json:"timeout,omitempty"`
-	PushListener    bool            `json:"push_listener,omitempty"`
+	Name           string          `json:"name,omitempty"`
+	Topic          string          `json:"topic,omitempty"`
+	Message        string          `json:"message,omitempty"`
+	Payload        json.RawMessage `json:"payload,omitempty"`
+	Type           string          `json:"type,omitempty"`
+	Tags           string          `json:"tags,omitempty"`
+	DependsOn      string          `json:"depends_on,omitempty"`
+	Priority       int             `json:"priority,omitempty"`
+	Lease          int             `json:"lease,omitempty"`
+	MaxRetries     int             `json:"max_retries,omitempty"`
+	IdempotencyKey string          `json:"idempotency_key,omitempty"`
+	Resource       string          `json:"resource,omitempty"`
+	TaskID         string          `json:"task_id,omitempty"`
+	ClaimToken     string          `json:"claim_token,omitempty"`
+	Result         json.RawMessage `json:"result,omitempty"`
+	Reason         string          `json:"reason,omitempty"`
+	Last           string          `json:"last,omitempty"`
+	State          string          `json:"state,omitempty"`
+	Owner          string          `json:"owner,omitempty"`
+	MessageID      int64           `json:"message_id,omitempty"`
+	MsgPriority    string          `json:"msg_priority,omitempty"`
+	TTL            int             `json:"ttl,omitempty"`
+	AwaitAck       bool            `json:"await_ack,omitempty"`
+	Timeout        int             `json:"timeout,omitempty"`
+	PushListener   bool            `json:"push_listener,omitempty"`
+	PushToken      string          `json:"push_token,omitempty"`
 }
 
 // Response represents a broker → client response
@@ -67,4 +68,3 @@ func ErrResponse(code, message string) Response {
 		Error: message,
 	}
 }
-

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -32,6 +32,7 @@ type Request struct {
 	TTL             int             `json:"ttl,omitempty"`
 	AwaitAck        bool            `json:"await_ack,omitempty"`
 	Timeout         int             `json:"timeout,omitempty"`
+	PushListener    bool            `json:"push_listener,omitempty"`
 }
 
 // Response represents a broker → client response

--- a/internal/protocol/message_test.go
+++ b/internal/protocol/message_test.go
@@ -8,26 +8,28 @@ import (
 // TestRequest_RoundTrip verifies P1: Request round-trips through JSON without data loss
 func TestRequest_RoundTrip(t *testing.T) {
 	original := Request{
-		Cmd:             CmdPublish,
-		Name:            "test-task",
-		Topic:           "test.topic",
-		Message:         "test message",
-		Payload:         json.RawMessage(`{"key":"value"}`),
-		Type:            "work",
-		Tags:            "tag1,tag2",
-		DependsOn:       "dep1,dep2",
-		Priority:        5,
-		Lease:           60,
-		MaxRetries:      3,
-		IdempotencyKey:  "unique-key",
-		Resource:        "resource1",
-		TaskID:          "task-123",
-		ClaimToken:      "token-456",
-		Result:          json.RawMessage(`{"status":"done"}`),
-		Reason:          "completed",
-		Last:            "last-id",
-		State:           "active",
-		Owner:           "worker-1",
+		Cmd:            CmdPublish,
+		Name:           "test-task",
+		Topic:          "test.topic",
+		Message:        "test message",
+		Payload:        json.RawMessage(`{"key":"value"}`),
+		Type:           "work",
+		Tags:           "tag1,tag2",
+		DependsOn:      "dep1,dep2",
+		Priority:       5,
+		Lease:          60,
+		MaxRetries:     3,
+		IdempotencyKey: "unique-key",
+		Resource:       "resource1",
+		TaskID:         "task-123",
+		ClaimToken:     "token-456",
+		Result:         json.RawMessage(`{"status":"done"}`),
+		Reason:         "completed",
+		Last:           "last-id",
+		State:          "active",
+		Owner:          "worker-1",
+		PushListener:   true,
+		PushToken:      "push-token-789",
 	}
 
 	// Marshal to JSON
@@ -102,6 +104,12 @@ func TestRequest_RoundTrip(t *testing.T) {
 	}
 	if decoded.Owner != original.Owner {
 		t.Errorf("Owner mismatch: got %q, want %q", decoded.Owner, original.Owner)
+	}
+	if decoded.PushListener != original.PushListener {
+		t.Errorf("PushListener mismatch: got %t, want %t", decoded.PushListener, original.PushListener)
+	}
+	if decoded.PushToken != original.PushToken {
+		t.Errorf("PushToken mismatch: got %q, want %q", decoded.PushToken, original.PushToken)
 	}
 }
 
@@ -215,4 +223,3 @@ func TestErrorCodes_Unique(t *testing.T) {
 		t.Errorf("Expected %d unique error codes, got %d", len(errorCodes), len(seen))
 	}
 }
-

--- a/internal/runtime/listener.go
+++ b/internal/runtime/listener.go
@@ -122,7 +122,7 @@ func (l *brokerListener) Listen(ctx context.Context, handler DeliveryHandler) er
 	if err := c.SetDeadline(config.Defaults.ConnectTimeout); err != nil {
 		return fmt.Errorf("set handshake deadline: %w", err)
 	}
-	resp, err := c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: l.name})
+	resp, err := c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: l.name, PushListener: true})
 	if err != nil {
 		return err
 	}

--- a/internal/runtime/listener.go
+++ b/internal/runtime/listener.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/seungpyoson/waggle/internal/broker"
 	"github.com/seungpyoson/waggle/internal/client"
 	"github.com/seungpyoson/waggle/internal/config"
 	"github.com/seungpyoson/waggle/internal/protocol"
@@ -32,6 +33,7 @@ func (f *BrokerListenerFactory) NewListener(w Watch) (Listener, error) {
 	}
 	return &brokerListener{
 		socketPath: paths.Socket,
+		baseName:   w.AgentName,
 		name:       w.AgentName + "-push",
 	}, nil
 }
@@ -109,10 +111,35 @@ func (f *BrokerListenerFactory) CatchUp(w Watch, handler DeliveryHandler) error 
 
 type brokerListener struct {
 	socketPath string
+	baseName   string
 	name       string
 }
 
 func (l *brokerListener) Listen(ctx context.Context, handler DeliveryHandler) error {
+	baseConn, err := client.Connect(l.socketPath, config.Defaults.ConnectTimeout)
+	if err != nil {
+		return err
+	}
+	defer disconnectClient(baseConn)
+
+	if err := baseConn.SetDeadline(config.Defaults.ConnectTimeout); err != nil {
+		return fmt.Errorf("set base handshake deadline: %w", err)
+	}
+	baseResp, err := baseConn.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: l.baseName})
+	if err != nil {
+		return err
+	}
+	if !baseResp.OK {
+		return fmt.Errorf("%s: %s", baseResp.Code, baseResp.Error)
+	}
+	pushToken, err := pushTokenFromConnect(l.socketPath, l.baseName, baseResp.Data)
+	if err != nil {
+		return err
+	}
+	if err := baseConn.ClearDeadline(); err != nil {
+		return fmt.Errorf("clear base deadline: %w", err)
+	}
+
 	c, err := client.Connect(l.socketPath, config.Defaults.ConnectTimeout)
 	if err != nil {
 		return err
@@ -122,7 +149,12 @@ func (l *brokerListener) Listen(ctx context.Context, handler DeliveryHandler) er
 	if err := c.SetDeadline(config.Defaults.ConnectTimeout); err != nil {
 		return fmt.Errorf("set handshake deadline: %w", err)
 	}
-	resp, err := c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: l.name, PushListener: true})
+	resp, err := c.Send(protocol.Request{
+		Cmd:          protocol.CmdConnect,
+		Name:         l.name,
+		PushListener: true,
+		PushToken:    pushToken,
+	})
 	if err != nil {
 		return err
 	}
@@ -169,4 +201,34 @@ func pushedMessageToDelivery(msg client.PushedMessage) (Delivery, error) {
 		SentAt:     sentAt,
 		ReceivedAt: time.Now().UTC(),
 	}, nil
+}
+
+func disconnectClient(c *client.Client) {
+	if c == nil {
+		return
+	}
+	if err := c.SetDeadline(config.Defaults.DisconnectTimeout); err == nil {
+		_, _ = c.Send(protocol.Request{Cmd: protocol.CmdDisconnect})
+	}
+	c.Close()
+}
+
+func pushTokenFromConnect(socketPath, agent string, data json.RawMessage) (string, error) {
+	var payload struct {
+		PushToken string `json:"push_token"`
+	}
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &payload); err != nil {
+			return "", fmt.Errorf("parse connect response: %w", err)
+		}
+		if payload.PushToken != "" {
+			return payload.PushToken, nil
+		}
+	}
+	if b := broker.LookupBySocket(socketPath); b != nil {
+		if token := b.GetPushToken(agent); token != "" {
+			return token, nil
+		}
+	}
+	return "", fmt.Errorf("connect succeeded but no push token available for %s", agent)
 }

--- a/internal/runtime/listener.go
+++ b/internal/runtime/listener.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/seungpyoson/waggle/internal/broker"
@@ -33,7 +34,7 @@ func (f *BrokerListenerFactory) NewListener(w Watch) (Listener, error) {
 	}
 	return &brokerListener{
 		socketPath: paths.Socket,
-		baseName:   w.AgentName,
+		agentName:  w.AgentName,
 		name:       w.AgentName + "-push",
 	}, nil
 }
@@ -48,15 +49,18 @@ func (f *BrokerListenerFactory) CatchUp(w Watch, handler DeliveryHandler) error 
 		return fmt.Errorf("cannot determine broker socket path")
 	}
 
+	pushToken, err := pushTokenForAgent(paths.Socket, w.AgentName)
+	if err != nil {
+		return err
+	}
+
 	c, err := client.Connect(paths.Socket, config.Defaults.ConnectTimeout)
 	if err != nil {
 		return err
 	}
 	defer func() {
 		// Clean disconnect prevents task requeue and lock release.
-		if err := c.SetDeadline(config.Defaults.DisconnectTimeout); err == nil {
-			_, _ = c.Send(protocol.Request{Cmd: protocol.CmdDisconnect})
-		}
+		sendDisconnect(c, fmt.Sprintf("catch-up %q/%q", w.ProjectID, w.AgentName))
 		c.Close()
 	}()
 
@@ -64,11 +68,18 @@ func (f *BrokerListenerFactory) CatchUp(w Watch, handler DeliveryHandler) error 
 	if err := c.SetDeadline(config.Defaults.ConnectTimeout); err != nil {
 		return fmt.Errorf("set deadline: %w", err)
 	}
-	resp, err := c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: w.AgentName})
+	resp, err := c.Send(protocol.Request{
+		Cmd:          protocol.CmdConnect,
+		Name:         w.AgentName + "-push",
+		PushListener: true,
+		PushToken:    pushToken,
+	})
 	if err != nil {
 		return err
 	}
 	if !resp.OK {
+		// protocol.ErrAlreadyConnected is transient during restarts or duplicate workers;
+		// Manager.runWatch treats the returned Listen error as retryable and reconnects.
 		return fmt.Errorf("%s: %s", resp.Code, resp.Error)
 	}
 
@@ -111,40 +122,21 @@ func (f *BrokerListenerFactory) CatchUp(w Watch, handler DeliveryHandler) error 
 
 type brokerListener struct {
 	socketPath string
-	baseName   string
+	agentName  string
 	name       string
 }
 
 func (l *brokerListener) Listen(ctx context.Context, handler DeliveryHandler) error {
-	baseConn, err := client.Connect(l.socketPath, config.Defaults.ConnectTimeout)
+	pushToken, err := pushTokenForAgent(l.socketPath, l.agentName)
 	if err != nil {
 		return err
-	}
-	defer disconnectClient(baseConn)
-
-	if err := baseConn.SetDeadline(config.Defaults.ConnectTimeout); err != nil {
-		return fmt.Errorf("set base handshake deadline: %w", err)
-	}
-	baseResp, err := baseConn.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: l.baseName})
-	if err != nil {
-		return err
-	}
-	if !baseResp.OK {
-		return fmt.Errorf("%s: %s", baseResp.Code, baseResp.Error)
-	}
-	pushToken, err := pushTokenFromConnect(l.socketPath, l.baseName, baseResp.Data)
-	if err != nil {
-		return err
-	}
-	if err := baseConn.ClearDeadline(); err != nil {
-		return fmt.Errorf("clear base deadline: %w", err)
 	}
 
 	c, err := client.Connect(l.socketPath, config.Defaults.ConnectTimeout)
 	if err != nil {
 		return err
 	}
-	defer c.Close()
+	defer disconnectClient(c)
 
 	if err := c.SetDeadline(config.Defaults.ConnectTimeout); err != nil {
 		return fmt.Errorf("set handshake deadline: %w", err)
@@ -207,28 +199,30 @@ func disconnectClient(c *client.Client) {
 	if c == nil {
 		return
 	}
-	if err := c.SetDeadline(config.Defaults.DisconnectTimeout); err == nil {
-		_, _ = c.Send(protocol.Request{Cmd: protocol.CmdDisconnect})
-	}
+	sendDisconnect(c, "listener")
 	c.Close()
 }
 
-func pushTokenFromConnect(socketPath, agent string, data json.RawMessage) (string, error) {
-	var payload struct {
-		PushToken string `json:"push_token"`
+func sendDisconnect(c *client.Client, context string) {
+	if c == nil {
+		return
 	}
-	if len(data) > 0 {
-		if err := json.Unmarshal(data, &payload); err != nil {
-			return "", fmt.Errorf("parse connect response: %w", err)
-		}
-		if payload.PushToken != "" {
-			return payload.PushToken, nil
-		}
+	if err := c.SetDeadline(config.Defaults.DisconnectTimeout); err != nil {
+		log.Printf("warning: set disconnect deadline for %s: %v", context, err)
+		return
 	}
-	if b := broker.LookupBySocket(socketPath); b != nil {
-		if token := b.GetPushToken(agent); token != "" {
-			return token, nil
-		}
+	if _, err := c.Send(protocol.Request{Cmd: protocol.CmdDisconnect}); err != nil {
+		log.Printf("warning: disconnect %s: %v", context, err)
 	}
-	return "", fmt.Errorf("connect succeeded but no push token available for %s", agent)
+}
+
+func pushTokenForAgent(socketPath, agent string) (string, error) {
+	b := broker.LookupBySocket(socketPath)
+	if b == nil {
+		return "", fmt.Errorf("no in-process broker available for %s", agent)
+	}
+	if token := b.GetPushToken(agent); token != "" {
+		return token, nil
+	}
+	return b.GeneratePushToken(agent)
 }

--- a/internal/runtime/listener.go
+++ b/internal/runtime/listener.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/seungpyoson/waggle/internal/client"
@@ -12,7 +15,9 @@ import (
 )
 
 // BrokerListenerFactory connects runtime watches directly to the broker push stream.
-type BrokerListenerFactory struct{}
+type BrokerListenerFactory struct {
+	PushToken string
+}
 
 func NewBrokerListenerFactory() *BrokerListenerFactory {
 	return &BrokerListenerFactory{}
@@ -33,6 +38,7 @@ func (f *BrokerListenerFactory) NewListener(w Watch) (Listener, error) {
 	return &brokerListener{
 		socketPath: paths.Socket,
 		name:       w.AgentName + "-push",
+		pushToken:  f.PushToken,
 	}, nil
 }
 
@@ -110,6 +116,7 @@ func (f *BrokerListenerFactory) CatchUp(w Watch, handler DeliveryHandler) error 
 type brokerListener struct {
 	socketPath string
 	name       string
+	pushToken  string
 }
 
 func (l *brokerListener) Listen(ctx context.Context, handler DeliveryHandler) error {
@@ -119,10 +126,25 @@ func (l *brokerListener) Listen(ctx context.Context, handler DeliveryHandler) er
 	}
 	defer c.Close()
 
+	// Read push token from broker's token file (cross-process sharing).
+	// Falls back to factory-provided token for in-process tests.
+	pushToken := l.pushToken
+	if pushToken == "" {
+		tokenPath := filepath.Join(filepath.Dir(l.socketPath), "push-token")
+		if data, err := os.ReadFile(tokenPath); err == nil {
+			pushToken = strings.TrimSpace(string(data))
+		}
+	}
+
 	if err := c.SetDeadline(config.Defaults.ConnectTimeout); err != nil {
 		return fmt.Errorf("set handshake deadline: %w", err)
 	}
-	resp, err := c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: l.name, PushListener: true})
+	resp, err := c.Send(protocol.Request{
+		Cmd:          protocol.CmdConnect,
+		Name:         l.name,
+		PushListener: true,
+		PushToken:    pushToken,
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/runtime/listener.go
+++ b/internal/runtime/listener.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/seungpyoson/waggle/internal/client"
@@ -15,9 +12,7 @@ import (
 )
 
 // BrokerListenerFactory connects runtime watches directly to the broker push stream.
-type BrokerListenerFactory struct {
-	PushToken string
-}
+type BrokerListenerFactory struct{}
 
 func NewBrokerListenerFactory() *BrokerListenerFactory {
 	return &BrokerListenerFactory{}
@@ -38,7 +33,6 @@ func (f *BrokerListenerFactory) NewListener(w Watch) (Listener, error) {
 	return &brokerListener{
 		socketPath: paths.Socket,
 		name:       w.AgentName + "-push",
-		pushToken:  f.PushToken,
 	}, nil
 }
 
@@ -116,7 +110,6 @@ func (f *BrokerListenerFactory) CatchUp(w Watch, handler DeliveryHandler) error 
 type brokerListener struct {
 	socketPath string
 	name       string
-	pushToken  string
 }
 
 func (l *brokerListener) Listen(ctx context.Context, handler DeliveryHandler) error {
@@ -126,25 +119,10 @@ func (l *brokerListener) Listen(ctx context.Context, handler DeliveryHandler) er
 	}
 	defer c.Close()
 
-	// Read push token from broker's token file (cross-process sharing).
-	// Falls back to factory-provided token for in-process tests.
-	pushToken := l.pushToken
-	if pushToken == "" {
-		tokenPath := filepath.Join(filepath.Dir(l.socketPath), "push-token")
-		if data, err := os.ReadFile(tokenPath); err == nil {
-			pushToken = strings.TrimSpace(string(data))
-		}
-	}
-
 	if err := c.SetDeadline(config.Defaults.ConnectTimeout); err != nil {
 		return fmt.Errorf("set handshake deadline: %w", err)
 	}
-	resp, err := c.Send(protocol.Request{
-		Cmd:          protocol.CmdConnect,
-		Name:         l.name,
-		PushListener: true,
-		PushToken:    pushToken,
-	})
+	resp, err := c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: l.name, PushListener: true})
 	if err != nil {
 		return err
 	}

--- a/internal/runtime/listener_test.go
+++ b/internal/runtime/listener_test.go
@@ -1,0 +1,182 @@
+package runtime
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/seungpyoson/waggle/internal/broker"
+	"github.com/seungpyoson/waggle/internal/client"
+	"github.com/seungpyoson/waggle/internal/config"
+	"github.com/seungpyoson/waggle/internal/protocol"
+)
+
+func startRuntimeTestBroker(t *testing.T, projectID string) (string, func()) {
+	t.Helper()
+
+	home, err := os.MkdirTemp("/tmp", "waggle-runtime-listener-")
+	if err != nil {
+		t.Fatalf("mktemp home: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(home)
+	})
+	t.Setenv("HOME", home)
+
+	paths := config.NewPaths(projectID)
+	if err := os.MkdirAll(filepath.Dir(paths.DB), 0o700); err != nil {
+		t.Fatalf("mkdir db dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.Socket), 0o700); err != nil {
+		t.Fatalf("mkdir socket dir: %v", err)
+	}
+
+	b, err := broker.New(broker.Config{
+		SocketPath: paths.Socket,
+		DBPath:     paths.DB,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		_ = b.Serve()
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	return paths.Socket, func() {
+		_ = b.Shutdown()
+		_ = os.Remove(paths.Socket)
+	}
+}
+
+func connectRuntimeClient(t *testing.T, socketPath string) *client.Client {
+	t.Helper()
+
+	c, err := client.Connect(socketPath, 5*time.Second)
+	if err != nil {
+		t.Fatalf("client.Connect: %v", err)
+	}
+	return c
+}
+
+func TestBrokerListenerListenReceivesPushWithoutBaseConnection(t *testing.T) {
+	socketPath, cleanup := startRuntimeTestBroker(t, "proj-listen")
+	defer cleanup()
+
+	listener, err := NewBrokerListenerFactory().NewListener(Watch{
+		ProjectID: "proj-listen",
+		AgentName: "alice",
+		Source:    "hook",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	deliveries := make(chan Delivery, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- listener.Listen(ctx, func(d Delivery) error {
+			deliveries <- d
+			cancel()
+			return nil
+		})
+	}()
+
+	sender := connectRuntimeClient(t, socketPath)
+	defer sender.Close()
+	resp, err := sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "sender"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("sender connect failed: %s", resp.Error)
+	}
+
+	sendResp, err := sender.Send(protocol.Request{
+		Cmd:     protocol.CmdSend,
+		Name:    "alice",
+		Message: "hello without base session",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sendResp.OK {
+		t.Fatalf("send failed: %s", sendResp.Error)
+	}
+
+	select {
+	case delivery := <-deliveries:
+		if delivery.FromName != "sender" {
+			t.Fatalf("delivery.FromName = %q, want sender", delivery.FromName)
+		}
+		if delivery.Body != "hello without base session" {
+			t.Fatalf("delivery.Body = %q, want %q", delivery.Body, "hello without base session")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for pushed delivery")
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Listen() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for listener shutdown")
+	}
+}
+
+func TestBrokerListenerCatchUpReadsInboxWithoutBaseConnection(t *testing.T) {
+	socketPath, cleanup := startRuntimeTestBroker(t, "proj-catchup")
+	defer cleanup()
+
+	sender := connectRuntimeClient(t, socketPath)
+	defer sender.Close()
+	resp, err := sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "sender"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("sender connect failed: %s", resp.Error)
+	}
+
+	sendResp, err := sender.Send(protocol.Request{
+		Cmd:     protocol.CmdSend,
+		Name:    "alice",
+		Message: "catch-up delivery",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sendResp.OK {
+		t.Fatalf("send failed: %s", sendResp.Error)
+	}
+
+	var got []Delivery
+	if err := NewBrokerListenerFactory().CatchUp(Watch{
+		ProjectID: "proj-catchup",
+		AgentName: "alice",
+		Source:    "hook",
+	}, func(d Delivery) error {
+		got = append(got, d)
+		return nil
+	}); err != nil {
+		t.Fatalf("CatchUp() error = %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("CatchUp() deliveries = %d, want 1", len(got))
+	}
+	if got[0].FromName != "sender" {
+		t.Fatalf("delivery.FromName = %q, want sender", got[0].FromName)
+	}
+	if got[0].Body != "catch-up delivery" {
+		t.Fatalf("delivery.Body = %q, want %q", got[0].Body, "catch-up delivery")
+	}
+}

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -775,6 +775,7 @@ func (m *Manager) runMaintenanceLoop(ctx context.Context) {
 			}
 			if m.signalDir != "" {
 				PruneStaleFiles(filepath.Dir(m.signalDir), "agent-ppid-", 24*time.Hour)
+				PruneStaleSignals(m.signalDir, 24*time.Hour)
 			}
 			if err := m.refreshTrackedDeliveryStates(); err != nil {
 				hadErr = true

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -66,6 +67,7 @@ type Manager struct {
 	lastDeliveryErr map[string]error
 	workers         map[watchKey]*watchWorker
 	recentErrors    []ErrorEntry // ring buffer, capped at config.Defaults.RuntimeRecentErrorCap
+	signalDir       string       // set via SetSignalDir; enables shell-hook signal files
 }
 
 func NewManager(store *Store, factory ListenerFactory, notifier Notifier) *Manager {
@@ -80,6 +82,11 @@ func NewManager(store *Store, factory ListenerFactory, notifier Notifier) *Manag
 		lastDeliveryErr: make(map[string]error),
 		workers:         make(map[watchKey]*watchWorker),
 	}
+}
+
+// SetSignalDir enables signal file writing for shell-hook delivery.
+func (m *Manager) SetSignalDir(dir string) {
+	m.signalDir = dir
 }
 
 func (m *Manager) Start(ctx context.Context) error {
@@ -471,6 +478,9 @@ func (m *Manager) notifyRecord(projectID, agentName string, messageID int64, tit
 			return err
 		}
 	}
+	if m.signalDir != "" {
+		_ = WriteSignal(m.signalDir, agentName, senderFromTitle(title), body, config.Defaults.SignalMaxBytes)
+	}
 	if err := m.store.MarkNotified(projectID, agentName, messageID, time.Now().UTC()); err != nil {
 		return err
 	}
@@ -592,6 +602,14 @@ func notificationTitle(d Delivery) string {
 		return "New waggle message"
 	}
 	return fmt.Sprintf("Message from %s", d.FromName)
+}
+
+func senderFromTitle(title string) string {
+	const prefix = "Message from "
+	if strings.HasPrefix(title, prefix) {
+		return strings.TrimPrefix(title, prefix)
+	}
+	return "unknown"
 }
 
 type deliveryKey struct {
@@ -754,6 +772,9 @@ func (m *Manager) runMaintenanceLoop(ctx context.Context) {
 			if _, err := m.store.PruneDeliveryRecords(now.Add(-config.Defaults.RuntimeDeliveryRetention)); err != nil {
 				hadErr = true
 				m.captureDeliveryError("maintenance", fmt.Errorf("prune delivery records: %w", err))
+			}
+			if m.signalDir != "" {
+				PruneStaleFiles(filepath.Dir(m.signalDir), "agent-ppid-", 24*time.Hour)
 			}
 			if err := m.refreshTrackedDeliveryStates(); err != nil {
 				hadErr = true

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -2,7 +2,9 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -274,7 +276,9 @@ func (m *Manager) stopWatch(key watchKey) {
 	m.clearDeliveryError(watchListenerErrorKey(worker.watch))
 	m.clearDeliveryError(watchCatchUpErrorKey(worker.watch))
 	m.clearDeliveryError(watchDeliveryErrorKey(worker.watch.ProjectID, worker.watch.AgentName))
-	_ = m.refreshWatchDeliveryState(worker.watch.ProjectID, worker.watch.AgentName)
+	if err := m.refreshWatchDeliveryState(worker.watch.ProjectID, worker.watch.AgentName); err != nil {
+		log.Printf("warning: refresh delivery state for %q/%q: %v", worker.watch.ProjectID, worker.watch.AgentName, err)
+	}
 }
 
 func (m *Manager) stopAllWorkers() {
@@ -405,10 +409,14 @@ func (m *Manager) handleDelivery(w Watch, d Delivery) error {
 		}
 		m.setDeliveryFailureCause(watchKey{projectID: w.ProjectID, agentName: w.AgentName}, err)
 		releasePending()
-		_ = m.refreshWatchDeliveryState(w.ProjectID, w.AgentName)
+		if refreshErr := m.refreshWatchDeliveryState(w.ProjectID, w.AgentName); refreshErr != nil {
+			log.Printf("warning: refresh delivery state for %q/%q: %v", w.ProjectID, w.AgentName, refreshErr)
+		}
 		return nil
 	}
-	_ = m.refreshWatchDeliveryState(w.ProjectID, w.AgentName)
+	if err := m.refreshWatchDeliveryState(w.ProjectID, w.AgentName); err != nil {
+		log.Printf("warning: refresh delivery state for %q/%q: %v", w.ProjectID, w.AgentName, err)
+	}
 	return nil
 }
 
@@ -446,7 +454,9 @@ func (m *Manager) retryPendingNotifications() error {
 		release()
 	}
 	for watch := range affected {
-		_ = m.refreshWatchDeliveryState(watch.projectID, watch.agentName)
+		if err := m.refreshWatchDeliveryState(watch.projectID, watch.agentName); err != nil {
+			log.Printf("warning: refresh delivery state for %q/%q: %v", watch.projectID, watch.agentName, err)
+		}
 	}
 	if firstErr == nil {
 		m.clearDeliveryError("retry-sweep")
@@ -471,20 +481,25 @@ func (m *Manager) runRetrySweepLoop(ctx context.Context) {
 }
 
 func (m *Manager) notifyRecord(projectID, agentName string, messageID int64, title, body string) error {
-	if m.notifier != nil {
-		notifyCtx, cancel := context.WithTimeout(m.ctx, config.Defaults.RuntimeNotificationTimeout)
-		defer cancel()
-		if err := m.notifier.Notify(notifyCtx, title, body); err != nil {
-			return err
-		}
-	}
 	if m.signalDir != "" {
 		if err := WriteSignal(m.signalDir, projectID, agentName, senderFromTitle(title), body, config.Defaults.SignalMaxBytes); err != nil {
+			if errors.Is(err, ErrSignalCapExceeded) {
+				log.Printf("warning: signal cap exceeded for %q/%q message %d", projectID, agentName, messageID)
+				return nil
+			}
 			return fmt.Errorf("write signal: %w", err)
 		}
 	}
 	if err := m.store.MarkNotified(projectID, agentName, messageID, time.Now().UTC()); err != nil {
 		return err
+	}
+	if m.notifier != nil {
+		notifyCtx, cancel := context.WithTimeout(m.ctx, config.Defaults.RuntimeNotificationTimeout)
+		err := m.notifier.Notify(notifyCtx, title, body)
+		cancel()
+		if err != nil {
+			log.Printf("warning: best-effort notifier failed for %q/%q message %d: %v", projectID, agentName, messageID, err)
+		}
 	}
 	return nil
 }

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -479,7 +479,7 @@ func (m *Manager) notifyRecord(projectID, agentName string, messageID int64, tit
 		}
 	}
 	if m.signalDir != "" {
-		_ = WriteSignal(m.signalDir, agentName, senderFromTitle(title), body, config.Defaults.SignalMaxBytes)
+		_ = WriteSignal(m.signalDir, projectID, agentName, senderFromTitle(title), body, config.Defaults.SignalMaxBytes)
 	}
 	if err := m.store.MarkNotified(projectID, agentName, messageID, time.Now().UTC()); err != nil {
 		return err

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -479,7 +479,9 @@ func (m *Manager) notifyRecord(projectID, agentName string, messageID int64, tit
 		}
 	}
 	if m.signalDir != "" {
-		_ = WriteSignal(m.signalDir, projectID, agentName, senderFromTitle(title), body, config.Defaults.SignalMaxBytes)
+		if err := WriteSignal(m.signalDir, projectID, agentName, senderFromTitle(title), body, config.Defaults.SignalMaxBytes); err != nil {
+			return fmt.Errorf("write signal: %w", err)
+		}
 	}
 	if err := m.store.MarkNotified(projectID, agentName, messageID, time.Now().UTC()); err != nil {
 		return err
@@ -775,6 +777,7 @@ func (m *Manager) runMaintenanceLoop(ctx context.Context) {
 			}
 			if m.signalDir != "" {
 				PruneStaleFiles(filepath.Dir(m.signalDir), "agent-ppid-", 24*time.Hour)
+				PruneStaleFiles(filepath.Dir(m.signalDir), "agent-session-", 24*time.Hour)
 				PruneStaleSignals(m.signalDir, 24*time.Hour)
 			}
 			if err := m.refreshTrackedDeliveryStates(); err != nil {

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -1609,7 +1609,6 @@ func TestManager_MaintenancePrunesExpiredWatchesAndResolvedRecords(t *testing.T)
 
 func TestBrokerListenerFactory_NewListenerUsesWatchProjectID(t *testing.T) {
 	factory := NewBrokerListenerFactory()
-	factory.PushToken = "push-token-123"
 
 	listener, err := factory.NewListener(Watch{
 		ProjectID: "proj-from-watch",
@@ -1628,9 +1627,6 @@ func TestBrokerListenerFactory_NewListenerUsesWatchProjectID(t *testing.T) {
 	want := config.NewPaths("proj-from-watch").Socket
 	if brokerListener.socketPath != want {
 		t.Fatalf("socket path = %q, want %q", brokerListener.socketPath, want)
-	}
-	if brokerListener.pushToken != "push-token-123" {
-		t.Fatalf("push token = %q, want %q", brokerListener.pushToken, "push-token-123")
 	}
 }
 

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -1609,6 +1609,7 @@ func TestManager_MaintenancePrunesExpiredWatchesAndResolvedRecords(t *testing.T)
 
 func TestBrokerListenerFactory_NewListenerUsesWatchProjectID(t *testing.T) {
 	factory := NewBrokerListenerFactory()
+	factory.PushToken = "push-token-123"
 
 	listener, err := factory.NewListener(Watch{
 		ProjectID: "proj-from-watch",
@@ -1627,6 +1628,9 @@ func TestBrokerListenerFactory_NewListenerUsesWatchProjectID(t *testing.T) {
 	want := config.NewPaths("proj-from-watch").Socket
 	if brokerListener.socketPath != want {
 		t.Fatalf("socket path = %q, want %q", brokerListener.socketPath, want)
+	}
+	if brokerListener.pushToken != "push-token-123" {
+		t.Fatalf("push token = %q, want %q", brokerListener.pushToken, "push-token-123")
 	}
 }
 

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -3,6 +3,8 @@ package runtime
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -100,10 +102,10 @@ func TestManager_HandleDeliveryDeduplicatesByProjectAgentAndMessageID(t *testing
 	}
 }
 
-func TestManager_HandleDeliveryRetriesNotifyAfterFailure(t *testing.T) {
+func TestManager_HandleDeliveryMarksNotifiedDespiteNotifierFailure(t *testing.T) {
 	store := newTestStore(t)
 	notifier := &fakeNotifier{
-		errs: []error{errors.New("notify failed"), nil},
+		errs: []error{errors.New("notify failed")},
 	}
 	manager := NewManager(store, newFakeListenerFactory(), notifier)
 
@@ -124,19 +126,8 @@ func TestManager_HandleDeliveryRetriesNotifyAfterFailure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if rec.RetryAttempts != 1 || rec.RetryNextAt.IsZero() || !rec.RetryExhaustedAt.IsZero() {
-		t.Fatalf("record retry state = %+v, want attempt=1 next_retry set exhausted unset", rec)
-	}
-	if err := store.RecordNotificationFailure("proj-a", "agent-1", 8, rec.RetryAttempts, time.Now().UTC().Add(-time.Millisecond), time.Time{}); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := manager.retryPendingNotifications(); err != nil {
-		t.Fatal(err)
-	}
-
-	if notifier.callCount() != 2 {
-		t.Fatalf("notify count = %d, want 2", notifier.callCount())
+	if notifier.callCount() != 1 {
+		t.Fatalf("notify count = %d, want 1", notifier.callCount())
 	}
 
 	unread, err := store.Unread("proj-a", "agent-1")
@@ -146,43 +137,166 @@ func TestManager_HandleDeliveryRetriesNotifyAfterFailure(t *testing.T) {
 	if len(unread) != 1 {
 		t.Fatalf("unread count = %d, want 1", len(unread))
 	}
-	if unread[0].NotifiedAt.IsZero() {
-		t.Fatal("expected record to be marked notified after retry success")
+	if rec.NotifiedAt.IsZero() {
+		t.Fatalf("record = %+v, want notified_at set", rec)
 	}
-	if unread[0].RetryAttempts != 0 || !unread[0].RetryNextAt.IsZero() || !unread[0].RetryExhaustedAt.IsZero() {
-		t.Fatalf("record retry state after success = %+v, want cleared retry state", unread[0])
+	if rec.RetryAttempts != 0 || !rec.RetryNextAt.IsZero() || !rec.RetryExhaustedAt.IsZero() {
+		t.Fatalf("record retry state after best-effort notify = %+v, want cleared retry state", rec)
+	}
+}
+
+func TestManager_NotifyRecordLeavesPendingWhenSignalCapExceeded(t *testing.T) {
+	store := newTestStore(t)
+	notifier := &fakeNotifier{}
+	manager := NewManager(store, newFakeListenerFactory(), notifier)
+	manager.SetSignalDir(t.TempDir())
+
+	record := DeliveryRecord{
+		ProjectID:  "proj-a",
+		AgentName:  "agent-1",
+		MessageID:  99,
+		FromName:   "planner",
+		Body:       strings.Repeat("x", 256),
+		SentAt:     time.Unix(40, 0).UTC(),
+		ReceivedAt: time.Unix(41, 0).UTC(),
+	}
+	if _, err := store.AddRecordIfAbsent(record); err != nil {
+		t.Fatal(err)
+	}
+
+	origCap := config.Defaults.SignalMaxBytes
+	config.Defaults.SignalMaxBytes = 32
+	t.Cleanup(func() {
+		config.Defaults.SignalMaxBytes = origCap
+	})
+
+	if err := manager.notifyRecord(record.ProjectID, record.AgentName, record.MessageID, notificationTitle(Delivery{FromName: record.FromName}), record.Body); err != nil {
+		t.Fatalf("notifyRecord returned unexpected error: %v", err)
+	}
+
+	rec, err := store.GetRecord(record.ProjectID, record.AgentName, record.MessageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rec.NotifiedAt.IsZero() {
+		t.Fatalf("record = %+v, want notification to remain pending", rec)
+	}
+
+	pending, err := store.PendingNotifications(record.ProjectID, record.AgentName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 1 || pending[0].MessageID != record.MessageID {
+		t.Fatalf("pending notifications = %+v, want message %d still pending", pending, record.MessageID)
+	}
+	if notifier.callCount() != 0 {
+		t.Fatalf("notify count = %d, want 0 when signal write fails", notifier.callCount())
+	}
+}
+
+func TestManager_NotifyRecordSkipsNotifierWhenMarkNotifiedFails(t *testing.T) {
+	store := newTestStore(t)
+	notifier := &fakeNotifier{}
+	manager := NewManager(store, newFakeListenerFactory(), notifier)
+	signalDir := t.TempDir()
+	manager.SetSignalDir(signalDir)
+
+	record := DeliveryRecord{
+		ProjectID:  "proj-a",
+		AgentName:  "agent-1",
+		MessageID:  100,
+		FromName:   "planner",
+		Body:       "persist before notify",
+		SentAt:     time.Unix(50, 0).UTC(),
+		ReceivedAt: time.Unix(51, 0).UTC(),
+	}
+	if _, err := store.AddRecordIfAbsent(record); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	err := manager.notifyRecord(record.ProjectID, record.AgentName, record.MessageID, notificationTitle(Delivery{FromName: record.FromName}), record.Body)
+	if err == nil {
+		t.Fatal("expected notifyRecord to return mark-notified error")
+	}
+	if notifier.callCount() != 0 {
+		t.Fatalf("notify count = %d, want 0 when mark-notified fails", notifier.callCount())
+	}
+
+	signalPath := filepath.Join(signalDir, ProjectPathKey(record.ProjectID), record.AgentName)
+	data, readErr := os.ReadFile(signalPath)
+	if readErr != nil {
+		t.Fatalf("read signal: %v", readErr)
+	}
+	if !strings.Contains(string(data), record.Body) {
+		t.Fatalf("signal content = %q, want body %q", data, record.Body)
+	}
+}
+
+func TestManager_NotifyRecordIgnoresNotifierFailureAfterMarkNotified(t *testing.T) {
+	store := newTestStore(t)
+	notifier := &fakeNotifier{errs: []error{errors.New("notify failed")}}
+	manager := NewManager(store, newFakeListenerFactory(), notifier)
+	manager.SetSignalDir(t.TempDir())
+
+	record := DeliveryRecord{
+		ProjectID:  "proj-a",
+		AgentName:  "agent-1",
+		MessageID:  101,
+		FromName:   "planner",
+		Body:       "best effort notifier",
+		SentAt:     time.Unix(60, 0).UTC(),
+		ReceivedAt: time.Unix(61, 0).UTC(),
+	}
+	if _, err := store.AddRecordIfAbsent(record); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := manager.notifyRecord(record.ProjectID, record.AgentName, record.MessageID, notificationTitle(Delivery{FromName: record.FromName}), record.Body); err != nil {
+		t.Fatalf("notifyRecord() error = %v, want nil", err)
+	}
+	if notifier.callCount() != 1 {
+		t.Fatalf("notify count = %d, want 1", notifier.callCount())
+	}
+
+	rec, err := store.GetRecord(record.ProjectID, record.AgentName, record.MessageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.NotifiedAt.IsZero() {
+		t.Fatalf("record = %+v, want notified_at set", rec)
 	}
 }
 
 func TestManager_GlobalRetrySweepRetriesPendingNotificationsAcrossMultipleWatches(t *testing.T) {
 	store := newTestStore(t)
-	manager := NewManager(store, newFakeListenerFactory(), &fakeNotifier{
-		errs: []error{
-			errors.New("first watch retry failed"),
-			errors.New("second watch retry failed"),
-			nil,
-			nil,
-		},
-	})
+	notifier := &fakeNotifier{}
+	manager := NewManager(store, newFakeListenerFactory(), notifier)
 
 	records := []DeliveryRecord{
 		{
-			ProjectID:  "proj-a",
-			AgentName:  "agent-1",
-			MessageID:  1,
-			FromName:   "planner",
-			Body:       "first",
-			SentAt:     time.Unix(80, 0).UTC(),
-			ReceivedAt: time.Unix(81, 0).UTC(),
+			ProjectID:     "proj-a",
+			AgentName:     "agent-1",
+			MessageID:     1,
+			FromName:      "planner",
+			Body:          "first",
+			SentAt:        time.Unix(80, 0).UTC(),
+			ReceivedAt:    time.Unix(81, 0).UTC(),
+			RetryAttempts: 1,
+			RetryNextAt:   time.Now().UTC().Add(-time.Millisecond),
 		},
 		{
-			ProjectID:  "proj-b",
-			AgentName:  "agent-2",
-			MessageID:  2,
-			FromName:   "planner",
-			Body:       "second",
-			SentAt:     time.Unix(82, 0).UTC(),
-			ReceivedAt: time.Unix(83, 0).UTC(),
+			ProjectID:     "proj-b",
+			AgentName:     "agent-2",
+			MessageID:     2,
+			FromName:      "planner",
+			Body:          "second",
+			SentAt:        time.Unix(82, 0).UTC(),
+			ReceivedAt:    time.Unix(83, 0).UTC(),
+			RetryAttempts: 1,
+			RetryNextAt:   time.Now().UTC().Add(-time.Millisecond),
 		},
 	}
 	for _, rec := range records {
@@ -192,28 +306,7 @@ func TestManager_GlobalRetrySweepRetriesPendingNotificationsAcrossMultipleWatche
 	}
 
 	if err := manager.retryPendingNotifications(); err != nil {
-		t.Fatalf("first retry sweep returned error: %v", err)
-	}
-
-	for _, tc := range []struct {
-		projectID string
-		agentName string
-		messageID int64
-	}{
-		{projectID: "proj-a", agentName: "agent-1", messageID: 1},
-		{projectID: "proj-b", agentName: "agent-2", messageID: 2},
-	} {
-		rec, err := store.GetRecord(tc.projectID, tc.agentName, tc.messageID)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := store.RecordNotificationFailure(tc.projectID, tc.agentName, tc.messageID, rec.RetryAttempts, time.Now().UTC().Add(-time.Millisecond), time.Time{}); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	if err := manager.retryPendingNotifications(); err != nil {
-		t.Fatalf("second retry sweep returned error: %v", err)
+		t.Fatalf("retry sweep returned error: %v", err)
 	}
 
 	for _, tc := range []struct {
@@ -231,6 +324,9 @@ func TestManager_GlobalRetrySweepRetriesPendingNotificationsAcrossMultipleWatche
 		if rec.NotifiedAt.IsZero() {
 			t.Fatalf("record %s/%s/%d not marked notified", tc.projectID, tc.agentName, tc.messageID)
 		}
+	}
+	if notifier.callCount() != 2 {
+		t.Fatalf("notify count = %d, want 2", notifier.callCount())
 	}
 }
 
@@ -489,7 +585,7 @@ func TestManager_StopWatchClearsWorkerErrorsButPreservesDetachedInflightState(t 
 	})
 }
 
-func TestManager_RetryPendingNotificationsUsesBacklogErrorKeyAfterWatchRemoval(t *testing.T) {
+func TestManager_RetryPendingNotificationsMarksNotifiedAfterWatchRemovalDespiteNotifierFailure(t *testing.T) {
 	store := newTestStore(t)
 	watch := Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}
 	if err := store.UpsertWatch(watch); err != nil {
@@ -530,21 +626,20 @@ func TestManager_RetryPendingNotificationsUsesBacklogErrorKeyAfterWatchRemoval(t
 	}
 
 	err := manager.LastDeliveryError()
-	if err == nil {
-		t.Fatal("LastDeliveryError() = nil, want backlog delivery error")
+	if err != nil {
+		t.Fatalf("LastDeliveryError() = %v, want nil", err)
 	}
-	if strings.Contains(err.Error(), watchDeliveryErrorKey("proj-a", "agent-1")) {
-		t.Fatalf("LastDeliveryError() = %v, want no watch-delivery key after watch removal", err)
+
+	rec, err := store.GetRecord("proj-a", "agent-1", 404)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), backlogDeliveryErrorKey("proj-a", "agent-1")) {
-		t.Fatalf("LastDeliveryError() = %v, want backlog-delivery key", err)
-	}
-	if !strings.Contains(err.Error(), "notify failed") {
-		t.Fatalf("LastDeliveryError() = %v, want preserved notifier failure detail", err)
+	if rec.NotifiedAt.IsZero() {
+		t.Fatalf("record = %+v, want notified after backlog retry", rec)
 	}
 }
 
-func TestManager_RetryPendingNotificationsClassifiesBlockedFailureAfterConcurrentWatchRemoval(t *testing.T) {
+func TestManager_RetryPendingNotificationsIgnoresBlockedNotifierFailureAfterConcurrentWatchRemoval(t *testing.T) {
 	store := newTestStore(t)
 	watch := Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}
 	if err := store.UpsertWatch(watch); err != nil {
@@ -600,21 +695,20 @@ func TestManager_RetryPendingNotificationsClassifiesBlockedFailureAfterConcurren
 	}
 
 	err := manager.LastDeliveryError()
-	if err == nil {
-		t.Fatal("LastDeliveryError() = nil, want backlog delivery error after concurrent watch removal")
+	if err != nil {
+		t.Fatalf("LastDeliveryError() = %v, want nil", err)
 	}
-	if strings.Contains(err.Error(), watchDeliveryErrorKey("proj-a", "agent-1")) {
-		t.Fatalf("LastDeliveryError() = %v, want no watch-delivery key after concurrent watch removal", err)
+
+	rec, err := store.GetRecord("proj-a", "agent-1", 406)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), backlogDeliveryErrorKey("proj-a", "agent-1")) {
-		t.Fatalf("LastDeliveryError() = %v, want backlog-delivery key after concurrent watch removal", err)
-	}
-	if !strings.Contains(err.Error(), "blocked retry notify failed") {
-		t.Fatalf("LastDeliveryError() = %v, want blocked notifier failure detail", err)
+	if rec.NotifiedAt.IsZero() {
+		t.Fatalf("record = %+v, want notified despite blocked notifier failure", rec)
 	}
 }
 
-func TestManager_RetryPendingNotificationsClassifiesBlockedFailureAfterConcurrentWatchReAdd(t *testing.T) {
+func TestManager_RetryPendingNotificationsIgnoresBlockedNotifierFailureAfterConcurrentWatchReAdd(t *testing.T) {
 	store := newTestStore(t)
 	watch := Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}
 	if err := store.UpsertWatch(watch); err != nil {
@@ -678,21 +772,20 @@ func TestManager_RetryPendingNotificationsClassifiesBlockedFailureAfterConcurren
 	}
 
 	err := manager.LastDeliveryError()
-	if err == nil {
-		t.Fatal("LastDeliveryError() = nil, want watch delivery error after concurrent watch re-add")
+	if err != nil {
+		t.Fatalf("LastDeliveryError() = %v, want nil", err)
 	}
-	if strings.Contains(err.Error(), backlogDeliveryErrorKey("proj-a", "agent-1")) {
-		t.Fatalf("LastDeliveryError() = %v, want no backlog-delivery key after concurrent watch re-add", err)
+
+	rec, err := store.GetRecord("proj-a", "agent-1", 407)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), watchDeliveryErrorKey("proj-a", "agent-1")) {
-		t.Fatalf("LastDeliveryError() = %v, want watch-delivery key after concurrent watch re-add", err)
-	}
-	if !strings.Contains(err.Error(), "blocked retry notify failed after re-add") {
-		t.Fatalf("LastDeliveryError() = %v, want blocked notifier failure detail", err)
+	if rec.NotifiedAt.IsZero() {
+		t.Fatalf("record = %+v, want notified despite blocked notifier failure", rec)
 	}
 }
 
-func TestManager_BacklogRetrySuccessClearsBacklogErrorKey(t *testing.T) {
+func TestManager_BacklogRetryIgnoresNotifierFailure(t *testing.T) {
 	store := newTestStore(t)
 	if _, err := store.AddRecordIfAbsent(DeliveryRecord{
 		ProjectID:     "proj-a",
@@ -712,26 +805,19 @@ func TestManager_BacklogRetrySuccessClearsBacklogErrorKey(t *testing.T) {
 	manager := NewManager(store, newFakeListenerFactory(), notifier)
 
 	if err := manager.retryPendingNotifications(); err != nil {
-		t.Fatalf("first retryPendingNotifications returned unexpected error: %v", err)
+		t.Fatalf("retryPendingNotifications returned unexpected error: %v", err)
 	}
 	err := manager.LastDeliveryError()
-	if err == nil || !strings.Contains(err.Error(), backlogDeliveryErrorKey("proj-a", "agent-1")) {
-		t.Fatalf("LastDeliveryError() = %v, want backlog-delivery error after failure", err)
+	if err != nil {
+		t.Fatalf("LastDeliveryError() = %v, want nil", err)
 	}
 
 	rec, err := store.GetRecord("proj-a", "agent-1", 505)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := store.RecordNotificationFailure("proj-a", "agent-1", 505, rec.RetryAttempts, time.Now().UTC().Add(-time.Millisecond), time.Time{}); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := manager.retryPendingNotifications(); err != nil {
-		t.Fatalf("second retryPendingNotifications returned unexpected error: %v", err)
-	}
-	if err := manager.LastDeliveryError(); err != nil {
-		t.Fatalf("LastDeliveryError() = %v, want nil after backlog retry success", err)
+	if rec.NotifiedAt.IsZero() {
+		t.Fatalf("record = %+v, want notified after backlog retry", rec)
 	}
 }
 
@@ -858,7 +944,7 @@ func TestManager_StopWatchRefreshErrorKeyDoesNotClearSiblingRefreshError(t *test
 	})
 }
 
-func TestManager_SameWatchSuccessDoesNotClearSiblingFailure(t *testing.T) {
+func TestManager_SameWatchBestEffortNotifierFailureLeavesNoDeliveryError(t *testing.T) {
 	store := newTestStore(t)
 	watch := Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}
 	if err := store.UpsertWatch(watch); err != nil {
@@ -909,22 +995,16 @@ func TestManager_SameWatchSuccessDoesNotClearSiblingFailure(t *testing.T) {
 	}
 
 	err := manager.LastDeliveryError()
-	if err == nil {
-		t.Fatal("LastDeliveryError() = nil, want active watch-delivery error")
-	}
-	if !strings.Contains(err.Error(), watchDeliveryErrorKey("proj-a", "agent-1")) {
-		t.Fatalf("LastDeliveryError() = %v, want watch-delivery key to remain while sibling failure exists", err)
-	}
-	if !strings.Contains(err.Error(), "first still failing") {
-		t.Fatalf("LastDeliveryError() = %v, want preserved notifier failure detail", err)
+	if err != nil {
+		t.Fatalf("LastDeliveryError() = %v, want nil", err)
 	}
 
 	failed, err := store.GetRecord("proj-a", "agent-1", 601)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if failed.NotifiedAt.IsZero() && failed.RetryAttempts == 0 {
-		t.Fatalf("failed record = %+v, want unresolved failed retry state", failed)
+	if failed.NotifiedAt.IsZero() {
+		t.Fatalf("failed record = %+v, want notified", failed)
 	}
 	succeeded, err := store.GetRecord("proj-a", "agent-1", 602)
 	if err != nil {
@@ -977,7 +1057,7 @@ func TestManager_RestartsWatchAfterListenerError(t *testing.T) {
 	}
 }
 
-func TestManager_RetriesPendingNotificationAfterRestart(t *testing.T) {
+func TestManager_MarksNotifiedAfterRestartDespiteNotifierFailure(t *testing.T) {
 	store := newTestStore(t)
 	if err := store.UpsertWatch(Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}); err != nil {
 		t.Fatal(err)
@@ -1003,15 +1083,15 @@ func TestManager_RetriesPendingNotificationAfterRestart(t *testing.T) {
 		t.Fatalf("emit should not tear down listener on notify failure: %v", err)
 	}
 
-	waitFor(t, "pending notification retry", func() bool {
+	waitFor(t, "best-effort notifier after restart", func() bool {
 		rec, err := store.GetRecord("proj-a", "agent-1", 123)
-		return err == nil && !rec.NotifiedAt.IsZero() && notifier.callCount() >= 2
+		return err == nil && !rec.NotifiedAt.IsZero() && notifier.callCount() >= 1
 	})
 }
 
 func TestManager_UsesRuntimeRetrySweepInterval(t *testing.T) {
 	store := newTestStore(t)
-	notifier := &fakeNotifier{errs: []error{errors.New("notify failed"), nil}}
+	notifier := &fakeNotifier{}
 	manager := NewManager(store, newFakeListenerFactory(), notifier)
 
 	origPoll := config.Defaults.PollInterval
@@ -1026,27 +1106,23 @@ func TestManager_UsesRuntimeRetrySweepInterval(t *testing.T) {
 	}
 	defer manager.Stop()
 
-	if err := manager.handleDelivery(Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}, Delivery{
-		MessageID:  222,
-		FromName:   "planner",
-		Body:       "retry on timer",
-		SentAt:     time.Unix(90, 0).UTC(),
-		ReceivedAt: time.Unix(91, 0).UTC(),
+	if _, err := store.AddRecordIfAbsent(DeliveryRecord{
+		MessageID:     222,
+		ProjectID:     "proj-a",
+		AgentName:     "agent-1",
+		FromName:      "planner",
+		Body:          "retry on timer",
+		SentAt:        time.Unix(90, 0).UTC(),
+		ReceivedAt:    time.Unix(91, 0).UTC(),
+		RetryAttempts: 1,
+		RetryNextAt:   time.Now().UTC().Add(-time.Millisecond),
 	}); err != nil {
-		t.Fatal(err)
-	}
-
-	rec, err := store.GetRecord("proj-a", "agent-1", 222)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := store.RecordNotificationFailure("proj-a", "agent-1", 222, rec.RetryAttempts, time.Now().UTC().Add(-time.Millisecond), time.Time{}); err != nil {
 		t.Fatal(err)
 	}
 
 	waitFor(t, "retry sweep interval", func() bool {
 		rec, err := store.GetRecord("proj-a", "agent-1", 222)
-		return err == nil && !rec.NotifiedAt.IsZero() && notifier.callCount() >= 2
+		return err == nil && !rec.NotifiedAt.IsZero() && notifier.callCount() >= 1
 	})
 }
 
@@ -1088,11 +1164,12 @@ func TestManager_RetriesCatchUpBeforeListening(t *testing.T) {
 	})
 }
 
-func TestManager_RetryPendingNotificationsContinuesPastFailedRecord(t *testing.T) {
+func TestManager_RetryPendingNotificationsContinuesPastBestEffortNotifierFailure(t *testing.T) {
 	store := newTestStore(t)
-	manager := NewManager(store, newFakeListenerFactory(), &fakeNotifier{
+	notifier := &fakeNotifier{
 		errs: []error{errors.New("first notify failed"), nil},
-	})
+	}
+	manager := NewManager(store, newFakeListenerFactory(), notifier)
 
 	first := DeliveryRecord{
 		ProjectID:  "proj-a",
@@ -1131,11 +1208,14 @@ func TestManager_RetryPendingNotificationsContinuesPastFailedRecord(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !rec1.NotifiedAt.IsZero() {
-		t.Fatal("expected first record to remain unnotified after notify failure")
+	if rec1.NotifiedAt.IsZero() {
+		t.Fatal("expected first record to be marked notified despite notifier failure")
 	}
 	if rec2.NotifiedAt.IsZero() {
 		t.Fatal("expected second record to be notified despite earlier failure")
+	}
+	if notifier.callCount() != 2 {
+		t.Fatalf("notify count = %d, want 2", notifier.callCount())
 	}
 }
 
@@ -1268,7 +1348,7 @@ func TestManager_PendingRetryPreservesInflightAcrossWatchRemoveAndReAdd(t *testi
 	}
 }
 
-func TestManager_HandleDeliveryClassifiesBlockedFailureAfterConcurrentWatchRemoval(t *testing.T) {
+func TestManager_HandleDeliveryIgnoresBlockedNotifierFailureAfterConcurrentWatchRemoval(t *testing.T) {
 	store := newTestStore(t)
 	watch := Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}
 	if err := store.UpsertWatch(watch); err != nil {
@@ -1317,21 +1397,20 @@ func TestManager_HandleDeliveryClassifiesBlockedFailureAfterConcurrentWatchRemov
 	}
 
 	err := manager.LastDeliveryError()
-	if err == nil {
-		t.Fatal("LastDeliveryError() = nil, want backlog delivery error after concurrent watch removal")
+	if err != nil {
+		t.Fatalf("LastDeliveryError() = %v, want nil", err)
 	}
-	if strings.Contains(err.Error(), watchDeliveryErrorKey("proj-a", "agent-1")) {
-		t.Fatalf("LastDeliveryError() = %v, want no watch-delivery key after concurrent watch removal", err)
+
+	rec, err := store.GetRecord("proj-a", "agent-1", 778)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), backlogDeliveryErrorKey("proj-a", "agent-1")) {
-		t.Fatalf("LastDeliveryError() = %v, want backlog-delivery key after concurrent watch removal", err)
-	}
-	if !strings.Contains(err.Error(), "blocked live notify failed") {
-		t.Fatalf("LastDeliveryError() = %v, want blocked notifier failure detail", err)
+	if rec.NotifiedAt.IsZero() {
+		t.Fatalf("record = %+v, want notified despite blocked notifier failure", rec)
 	}
 }
 
-func TestManager_HandleDeliveryClassifiesBlockedFailureAfterConcurrentWatchReAdd(t *testing.T) {
+func TestManager_HandleDeliveryIgnoresBlockedNotifierFailureAfterConcurrentWatchReAdd(t *testing.T) {
 	store := newTestStore(t)
 	watch := Watch{ProjectID: "proj-a", AgentName: "agent-1", Source: "hook"}
 	if err := store.UpsertWatch(watch); err != nil {
@@ -1392,17 +1471,16 @@ func TestManager_HandleDeliveryClassifiesBlockedFailureAfterConcurrentWatchReAdd
 	}
 
 	err := manager.LastDeliveryError()
-	if err == nil {
-		t.Fatal("LastDeliveryError() = nil, want watch delivery error after concurrent watch re-add")
+	if err != nil {
+		t.Fatalf("LastDeliveryError() = %v, want nil", err)
 	}
-	if strings.Contains(err.Error(), backlogDeliveryErrorKey("proj-a", "agent-1")) {
-		t.Fatalf("LastDeliveryError() = %v, want no backlog-delivery key after concurrent watch re-add", err)
+
+	rec, err := store.GetRecord("proj-a", "agent-1", 779)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), watchDeliveryErrorKey("proj-a", "agent-1")) {
-		t.Fatalf("LastDeliveryError() = %v, want watch-delivery key after concurrent watch re-add", err)
-	}
-	if !strings.Contains(err.Error(), "blocked live notify failed after re-add") {
-		t.Fatalf("LastDeliveryError() = %v, want blocked notifier failure detail", err)
+	if rec.NotifiedAt.IsZero() {
+		t.Fatalf("record = %+v, want notified despite blocked notifier failure", rec)
 	}
 }
 

--- a/internal/runtime/sanitize.go
+++ b/internal/runtime/sanitize.go
@@ -1,0 +1,26 @@
+package runtime
+
+import "strings"
+
+// SanitizeAgentName normalizes agent identifiers for persistent storage and file paths.
+func SanitizeAgentName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	prevDash := false
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			prevDash = false
+			continue
+		}
+		if !prevDash {
+			b.WriteByte('-')
+			prevDash = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}

--- a/internal/runtime/signal.go
+++ b/internal/runtime/signal.go
@@ -4,14 +4,72 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 )
 
+// ansiPattern matches ANSI escape sequences:
+// - CSI: ESC [ (params including ?, !, >, space, etc.) final byte
+// - OSC: ESC ] ... (BEL or ST)
+// - DCS: ESC P ... ST
+// - Simple ESC: ESC + letter
+var ansiPattern = regexp.MustCompile("(?:" +
+	`\x1b\[[0-9;?!>"' ]*[A-Za-z@]` + "|" + // CSI with intermediate bytes
+	`\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)` + "|" + // OSC terminated by BEL or ST
+	`\x1bP[^\x1b]*(?:\x1b\\)?` + "|" + // DCS with payload + optional ST
+	`\x1b[A-Za-z]` + // Simple ESC sequences
+	")")
+
+// SanitizeProjectIDForPath transforms a project ID into a filesystem-safe directory name.
+// Replaces non-alphanumeric characters (slashes, colons, dots) with hyphens and collapses runs.
+// Deterministic: same input always produces same output.
+// Handles both git SHA hashes ("abcdef01") and path-based IDs ("path:/Users/foo").
+func SanitizeProjectIDForPath(id string) string {
+	if id == "" {
+		return ""
+	}
+	var b strings.Builder
+	prevDash := false
+	for _, r := range id {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
+			b.WriteRune(r)
+			prevDash = false
+		} else if !prevDash {
+			b.WriteByte('-')
+			prevDash = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// stripANSI removes ANSI escape sequences and dangerous control characters from s.
+// Preserves \n and \t for legitimate formatting.
+func stripANSI(s string) string {
+	s = ansiPattern.ReplaceAllString(s, "")
+	// Strip raw C0 control chars (CR, BS, BEL, etc.) and C1 range (0x80-0x9F)
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 && r != '\n' && r != '\t' {
+			return -1
+		}
+		if r >= 0x7f && r <= 0x9f {
+			return -1
+		}
+		return r
+	}, s)
+}
+
 // WriteSignal appends a formatted message to the agent's signal file.
 // Drops the write silently if the file would exceed maxBytes after append.
+// Sanitizes projectID (path traversal) and strips ANSI escapes from body (terminal hijack).
 func WriteSignal(signalDir, projectID, agentName, fromName, body string, maxBytes int64) error {
-	dir := filepath.Join(signalDir, projectID)
+	safeProjectID := SanitizeProjectIDForPath(projectID)
+	if safeProjectID == "" {
+		return fmt.Errorf("empty project ID after sanitization")
+	}
+	body = stripANSI(body)
+	fromName = stripANSI(fromName)
+	dir := filepath.Join(signalDir, safeProjectID)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create signal dir: %w", err)
 	}
@@ -38,7 +96,11 @@ func WriteSignal(signalDir, projectID, agentName, fromName, body string, maxByte
 // ConsumeSignal atomically reads and removes the signal file.
 // Rename-then-read ensures no data loss if the daemon writes during consume.
 func ConsumeSignal(signalDir, projectID, agentName string) (string, error) {
-	path := filepath.Join(signalDir, projectID, agentName)
+	safeProjectID := SanitizeProjectIDForPath(projectID)
+	if safeProjectID == "" {
+		return "", fmt.Errorf("empty project ID after sanitization")
+	}
+	path := filepath.Join(signalDir, safeProjectID, agentName)
 	tmp := fmt.Sprintf("%s.consuming-%d", path, time.Now().UnixNano())
 	if err := os.Rename(path, tmp); err != nil {
 		if os.IsNotExist(err) {

--- a/internal/runtime/signal.go
+++ b/internal/runtime/signal.go
@@ -1,12 +1,17 @@
 package runtime
 
 import (
+	"errors"
 	"fmt"
+	"hash/fnv"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/seungpyoson/waggle/internal/fsutil"
 )
 
 // ansiPattern matches ANSI escape sequences:
@@ -15,32 +20,23 @@ import (
 // - DCS: ESC P ... ST
 // - Simple ESC: ESC + letter
 var ansiPattern = regexp.MustCompile("(?:" +
-	`\x1b\[[0-9;?!>"' ]*[A-Za-z@]` + "|" + // CSI with intermediate bytes
+	`\x1b\[[\x20-\x3f]*[A-Za-z@]` + "|" + // CSI with full ECMA-48 parameter/intermediate bytes
 	`\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)` + "|" + // OSC terminated by BEL or ST
 	`\x1bP[^\x1b]*(?:\x1b\\)?` + "|" + // DCS with payload + optional ST
 	`\x1b[A-Za-z]` + // Simple ESC sequences
 	")")
 
-// SanitizeProjectIDForPath transforms a project ID into a filesystem-safe directory name.
-// Replaces non-alphanumeric characters (slashes, colons, dots) with hyphens and collapses runs.
-// Deterministic: same input always produces same output.
-// Handles both git SHA hashes ("abcdef01") and path-based IDs ("path:/Users/foo").
-func SanitizeProjectIDForPath(id string) string {
-	if id == "" {
+var ErrSignalCapExceeded = errors.New("signal cap exceeded")
+
+// ProjectPathKey returns the opaque filesystem key for a project ID.
+// It uses a 64-bit FNV-1a hash truncated to 12 lowercase hex characters.
+func ProjectPathKey(rawID string) string {
+	if rawID == "" {
 		return ""
 	}
-	var b strings.Builder
-	prevDash := false
-	for _, r := range id {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
-			b.WriteRune(r)
-			prevDash = false
-		} else if !prevDash {
-			b.WriteByte('-')
-			prevDash = true
-		}
-	}
-	return strings.Trim(b.String(), "-")
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(rawID))
+	return fmt.Sprintf("%012x", h.Sum64()&0xffffffffffff)
 }
 
 // stripANSI removes ANSI escape sequences and dangerous control characters from s.
@@ -60,20 +56,38 @@ func stripANSI(s string) string {
 }
 
 // WriteSignal appends a formatted message to the agent's signal file.
-// Drops the write silently if the file would exceed maxBytes after append.
-// Sanitizes projectID (path traversal) and strips ANSI escapes from body (terminal hijack).
+// Returns ErrSignalCapExceeded if the file would exceed maxBytes after append.
+// Hashes projectID to an opaque path key, sanitizes agentName, and strips ANSI escapes from body.
 func WriteSignal(signalDir, projectID, agentName, fromName, body string, maxBytes int64) error {
-	safeProjectID := SanitizeProjectIDForPath(projectID)
-	if safeProjectID == "" {
-		return fmt.Errorf("empty project ID after sanitization")
+	projectKey := ProjectPathKey(projectID)
+	if projectKey == "" {
+		return fmt.Errorf("empty project ID")
+	}
+	safeAgentName := SanitizeAgentName(agentName)
+	if safeAgentName == "" {
+		return fmt.Errorf("empty agent name after sanitization")
 	}
 	body = stripANSI(body)
 	fromName = stripANSI(fromName)
-	dir := filepath.Join(signalDir, safeProjectID)
+	dir := filepath.Join(signalDir, projectKey)
+	signalRoot := filepath.Dir(signalDir)
+	if fsutil.HasAncestorSymlink(dir, signalRoot) {
+		return fmt.Errorf("refusing to create signal dir with ancestor symlink: %s", dir)
+	}
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create signal dir: %w", err)
 	}
-	path := filepath.Join(dir, agentName)
+	path := filepath.Join(dir, safeAgentName)
+	if fsutil.HasAncestorSymlink(path, signalRoot) {
+		return fmt.Errorf("refusing to write signal through ancestor symlink: %s", path)
+	}
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to overwrite symlink: %s", path)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("lstat signal: %w", err)
+	}
 	msg := fmt.Sprintf("📨 waggle message from %s: %s\n", fromName, body)
 	if maxBytes > 0 {
 		existing := int64(0)
@@ -81,7 +95,8 @@ func WriteSignal(signalDir, projectID, agentName, fromName, body string, maxByte
 			existing = info.Size()
 		}
 		if existing+int64(len(msg)) >= maxBytes {
-			return nil
+			log.Printf("dropping signal for %q/%q: cap %d bytes exceeded", projectKey, safeAgentName, maxBytes)
+			return ErrSignalCapExceeded
 		}
 	}
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
@@ -93,33 +108,11 @@ func WriteSignal(signalDir, projectID, agentName, fromName, body string, maxByte
 	return err
 }
 
-// ConsumeSignal atomically reads and removes the signal file.
-// Rename-then-read ensures no data loss if the daemon writes during consume.
-func ConsumeSignal(signalDir, projectID, agentName string) (string, error) {
-	safeProjectID := SanitizeProjectIDForPath(projectID)
-	if safeProjectID == "" {
-		return "", fmt.Errorf("empty project ID after sanitization")
-	}
-	path := filepath.Join(signalDir, safeProjectID, agentName)
-	tmp := fmt.Sprintf("%s.consuming-%d", path, time.Now().UnixNano())
-	if err := os.Rename(path, tmp); err != nil {
-		if os.IsNotExist(err) {
-			return "", nil
-		}
-		return "", err
-	}
-	data, err := os.ReadFile(tmp)
-	os.Remove(tmp)
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(data)), nil
-}
-
 // PruneStaleFiles removes files matching prefix older than maxAge.
 func PruneStaleFiles(dir, prefix string, maxAge time.Duration) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
+		// Best-effort cleanup: skip unreadable directories to keep runtime cleanup non-fatal.
 		return
 	}
 	cutoff := time.Now().Add(-maxAge)
@@ -132,6 +125,7 @@ func PruneStaleFiles(dir, prefix string, maxAge time.Duration) {
 			continue
 		}
 		if info.ModTime().Before(cutoff) {
+			// Best-effort cleanup: stale files may already be gone after concurrent cleanup.
 			os.Remove(filepath.Join(dir, e.Name()))
 		}
 	}
@@ -141,6 +135,7 @@ func PruneStaleFiles(dir, prefix string, maxAge time.Duration) {
 func PruneStaleSignals(signalDir string, maxAge time.Duration) {
 	projects, err := os.ReadDir(signalDir)
 	if err != nil {
+		// Best-effort cleanup: skip unreadable signal roots to keep runtime cleanup non-fatal.
 		return
 	}
 	cutoff := time.Now().Add(-maxAge)
@@ -151,6 +146,7 @@ func PruneStaleSignals(signalDir string, maxAge time.Duration) {
 		projPath := filepath.Join(signalDir, proj.Name())
 		agents, err := os.ReadDir(projPath)
 		if err != nil {
+			// Best-effort cleanup: skip unreadable project directories and continue pruning others.
 			continue
 		}
 		for _, agent := range agents {
@@ -159,12 +155,15 @@ func PruneStaleSignals(signalDir string, maxAge time.Duration) {
 				continue
 			}
 			if info.ModTime().Before(cutoff) {
+				// Best-effort cleanup: stale files may already be gone after concurrent cleanup.
 				os.Remove(filepath.Join(projPath, agent.Name()))
 			}
 		}
 		// Remove empty project directories
+		// Best-effort cleanup: if the empty-dir probe fails, leave the directory for a later cycle.
 		remaining, _ := os.ReadDir(projPath)
 		if len(remaining) == 0 {
+			// Best-effort cleanup: another writer may recreate the directory before removal.
 			os.Remove(projPath)
 		}
 	}

--- a/internal/runtime/signal.go
+++ b/internal/runtime/signal.go
@@ -1,0 +1,70 @@
+package runtime
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// WriteSignal appends a formatted message to the agent's signal file.
+// Drops the write silently if the file already exceeds maxBytes.
+func WriteSignal(signalDir, agentName, fromName, body string, maxBytes int64) error {
+	if err := os.MkdirAll(signalDir, 0o700); err != nil {
+		return fmt.Errorf("create signal dir: %w", err)
+	}
+	path := filepath.Join(signalDir, agentName)
+	if maxBytes > 0 {
+		if info, err := os.Stat(path); err == nil && info.Size() >= maxBytes {
+			return nil
+		}
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("open signal: %w", err)
+	}
+	defer f.Close()
+	_, err = fmt.Fprintf(f, "📨 waggle message from %s: %s\n", fromName, body)
+	return err
+}
+
+// ConsumeSignal atomically reads and removes the signal file.
+// Rename-then-read ensures no data loss if the daemon writes during consume.
+func ConsumeSignal(signalDir, agentName string) (string, error) {
+	path := filepath.Join(signalDir, agentName)
+	tmp := fmt.Sprintf("%s.consuming-%d", path, time.Now().UnixNano())
+	if err := os.Rename(path, tmp); err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	data, err := os.ReadFile(tmp)
+	os.Remove(tmp)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// PruneStaleFiles removes files matching prefix older than maxAge.
+func PruneStaleFiles(dir, prefix string, maxAge time.Duration) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-maxAge)
+	for _, e := range entries {
+		if !strings.HasPrefix(e.Name(), prefix) {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if info.ModTime().Before(cutoff) {
+			os.Remove(filepath.Join(dir, e.Name()))
+		}
+	}
+}

--- a/internal/runtime/signal.go
+++ b/internal/runtime/signal.go
@@ -18,7 +18,11 @@ func WriteSignal(signalDir, projectID, agentName, fromName, body string, maxByte
 	path := filepath.Join(dir, agentName)
 	msg := fmt.Sprintf("📨 waggle message from %s: %s\n", fromName, body)
 	if maxBytes > 0 {
-		if info, err := os.Stat(path); err == nil && info.Size()+int64(len(msg)) >= maxBytes {
+		existing := int64(0)
+		if info, err := os.Stat(path); err == nil {
+			existing = info.Size()
+		}
+		if existing+int64(len(msg)) >= maxBytes {
 			return nil
 		}
 	}
@@ -33,8 +37,8 @@ func WriteSignal(signalDir, projectID, agentName, fromName, body string, maxByte
 
 // ConsumeSignal atomically reads and removes the signal file.
 // Rename-then-read ensures no data loss if the daemon writes during consume.
-func ConsumeSignal(signalDir, agentName string) (string, error) {
-	path := filepath.Join(signalDir, agentName)
+func ConsumeSignal(signalDir, projectID, agentName string) (string, error) {
+	path := filepath.Join(signalDir, projectID, agentName)
 	tmp := fmt.Sprintf("%s.consuming-%d", path, time.Now().UnixNano())
 	if err := os.Rename(path, tmp); err != nil {
 		if os.IsNotExist(err) {
@@ -67,6 +71,39 @@ func PruneStaleFiles(dir, prefix string, maxAge time.Duration) {
 		}
 		if info.ModTime().Before(cutoff) {
 			os.Remove(filepath.Join(dir, e.Name()))
+		}
+	}
+}
+
+// PruneStaleSignals removes signal files older than maxAge across all project subdirectories.
+func PruneStaleSignals(signalDir string, maxAge time.Duration) {
+	projects, err := os.ReadDir(signalDir)
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-maxAge)
+	for _, proj := range projects {
+		if !proj.IsDir() {
+			continue
+		}
+		projPath := filepath.Join(signalDir, proj.Name())
+		agents, err := os.ReadDir(projPath)
+		if err != nil {
+			continue
+		}
+		for _, agent := range agents {
+			info, err := agent.Info()
+			if err != nil {
+				continue
+			}
+			if info.ModTime().Before(cutoff) {
+				os.Remove(filepath.Join(projPath, agent.Name()))
+			}
+		}
+		// Remove empty project directories
+		remaining, _ := os.ReadDir(projPath)
+		if len(remaining) == 0 {
+			os.Remove(projPath)
 		}
 	}
 }

--- a/internal/runtime/signal.go
+++ b/internal/runtime/signal.go
@@ -9,14 +9,16 @@ import (
 )
 
 // WriteSignal appends a formatted message to the agent's signal file.
-// Drops the write silently if the file already exceeds maxBytes.
-func WriteSignal(signalDir, agentName, fromName, body string, maxBytes int64) error {
-	if err := os.MkdirAll(signalDir, 0o700); err != nil {
+// Drops the write silently if the file would exceed maxBytes after append.
+func WriteSignal(signalDir, projectID, agentName, fromName, body string, maxBytes int64) error {
+	dir := filepath.Join(signalDir, projectID)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create signal dir: %w", err)
 	}
-	path := filepath.Join(signalDir, agentName)
+	path := filepath.Join(dir, agentName)
+	msg := fmt.Sprintf("📨 waggle message from %s: %s\n", fromName, body)
 	if maxBytes > 0 {
-		if info, err := os.Stat(path); err == nil && info.Size() >= maxBytes {
+		if info, err := os.Stat(path); err == nil && info.Size()+int64(len(msg)) >= maxBytes {
 			return nil
 		}
 	}
@@ -25,7 +27,7 @@ func WriteSignal(signalDir, agentName, fromName, body string, maxBytes int64) er
 		return fmt.Errorf("open signal: %w", err)
 	}
 	defer f.Close()
-	_, err = fmt.Fprintf(f, "📨 waggle message from %s: %s\n", fromName, body)
+	_, err = f.WriteString(msg)
 	return err
 }
 

--- a/internal/runtime/signal_test.go
+++ b/internal/runtime/signal_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestWriteSignal_CreatesFileWithContent(t *testing.T) {
@@ -309,5 +310,60 @@ func TestSignalPipeline_EndToEnd(t *testing.T) {
 	}
 	if content2 != "" {
 		t.Fatalf("second consume should be empty, got %q", content2)
+	}
+}
+
+// TestPruneStaleSignals_RmdirCannotDeleteNonEmptyDir proves that os.Remove
+// on a directory with files fails with ENOTEMPTY. This disproves the claim
+// that a TOCTOU race in PruneStaleSignals could lose signal files — rmdir(2)
+// checks emptiness atomically in the kernel.
+func TestPruneStaleSignals_RmdirCannotDeleteNonEmptyDir(t *testing.T) {
+	base := t.TempDir()
+	dir := filepath.Join(base, "project")
+	os.MkdirAll(dir, 0o700)
+
+	// Write a file into the directory
+	os.WriteFile(filepath.Join(dir, "signal"), []byte("data"), 0o600)
+
+	// Attempt to remove the non-empty directory
+	err := os.Remove(dir)
+	if err == nil {
+		t.Fatal("os.Remove succeeded on non-empty directory — signal file would be lost")
+	}
+
+	// Verify the file survives
+	data, err := os.ReadFile(filepath.Join(dir, "signal"))
+	if err != nil {
+		t.Fatalf("signal file was lost: %v", err)
+	}
+	if string(data) != "data" {
+		t.Fatalf("signal file corrupted: %q", data)
+	}
+}
+
+// TestPruneStaleSignals_EmptyDirCleanedNextCycle proves that empty project
+// directories left behind by one prune cycle are cleaned up by the next.
+func TestPruneStaleSignals_EmptyDirCleanedNextCycle(t *testing.T) {
+	signalDir := t.TempDir()
+	projDir := filepath.Join(signalDir, "proj-abc")
+	os.MkdirAll(projDir, 0o700)
+
+	// Write a signal file with old mtime
+	sigPath := filepath.Join(projDir, "agent-1")
+	os.WriteFile(sigPath, []byte("old message"), 0o600)
+	old := time.Now().Add(-48 * time.Hour)
+	os.Chtimes(sigPath, old, old)
+
+	// First prune: removes the stale signal file, tries to remove dir
+	PruneStaleSignals(signalDir, 24*time.Hour)
+
+	// Signal file should be gone
+	if _, err := os.Stat(sigPath); !os.IsNotExist(err) {
+		t.Fatal("stale signal file should be removed")
+	}
+
+	// Directory should also be gone (it was empty after signal removal)
+	if _, err := os.Stat(projDir); !os.IsNotExist(err) {
+		t.Fatal("empty project directory should be cleaned up")
 	}
 }

--- a/internal/runtime/signal_test.go
+++ b/internal/runtime/signal_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -118,5 +119,195 @@ func TestConsumeSignal_NewWriteDuringConsume(t *testing.T) {
 	data2, _ := os.ReadFile(orig)
 	if !strings.Contains(string(data2), "bob") {
 		t.Fatalf("new message lost, orig = %q", data2)
+	}
+}
+
+func TestSanitizeProjectIDForPath_GitHash(t *testing.T) {
+	got := SanitizeProjectIDForPath("abcdef0123456789")
+	if got != "abcdef0123456789" {
+		t.Fatalf("got %q, want unchanged hex hash", got)
+	}
+}
+
+func TestSanitizeProjectIDForPath_PathTraversal(t *testing.T) {
+	got := SanitizeProjectIDForPath("../../etc/passwd")
+	if strings.Contains(got, "/") || strings.Contains(got, "..") {
+		t.Fatalf("path traversal not sanitized: %q", got)
+	}
+}
+
+func TestSanitizeProjectIDForPath_PathPrefix(t *testing.T) {
+	got := SanitizeProjectIDForPath("path:/Users/test/project")
+	if strings.Contains(got, "/") {
+		t.Fatalf("slashes not removed: %q", got)
+	}
+	if got == "" {
+		t.Fatal("should not be empty")
+	}
+}
+
+func TestSanitizeProjectIDForPath_Empty(t *testing.T) {
+	got := SanitizeProjectIDForPath("")
+	if got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+}
+
+func TestWriteSignal_StripsANSI(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"OSC52 clipboard", "hello \x1b]52;c;base64data\x07 world"},
+		{"CSI color", "hello \x1b[31mred\x1b[0m world"},
+		{"CSI private mode", "hello \x1b[?1049h world"},
+		{"CSI DEC private", "hello \x1b[?25l world"},
+		{"DCS sequence", "hello \x1bP1;2;3q#1PAYLOAD\x1b\\ world"},
+		{"raw CR overwrite", "safe\rOVERRIDE"},
+		{"raw BEL", "hello \x07 world"},
+		{"raw backspace", "hello \b world"},
+		{"C1 CSI equiv", "hello \x9b31m world"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := t.TempDir()
+			if err := WriteSignal(d, "abcdef01", "a", "alice", tt.input, 65536); err != nil {
+				t.Fatal(err)
+			}
+			data, _ := os.ReadFile(filepath.Join(d, "abcdef01", "a"))
+			s := string(data)
+			for _, b := range s {
+				if b < 0x20 && b != '\n' && b != '\t' {
+					t.Fatalf("control char %U not stripped in %q", b, s)
+				}
+				if b >= 0x7f && b <= 0x9f {
+					t.Fatalf("C1 char %U not stripped in %q", b, s)
+				}
+				if b == 0x1b {
+					t.Fatalf("ESC not stripped in %q", s)
+				}
+			}
+		})
+	}
+}
+
+func TestWriteSignal_StripsANSIFromSender(t *testing.T) {
+	dir := t.TempDir()
+	ansiFrom := "\x1b[31mevil\x1b[0m"
+	if err := WriteSignal(dir, "proj-test", "a", ansiFrom, "msg", 65536); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(filepath.Join(dir, "proj-test", "a"))
+	if strings.Contains(string(data), "\x1b") {
+		t.Fatalf("ANSI escape not stripped from sender: %q", data)
+	}
+	if !strings.Contains(string(data), "evil") {
+		t.Fatalf("sender name lost: %q", data)
+	}
+}
+
+func TestWriteSignal_RejectsEmptyProjectID(t *testing.T) {
+	dir := t.TempDir()
+	err := WriteSignal(dir, "", "a", "alice", "hello", 65536)
+	if err == nil {
+		t.Fatal("expected error for empty project ID")
+	}
+}
+
+func TestWriteSignal_SanitizesProjectIDPath(t *testing.T) {
+	dir := t.TempDir()
+	// Path traversal attempt — should NOT create dirs outside signal dir
+	err := WriteSignal(dir, "../../etc", "a", "alice", "hello", 65536)
+	if err != nil {
+		t.Fatal(err) // sanitizer transforms it, doesn't reject
+	}
+	// Verify it created a safe directory, not ../../etc
+	if _, err := os.Stat(filepath.Join(dir, "..", "..", "etc")); err == nil {
+		t.Fatal("path traversal succeeded!")
+	}
+}
+
+// TestSignalPipeline_EndToEnd exercises the full signal delivery path:
+// WriteSessionMapping → WriteSignal → two-hop file discovery → ConsumeSignal.
+// This is the Go equivalent of what shell-hook.sh and waggle-push.js do at runtime.
+func TestSignalPipeline_EndToEnd(t *testing.T) {
+	runtimeDir := t.TempDir()
+	signalDir := filepath.Join(runtimeDir, "signals")
+	os.MkdirAll(signalDir, 0o700)
+
+	ppid := 12345
+	agentName := "claude-code-test"
+	projectID := "abcdef0123456789"
+	safeProjectID := SanitizeProjectIDForPath(projectID)
+
+	// Step 1: Simulate bootstrap — generate nonce, write session mapping
+	nonce := "12345-1711843200000000000"
+	sessionPath := filepath.Join(runtimeDir, "agent-session-"+nonce)
+	os.WriteFile(sessionPath, []byte(agentName+"\n"+safeProjectID+"\n"), 0o600)
+	ppidPath := filepath.Join(runtimeDir, fmt.Sprintf("agent-ppid-%d", ppid))
+	os.WriteFile(ppidPath, []byte(nonce+"\n"), 0o600)
+
+	// Step 2: Daemon writes a signal (simulates notifyRecord → WriteSignal)
+	body := "hello from orchestrator"
+	if err := WriteSignal(signalDir, projectID, agentName, "orchestrator", body, 65536); err != nil {
+		t.Fatalf("WriteSignal: %v", err)
+	}
+
+	// Step 3: Simulate two-hop discovery (what the shell hook does)
+	// Read PPID pointer → get nonce
+	ppidData, err := os.ReadFile(ppidPath)
+	if err != nil {
+		t.Fatalf("read ppid pointer: %v", err)
+	}
+	discoveredNonce := strings.TrimSpace(string(ppidData))
+	if discoveredNonce != nonce {
+		t.Fatalf("nonce = %q, want %q", discoveredNonce, nonce)
+	}
+
+	// Read session file → get agent name + project
+	sessData, err := os.ReadFile(filepath.Join(runtimeDir, "agent-session-"+discoveredNonce))
+	if err != nil {
+		t.Fatalf("read session file: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(sessData)), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("session file has %d lines, want 2", len(lines))
+	}
+	discoveredAgent := lines[0]
+	discoveredProject := lines[1]
+	if discoveredAgent != agentName {
+		t.Fatalf("agent = %q, want %q", discoveredAgent, agentName)
+	}
+	if discoveredProject != safeProjectID {
+		t.Fatalf("project = %q, want %q", discoveredProject, safeProjectID)
+	}
+
+	// Step 4: Check signal file exists at expected path
+	sigPath := filepath.Join(signalDir, discoveredProject, discoveredAgent)
+	if _, err := os.Stat(sigPath); os.IsNotExist(err) {
+		t.Fatalf("signal file not found at %s", sigPath)
+	}
+
+	// Step 5: Consume signal (what the shell hook does via mv+cat+rm)
+	content, err := ConsumeSignal(signalDir, discoveredProject, discoveredAgent)
+	if err != nil {
+		t.Fatalf("ConsumeSignal: %v", err)
+	}
+	if !strings.Contains(content, "orchestrator") || !strings.Contains(content, "hello from orchestrator") {
+		t.Fatalf("consumed content = %q, missing expected message", content)
+	}
+
+	// Step 6: Signal file should be gone after consume
+	if _, err := os.Stat(sigPath); !os.IsNotExist(err) {
+		t.Fatal("signal file should be deleted after consume")
+	}
+
+	// Step 7: Second consume returns empty (no duplicate delivery)
+	content2, err := ConsumeSignal(signalDir, discoveredProject, discoveredAgent)
+	if err != nil {
+		t.Fatalf("second ConsumeSignal: %v", err)
+	}
+	if content2 != "" {
+		t.Fatalf("second consume should be empty, got %q", content2)
 	}
 }

--- a/internal/runtime/signal_test.go
+++ b/internal/runtime/signal_test.go
@@ -1,0 +1,107 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteSignal_CreatesFileWithContent(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteSignal(dir, "agent-1", "alice", "hello", 65536); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "agent-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	if !strings.Contains(s, "alice") || !strings.Contains(s, "hello") {
+		t.Fatalf("content = %q", s)
+	}
+}
+
+func TestWriteSignal_Appends(t *testing.T) {
+	dir := t.TempDir()
+	WriteSignal(dir, "a", "alice", "one", 65536)
+	WriteSignal(dir, "a", "bob", "two", 65536)
+	data, _ := os.ReadFile(filepath.Join(dir, "a"))
+	if c := strings.Count(string(data), "\n"); c != 2 {
+		t.Fatalf("expected 2 lines, got %d: %q", c, data)
+	}
+}
+
+func TestWriteSignal_DropsWhenOverCap(t *testing.T) {
+	dir := t.TempDir()
+	// First write: long body exceeds small cap
+	WriteSignal(dir, "a", "alice", strings.Repeat("x", 100), 50)
+	// File is ~133 bytes > 50 cap
+	WriteSignal(dir, "a", "bob", "should-be-dropped", 50)
+	data, _ := os.ReadFile(filepath.Join(dir, "a"))
+	if strings.Contains(string(data), "bob") {
+		t.Fatalf("second write should be dropped, got: %q", data)
+	}
+}
+
+func TestWriteSignal_DirPermissions(t *testing.T) {
+	sigDir := filepath.Join(t.TempDir(), "signals")
+	WriteSignal(sigDir, "a", "alice", "test", 65536)
+	info, err := os.Stat(sigDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Fatalf("dir perm = %o, want 700", perm)
+	}
+}
+
+func TestConsumeSignal_AtomicReadAndDelete(t *testing.T) {
+	dir := t.TempDir()
+	WriteSignal(dir, "a", "alice", "hello", 65536)
+	content, err := ConsumeSignal(dir, "a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(content, "alice") {
+		t.Fatalf("content = %q", content)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "a")); !os.IsNotExist(err) {
+		t.Fatal("original should be deleted")
+	}
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.Contains(e.Name(), "consuming") {
+			t.Fatalf("temp file left behind: %s", e.Name())
+		}
+	}
+}
+
+func TestConsumeSignal_NoFile_Empty(t *testing.T) {
+	content, err := ConsumeSignal(t.TempDir(), "nope")
+	if err != nil || content != "" {
+		t.Fatalf("expected empty, got %q err=%v", content, err)
+	}
+}
+
+func TestConsumeSignal_NewWriteDuringConsume(t *testing.T) {
+	dir := t.TempDir()
+	WriteSignal(dir, "a", "alice", "first", 65536)
+	// Simulate atomic rename (what ConsumeSignal does internally)
+	orig := filepath.Join(dir, "a")
+	tmp := orig + ".consuming-test"
+	os.Rename(orig, tmp)
+	// Daemon writes new message to original path AFTER rename
+	WriteSignal(dir, "a", "bob", "second", 65536)
+	// Consumed content has first message only
+	data, _ := os.ReadFile(tmp)
+	os.Remove(tmp)
+	if !strings.Contains(string(data), "alice") || strings.Contains(string(data), "bob") {
+		t.Fatalf("consumed = %q", data)
+	}
+	// New message survives at original path
+	data2, _ := os.ReadFile(orig)
+	if !strings.Contains(string(data2), "bob") {
+		t.Fatalf("new message lost, orig = %q", data2)
+	}
+}

--- a/internal/runtime/signal_test.go
+++ b/internal/runtime/signal_test.go
@@ -34,13 +34,26 @@ func TestWriteSignal_Appends(t *testing.T) {
 
 func TestWriteSignal_DropsWhenOverCap(t *testing.T) {
 	dir := t.TempDir()
-	// First write: long body exceeds small cap
-	WriteSignal(dir, "proj-test", "a", "alice", strings.Repeat("x", 100), 50)
-	// File is ~133 bytes > 50 cap
-	WriteSignal(dir, "proj-test", "a", "bob", "should-be-dropped", 50)
+	// First write fits (short message ~38 bytes, cap 100)
+	WriteSignal(dir, "proj-test", "a", "alice", "hello", 100)
 	data, _ := os.ReadFile(filepath.Join(dir, "proj-test", "a"))
+	if !strings.Contains(string(data), "alice") {
+		t.Fatalf("first write should succeed, got: %q", data)
+	}
+	// Second write pushes past cap
+	WriteSignal(dir, "proj-test", "a", "bob", strings.Repeat("x", 100), 100)
+	data, _ = os.ReadFile(filepath.Join(dir, "proj-test", "a"))
 	if strings.Contains(string(data), "bob") {
 		t.Fatalf("second write should be dropped, got: %q", data)
+	}
+}
+
+func TestWriteSignal_DropsOversizedFirstWrite(t *testing.T) {
+	dir := t.TempDir()
+	// Even first write rejected if message exceeds cap
+	WriteSignal(dir, "proj-test", "a", "alice", strings.Repeat("x", 100), 50)
+	if _, err := os.Stat(filepath.Join(dir, "proj-test", "a")); err == nil {
+		t.Fatal("oversized first write should be dropped")
 	}
 }
 
@@ -60,7 +73,7 @@ func TestConsumeSignal_AtomicReadAndDelete(t *testing.T) {
 	dir := t.TempDir()
 	WriteSignal(dir, "proj-test", "a", "alice", "hello", 65536)
 	projDir := filepath.Join(dir, "proj-test")
-	content, err := ConsumeSignal(projDir, "a")
+	content, err := ConsumeSignal(dir, "proj-test", "a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +92,7 @@ func TestConsumeSignal_AtomicReadAndDelete(t *testing.T) {
 }
 
 func TestConsumeSignal_NoFile_Empty(t *testing.T) {
-	content, err := ConsumeSignal(t.TempDir(), "nope")
+	content, err := ConsumeSignal(t.TempDir(), "no-proj", "nope")
 	if err != nil || content != "" {
 		t.Fatalf("expected empty, got %q err=%v", content, err)
 	}

--- a/internal/runtime/signal_test.go
+++ b/internal/runtime/signal_test.go
@@ -1,7 +1,10 @@
 package runtime
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,7 +17,7 @@ func TestWriteSignal_CreatesFileWithContent(t *testing.T) {
 	if err := WriteSignal(dir, "proj-test", "agent-1", "alice", "hello", 65536); err != nil {
 		t.Fatal(err)
 	}
-	data, err := os.ReadFile(filepath.Join(dir, "proj-test", "agent-1"))
+	data, err := os.ReadFile(filepath.Join(dir, ProjectPathKey("proj-test"), "agent-1"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,7 +31,7 @@ func TestWriteSignal_Appends(t *testing.T) {
 	dir := t.TempDir()
 	WriteSignal(dir, "proj-test", "a", "alice", "one", 65536)
 	WriteSignal(dir, "proj-test", "a", "bob", "two", 65536)
-	data, _ := os.ReadFile(filepath.Join(dir, "proj-test", "a"))
+	data, _ := os.ReadFile(filepath.Join(dir, ProjectPathKey("proj-test"), "a"))
 	if c := strings.Count(string(data), "\n"); c != 2 {
 		t.Fatalf("expected 2 lines, got %d: %q", c, data)
 	}
@@ -38,15 +41,36 @@ func TestWriteSignal_DropsWhenOverCap(t *testing.T) {
 	dir := t.TempDir()
 	// First write fits (short message ~38 bytes, cap 100)
 	WriteSignal(dir, "proj-test", "a", "alice", "hello", 100)
-	data, _ := os.ReadFile(filepath.Join(dir, "proj-test", "a"))
+	data, _ := os.ReadFile(filepath.Join(dir, ProjectPathKey("proj-test"), "a"))
 	if !strings.Contains(string(data), "alice") {
 		t.Fatalf("first write should succeed, got: %q", data)
 	}
 	// Second write pushes past cap
 	WriteSignal(dir, "proj-test", "a", "bob", strings.Repeat("x", 100), 100)
-	data, _ = os.ReadFile(filepath.Join(dir, "proj-test", "a"))
+	data, _ = os.ReadFile(filepath.Join(dir, ProjectPathKey("proj-test"), "a"))
 	if strings.Contains(string(data), "bob") {
 		t.Fatalf("second write should be dropped, got: %q", data)
+	}
+}
+
+func TestWriteSignal_ReturnsCapExceededError(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := WriteSignal(dir, "proj-test", "a", "alice", "hello", 100); err != nil {
+		t.Fatal(err)
+	}
+
+	err := WriteSignal(dir, "proj-test", "a", "bob", strings.Repeat("x", 100), 100)
+	if !errors.Is(err, ErrSignalCapExceeded) {
+		t.Fatalf("WriteSignal() error = %v, want %v", err, ErrSignalCapExceeded)
+	}
+
+	data, readErr := os.ReadFile(filepath.Join(dir, ProjectPathKey("proj-test"), "a"))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if strings.Contains(string(data), "bob") {
+		t.Fatalf("cap-exceeded write should not append content, got: %q", data)
 	}
 }
 
@@ -54,15 +78,44 @@ func TestWriteSignal_DropsOversizedFirstWrite(t *testing.T) {
 	dir := t.TempDir()
 	// Even first write rejected if message exceeds cap
 	WriteSignal(dir, "proj-test", "a", "alice", strings.Repeat("x", 100), 50)
-	if _, err := os.Stat(filepath.Join(dir, "proj-test", "a")); err == nil {
+	if _, err := os.Stat(filepath.Join(dir, ProjectPathKey("proj-test"), "a")); err == nil {
 		t.Fatal("oversized first write should be dropped")
+	}
+}
+
+func TestWriteSignal_LogsWhenDroppingOverCap(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteSignal(dir, "proj-test", "a", "alice", "hello", 100); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	oldWriter := log.Writer()
+	oldFlags := log.Flags()
+	oldPrefix := log.Prefix()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	log.SetPrefix("")
+	t.Cleanup(func() {
+		log.SetOutput(oldWriter)
+		log.SetFlags(oldFlags)
+		log.SetPrefix(oldPrefix)
+	})
+
+	if err := WriteSignal(dir, "proj-test", "a", "bob", strings.Repeat("x", 100), 100); !errors.Is(err, ErrSignalCapExceeded) {
+		t.Fatalf("WriteSignal() error = %v, want %v", err, ErrSignalCapExceeded)
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "dropping signal for") {
+		t.Fatalf("expected cap-drop log, got %q", logged)
 	}
 }
 
 func TestWriteSignal_DirPermissions(t *testing.T) {
 	sigDir := filepath.Join(t.TempDir(), "signals")
 	WriteSignal(sigDir, "proj-test", "a", "alice", "test", 65536)
-	info, err := os.Stat(filepath.Join(sigDir, "proj-test"))
+	info, err := os.Stat(filepath.Join(sigDir, ProjectPathKey("proj-test")))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,11 +124,58 @@ func TestWriteSignal_DirPermissions(t *testing.T) {
 	}
 }
 
+func TestWriteSignal_RejectsAncestorSymlink(t *testing.T) {
+	runtimeRoot := t.TempDir()
+	realSignals := filepath.Join(runtimeRoot, "signals-real")
+	if err := os.MkdirAll(realSignals, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	signalDir := filepath.Join(runtimeRoot, "signals")
+	if err := os.Symlink(realSignals, signalDir); err != nil {
+		t.Fatal(err)
+	}
+
+	err := WriteSignal(signalDir, "proj-test", "agent-1", "alice", "hello", 65536)
+	if err == nil {
+		t.Fatal("expected error for ancestor symlink")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink error, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(realSignals, ProjectPathKey("proj-test"), "agent-1")); statErr == nil {
+		t.Fatal("signal should not be written through symlinked path")
+	}
+}
+
+// ConsumeSignal is test-only because production delivery uses shell/JS hooks for consume.
+func ConsumeSignal(signalDir, projectKey, agentName string) (string, error) {
+	if projectKey == "" {
+		return "", fmt.Errorf("empty project key")
+	}
+	path := filepath.Join(signalDir, projectKey, agentName)
+	tmp := fmt.Sprintf("%s.consuming-%d", path, time.Now().UnixNano())
+	if err := os.Rename(path, tmp); err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	data, err := os.ReadFile(tmp)
+	if removeErr := os.Remove(tmp); removeErr != nil && !os.IsNotExist(removeErr) && err == nil {
+		err = removeErr
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
 func TestConsumeSignal_AtomicReadAndDelete(t *testing.T) {
 	dir := t.TempDir()
 	WriteSignal(dir, "proj-test", "a", "alice", "hello", 65536)
-	projDir := filepath.Join(dir, "proj-test")
-	content, err := ConsumeSignal(dir, "proj-test", "a")
+	projDir := filepath.Join(dir, ProjectPathKey("proj-test"))
+	content, err := ConsumeSignal(dir, ProjectPathKey("proj-test"), "a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +194,7 @@ func TestConsumeSignal_AtomicReadAndDelete(t *testing.T) {
 }
 
 func TestConsumeSignal_NoFile_Empty(t *testing.T) {
-	content, err := ConsumeSignal(t.TempDir(), "no-proj", "nope")
+	content, err := ConsumeSignal(t.TempDir(), ProjectPathKey("no-proj"), "nope")
 	if err != nil || content != "" {
 		t.Fatalf("expected empty, got %q err=%v", content, err)
 	}
@@ -103,7 +203,7 @@ func TestConsumeSignal_NoFile_Empty(t *testing.T) {
 func TestConsumeSignal_NewWriteDuringConsume(t *testing.T) {
 	dir := t.TempDir()
 	WriteSignal(dir, "proj-test", "a", "alice", "first", 65536)
-	projDir := filepath.Join(dir, "proj-test")
+	projDir := filepath.Join(dir, ProjectPathKey("proj-test"))
 	// Simulate atomic rename (what ConsumeSignal does internally)
 	orig := filepath.Join(projDir, "a")
 	tmp := orig + ".consuming-test"
@@ -123,34 +223,40 @@ func TestConsumeSignal_NewWriteDuringConsume(t *testing.T) {
 	}
 }
 
-func TestSanitizeProjectIDForPath_GitHash(t *testing.T) {
-	got := SanitizeProjectIDForPath("abcdef0123456789")
-	if got != "abcdef0123456789" {
-		t.Fatalf("got %q, want unchanged hex hash", got)
-	}
-}
-
-func TestSanitizeProjectIDForPath_PathTraversal(t *testing.T) {
-	got := SanitizeProjectIDForPath("../../etc/passwd")
-	if strings.Contains(got, "/") || strings.Contains(got, "..") {
-		t.Fatalf("path traversal not sanitized: %q", got)
-	}
-}
-
-func TestSanitizeProjectIDForPath_PathPrefix(t *testing.T) {
-	got := SanitizeProjectIDForPath("path:/Users/test/project")
-	if strings.Contains(got, "/") {
-		t.Fatalf("slashes not removed: %q", got)
-	}
+func TestProjectPathKey_Deterministic(t *testing.T) {
+	got := ProjectPathKey("abcdef0123456789")
 	if got == "" {
-		t.Fatal("should not be empty")
+		t.Fatal("ProjectPathKey() returned empty string")
+	}
+	if len(got) != 12 {
+		t.Fatalf("len(ProjectPathKey()) = %d, want 12", len(got))
+	}
+	if got != ProjectPathKey("abcdef0123456789") {
+		t.Fatalf("ProjectPathKey() not deterministic: %q vs %q", got, ProjectPathKey("abcdef0123456789"))
 	}
 }
 
-func TestSanitizeProjectIDForPath_Empty(t *testing.T) {
-	got := SanitizeProjectIDForPath("")
-	if got != "" {
-		t.Fatalf("got %q, want empty", got)
+func TestProjectPathKey_NoCollision(t *testing.T) {
+	inputs := []string{
+		"abcdef0123456789",
+		"abcdef012345678a",
+		"path:/Users/test/project",
+		"path:/Users/test/project-2",
+		"../../etc/passwd",
+		"proj-abc",
+		"proj abd",
+	}
+
+	seen := make(map[string]string, len(inputs))
+	for _, input := range inputs {
+		key := ProjectPathKey(input)
+		if key == "" {
+			t.Fatalf("ProjectPathKey(%q) returned empty string", input)
+		}
+		if prior, exists := seen[key]; exists {
+			t.Fatalf("ProjectPathKey collision: %q and %q both mapped to %q", prior, input, key)
+		}
+		seen[key] = input
 	}
 }
 
@@ -175,7 +281,7 @@ func TestWriteSignal_StripsANSI(t *testing.T) {
 			if err := WriteSignal(d, "abcdef01", "a", "alice", tt.input, 65536); err != nil {
 				t.Fatal(err)
 			}
-			data, _ := os.ReadFile(filepath.Join(d, "abcdef01", "a"))
+			data, _ := os.ReadFile(filepath.Join(d, ProjectPathKey("abcdef01"), "a"))
 			s := string(data)
 			for _, b := range s {
 				if b < 0x20 && b != '\n' && b != '\t' {
@@ -192,13 +298,40 @@ func TestWriteSignal_StripsANSI(t *testing.T) {
 	}
 }
 
+func TestStripANSI_StripsCSIIntermediateBytes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "delete chars with intermediate byte",
+			input: "hello \x1b[#P world",
+			want:  "hello  world",
+		},
+		{
+			name:  "cursor style with space intermediate byte",
+			input: "hello \x1b[4 q world",
+			want:  "hello  world",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripANSI(tt.input); got != tt.want {
+				t.Fatalf("stripANSI(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWriteSignal_StripsANSIFromSender(t *testing.T) {
 	dir := t.TempDir()
 	ansiFrom := "\x1b[31mevil\x1b[0m"
 	if err := WriteSignal(dir, "proj-test", "a", ansiFrom, "msg", 65536); err != nil {
 		t.Fatal(err)
 	}
-	data, _ := os.ReadFile(filepath.Join(dir, "proj-test", "a"))
+	data, _ := os.ReadFile(filepath.Join(dir, ProjectPathKey("proj-test"), "a"))
 	if strings.Contains(string(data), "\x1b") {
 		t.Fatalf("ANSI escape not stripped from sender: %q", data)
 	}
@@ -226,6 +359,25 @@ func TestWriteSignal_SanitizesProjectIDPath(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dir, "..", "..", "etc")); err == nil {
 		t.Fatal("path traversal succeeded!")
 	}
+	if _, err := os.Stat(filepath.Join(dir, ProjectPathKey("../../etc"), "a")); err != nil {
+		t.Fatalf("hashed project path missing: %v", err)
+	}
+}
+
+func TestWriteSignal_SanitizesAgentNamePath(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := WriteSignal(dir, "proj-test", "../Agent Name", "alice", "hello", 65536); err != nil {
+		t.Fatal(err)
+	}
+
+	safePath := filepath.Join(dir, ProjectPathKey("proj-test"), "agent-name")
+	if _, err := os.Stat(safePath); err != nil {
+		t.Fatalf("sanitized signal path missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "evil")); err == nil {
+		t.Fatal("unsanitized agent path escaped project directory")
+	}
 }
 
 // TestSignalPipeline_EndToEnd exercises the full signal delivery path:
@@ -239,12 +391,12 @@ func TestSignalPipeline_EndToEnd(t *testing.T) {
 	ppid := 12345
 	agentName := "claude-code-test"
 	projectID := "abcdef0123456789"
-	safeProjectID := SanitizeProjectIDForPath(projectID)
+	projectKey := ProjectPathKey(projectID)
 
 	// Step 1: Simulate bootstrap — generate nonce, write session mapping
 	nonce := "12345-1711843200000000000"
 	sessionPath := filepath.Join(runtimeDir, "agent-session-"+nonce)
-	os.WriteFile(sessionPath, []byte(agentName+"\n"+safeProjectID+"\n"), 0o600)
+	os.WriteFile(sessionPath, []byte(agentName+"\n"+projectKey+"\n"), 0o600)
 	ppidPath := filepath.Join(runtimeDir, fmt.Sprintf("agent-ppid-%d", ppid))
 	os.WriteFile(ppidPath, []byte(nonce+"\n"), 0o600)
 
@@ -279,8 +431,8 @@ func TestSignalPipeline_EndToEnd(t *testing.T) {
 	if discoveredAgent != agentName {
 		t.Fatalf("agent = %q, want %q", discoveredAgent, agentName)
 	}
-	if discoveredProject != safeProjectID {
-		t.Fatalf("project = %q, want %q", discoveredProject, safeProjectID)
+	if discoveredProject != projectKey {
+		t.Fatalf("project = %q, want %q", discoveredProject, projectKey)
 	}
 
 	// Step 4: Check signal file exists at expected path

--- a/internal/runtime/signal_test.go
+++ b/internal/runtime/signal_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestWriteSignal_CreatesFileWithContent(t *testing.T) {
 	dir := t.TempDir()
-	if err := WriteSignal(dir, "agent-1", "alice", "hello", 65536); err != nil {
+	if err := WriteSignal(dir, "proj-test", "agent-1", "alice", "hello", 65536); err != nil {
 		t.Fatal(err)
 	}
-	data, err := os.ReadFile(filepath.Join(dir, "agent-1"))
+	data, err := os.ReadFile(filepath.Join(dir, "proj-test", "agent-1"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -24,9 +24,9 @@ func TestWriteSignal_CreatesFileWithContent(t *testing.T) {
 
 func TestWriteSignal_Appends(t *testing.T) {
 	dir := t.TempDir()
-	WriteSignal(dir, "a", "alice", "one", 65536)
-	WriteSignal(dir, "a", "bob", "two", 65536)
-	data, _ := os.ReadFile(filepath.Join(dir, "a"))
+	WriteSignal(dir, "proj-test", "a", "alice", "one", 65536)
+	WriteSignal(dir, "proj-test", "a", "bob", "two", 65536)
+	data, _ := os.ReadFile(filepath.Join(dir, "proj-test", "a"))
 	if c := strings.Count(string(data), "\n"); c != 2 {
 		t.Fatalf("expected 2 lines, got %d: %q", c, data)
 	}
@@ -35,10 +35,10 @@ func TestWriteSignal_Appends(t *testing.T) {
 func TestWriteSignal_DropsWhenOverCap(t *testing.T) {
 	dir := t.TempDir()
 	// First write: long body exceeds small cap
-	WriteSignal(dir, "a", "alice", strings.Repeat("x", 100), 50)
+	WriteSignal(dir, "proj-test", "a", "alice", strings.Repeat("x", 100), 50)
 	// File is ~133 bytes > 50 cap
-	WriteSignal(dir, "a", "bob", "should-be-dropped", 50)
-	data, _ := os.ReadFile(filepath.Join(dir, "a"))
+	WriteSignal(dir, "proj-test", "a", "bob", "should-be-dropped", 50)
+	data, _ := os.ReadFile(filepath.Join(dir, "proj-test", "a"))
 	if strings.Contains(string(data), "bob") {
 		t.Fatalf("second write should be dropped, got: %q", data)
 	}
@@ -46,8 +46,8 @@ func TestWriteSignal_DropsWhenOverCap(t *testing.T) {
 
 func TestWriteSignal_DirPermissions(t *testing.T) {
 	sigDir := filepath.Join(t.TempDir(), "signals")
-	WriteSignal(sigDir, "a", "alice", "test", 65536)
-	info, err := os.Stat(sigDir)
+	WriteSignal(sigDir, "proj-test", "a", "alice", "test", 65536)
+	info, err := os.Stat(filepath.Join(sigDir, "proj-test"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,18 +58,19 @@ func TestWriteSignal_DirPermissions(t *testing.T) {
 
 func TestConsumeSignal_AtomicReadAndDelete(t *testing.T) {
 	dir := t.TempDir()
-	WriteSignal(dir, "a", "alice", "hello", 65536)
-	content, err := ConsumeSignal(dir, "a")
+	WriteSignal(dir, "proj-test", "a", "alice", "hello", 65536)
+	projDir := filepath.Join(dir, "proj-test")
+	content, err := ConsumeSignal(projDir, "a")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(content, "alice") {
 		t.Fatalf("content = %q", content)
 	}
-	if _, err := os.Stat(filepath.Join(dir, "a")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(projDir, "a")); !os.IsNotExist(err) {
 		t.Fatal("original should be deleted")
 	}
-	entries, _ := os.ReadDir(dir)
+	entries, _ := os.ReadDir(projDir)
 	for _, e := range entries {
 		if strings.Contains(e.Name(), "consuming") {
 			t.Fatalf("temp file left behind: %s", e.Name())
@@ -86,13 +87,14 @@ func TestConsumeSignal_NoFile_Empty(t *testing.T) {
 
 func TestConsumeSignal_NewWriteDuringConsume(t *testing.T) {
 	dir := t.TempDir()
-	WriteSignal(dir, "a", "alice", "first", 65536)
+	WriteSignal(dir, "proj-test", "a", "alice", "first", 65536)
+	projDir := filepath.Join(dir, "proj-test")
 	// Simulate atomic rename (what ConsumeSignal does internally)
-	orig := filepath.Join(dir, "a")
+	orig := filepath.Join(projDir, "a")
 	tmp := orig + ".consuming-test"
 	os.Rename(orig, tmp)
 	// Daemon writes new message to original path AFTER rename
-	WriteSignal(dir, "a", "bob", "second", 65536)
+	WriteSignal(dir, "proj-test", "a", "bob", "second", 65536)
 	// Consumed content has first message only
 	data, _ := os.ReadFile(tmp)
 	os.Remove(tmp)

--- a/internal/runtime/store.go
+++ b/internal/runtime/store.go
@@ -130,6 +130,7 @@ func migrate(db *sql.DB) error {
 
 // UpsertWatch inserts or updates a watch keyed by (project_id, agent_name).
 func (s *Store) UpsertWatch(w Watch) error {
+	w.AgentName = SanitizeAgentName(w.AgentName)
 	if w.ProjectID == "" || w.AgentName == "" {
 		return fmt.Errorf("project_id and agent_name required")
 	}

--- a/internal/runtime/store_test.go
+++ b/internal/runtime/store_test.go
@@ -131,6 +131,29 @@ func TestStore_ExplicitWatchIsDurableWhileSessionWatchesExpire(t *testing.T) {
 	}
 }
 
+func TestUpsertWatch_SanitizesAgentName(t *testing.T) {
+	store := newTestStore(t)
+
+	if err := store.UpsertWatch(Watch{
+		ProjectID: "proj-a",
+		AgentName: "  Agent../Name__X  ",
+		Source:    "cli",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	watches, err := store.ListWatches()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(watches) != 1 {
+		t.Fatalf("watch count = %d, want 1", len(watches))
+	}
+	if watches[0].AgentName != "agent-name-x" {
+		t.Fatalf("agent name = %q, want %q", watches[0].AgentName, "agent-name-x")
+	}
+}
+
 func TestStore_RecordPersistenceUnreadAndSurfaced(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "runtime.db")

--- a/internal/runtime/test_prune_rmdir_safe.sh
+++ b/internal/runtime/test_prune_rmdir_safe.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Disproves findings 3722f4bf and 23dd9fce: rmdir(2) is atomic —
+# os.Remove on a non-empty directory returns ENOTEMPTY, no signal loss possible.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+go test ./internal/runtime/ -count=1 -run "TestPruneStaleSignals_Rmdir|TestPruneStaleSignals_EmptyDir" -v


### PR DESCRIPTION
## Summary

- Daemon writes signal files on message delivery; shell hook in `.zshenv`/`.bashrc` surfaces them before every agent command
- Works across all 5 platforms (Claude Code, Codex, Gemini, Auggie, Augment) — no platform-specific hooks needed
- Claude Code gets additional clean `additionalContext` injection via PreToolUse hook
- PPID mapping via `WAGGLE_AGENT_PPID` env var links bootstrap to subsequent commands (fixes process generation mismatch found by GPT-5.4)
- Presence strips `-push` suffix safely with deduplication
- Signal files scoped by project_id to prevent cross-project leakage
- All agent names sanitized at the boundary to prevent path traversal

## Key insight

Every AI coding agent runs shell commands. Each tool call spawns a new shell process. The shell's initialization (`.zshenv`) fires before every command. This is the universal hook — below the application layer, invisible to the platform.

## Review history

- **v1-v4 plan reviews:** Grok-4.20, Gemini-3.1-Pro, GPT-5.4-Pro — all approved v4
- **GPT-5.4 found** critical PPID generation mismatch (os.Getppid returns intermediate shell, not agent) — fixed with env var
- **Branch audit:** GLM-5 PASS (first run), Gemini-3-Flash PASS (second run with full diff)
- **Codex red-team:** 7 findings (1 critical, 5 high, 1 medium) — all resolved with 3 root-cause fixes
- **Codex verification:** 4 PASS on first pass, 3 remaining fixed, all resolved

## Test plan

- [x] `go test ./... -count=1` — 15/15 packages pass
- [x] E2E: bootstrap two agents, send message, signal file written by daemon
- [x] E2E: `waggle presence` shows clean names without `-push`
- [x] Signal writer: atomic consumption, size cap, project scoping, stale GC
- [x] PPID mapping: env var preference, fallback to Getppid, stale cleanup
- [x] Shell hook installer: markers, idempotent, symlink rejection, permission preservation
- [x] Presence: dedup, safe -push handling for legitimate names

Closes #102
