### PR TITLE
fix: complete adapter bootstrap and runtime listener hardening

### DIFF
--- a/cmd/adapter_test.go
+++ b/cmd/adapter_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -196,5 +197,67 @@ func TestAdapterBootstrapDoesNotLeakFlagStateAcrossExecutions(t *testing.T) {
 	}
 	if secondResp.AgentName != "codex-ttys009" {
 		t.Fatalf("agent_name after prior flagged execution = %q, want codex-ttys009", secondResp.AgentName)
+	}
+}
+
+func TestAdapterBootstrapMarkdownSilentWhenRuntimeStoreUnavailable(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("WAGGLE_PROJECT_ID", "proj-runtime-db-unavailable")
+	t.Setenv("WAGGLE_ADAPTER_SKIP_RUNTIME_START", "1")
+	blockRuntimeDirForTest(t, home)
+
+	stdout, stderr := executeRootCommandForTest(t, "adapter", "bootstrap", "codex", "--format", "markdown")
+	if stdout != "" {
+		t.Fatalf("adapter bootstrap stdout = %q, want empty for degraded markdown startup", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("adapter bootstrap stderr = %q, want empty for degraded markdown startup", stderr)
+	}
+}
+
+func TestAdapterBootstrapJSONReportsSkippedWhenRuntimeStoreUnavailable(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("WAGGLE_PROJECT_ID", "proj-runtime-db-unavailable")
+	t.Setenv("WAGGLE_ADAPTER_SKIP_RUNTIME_START", "1")
+	blockRuntimeDirForTest(t, home)
+
+	stdout, stderr := executeRootCommandForTest(t, "adapter", "bootstrap", "codex")
+	if stderr != "" {
+		t.Fatalf("adapter bootstrap stderr = %q, want empty", stderr)
+	}
+
+	var resp struct {
+		OK         bool   `json:"ok"`
+		Skipped    bool   `json:"skipped"`
+		SkipReason string `json:"skip_reason"`
+		Tool       string `json:"tool"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &resp); err != nil {
+		t.Fatalf("unmarshal skipped bootstrap response: %v", err)
+	}
+	if resp.OK {
+		t.Fatalf("bootstrap response OK = true, want false for skipped runtime store")
+	}
+	if !resp.Skipped {
+		t.Fatalf("bootstrap response skipped = false, want true")
+	}
+	if !strings.Contains(resp.SkipReason, "runtime store unavailable") {
+		t.Fatalf("skip_reason = %q, want runtime store unavailable", resp.SkipReason)
+	}
+	if resp.Tool != "codex" {
+		t.Fatalf("tool = %q, want codex", resp.Tool)
+	}
+}
+
+func blockRuntimeDirForTest(t *testing.T, home string) {
+	t.Helper()
+	waggleDir := filepath.Join(home, ".waggle")
+	if err := os.MkdirAll(waggleDir, 0o755); err != nil {
+		t.Fatalf("create .waggle: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(waggleDir, "runtime"), []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("create runtime path blocker: %v", err)
 	}
 }

--- a/e2e/runtime_integration_test.go
+++ b/e2e/runtime_integration_test.go
@@ -1,8 +1,13 @@
 package e2e
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -146,6 +151,88 @@ func TestRuntimeEndToEndPushStoreAndPull(t *testing.T) {
 	if len(unread) != 0 {
 		t.Fatalf("unread count after pull = %d, want 0", len(unread))
 	}
+}
+
+func TestRuntimeRealProcessesReceiveWatchedAgentMessage(t *testing.T) {
+	t.Setenv("GOTMPDIR", "/tmp") // keep socket path under macOS 104-byte limit
+	projectID := "proj-process-e2e"
+	agentName := "agent-process"
+
+	bin := filepath.Join(t.TempDir(), "waggle-e2e")
+	build := exec.Command("go", "build", "-o", bin, "..")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build waggle test binary: %v\n%s", err, out)
+	}
+
+	home, err := os.MkdirTemp("/tmp", "wge2e-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(home)
+	})
+	t.Setenv("HOME", home)
+	t.Setenv("WAGGLE_PROJECT_ID", projectID)
+
+	env := append(os.Environ(),
+		"HOME="+home,
+		"WAGGLE_PROJECT_ID="+projectID,
+		"GOTMPDIR=/tmp",
+	)
+
+	paths := config.NewPaths(projectID)
+	brokerProc := startProcess(t, env, bin, "start", "--foreground")
+	t.Cleanup(func() {
+		stopProcess(t, brokerProc)
+	})
+
+	waitForProcessSocket(t, brokerProc, paths.Socket)
+
+	runCommand(t, env, bin, "runtime", "watch", agentName, "--project-id", projectID, "--source", "process-e2e")
+
+	runtimeProc := startProcess(t, env, bin, "runtime", "start", "--foreground")
+	t.Cleanup(func() {
+		stopProcess(t, runtimeProc)
+	})
+
+	waitForPresence(t, runtimeProc, paths.Socket, paths.RuntimeState, agentName)
+
+	sender, err := client.Connect(paths.Socket, 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sender.Close()
+
+	if resp, err := sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "sender-process"}); err != nil {
+		t.Fatal(err)
+	} else if !resp.OK {
+		t.Fatalf("connect sender failed: %s", resp.Error)
+	}
+
+	resp, err := sender.Send(protocol.Request{
+		Cmd:     protocol.CmdSend,
+		Name:    agentName,
+		Message: "hello real processes",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("send failed: %s", resp.Error)
+	}
+
+	store, err := rt.NewStore(paths.RuntimeDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = store.Close()
+	})
+
+	waitForCondition(t, "real runtime store record", func() bool {
+		rec, err := store.GetRecord(projectID, agentName, 1)
+		return err == nil && !rec.NotifiedAt.IsZero() && rec.Body == "hello real processes"
+	})
 }
 
 func pullUnreadRecords(store *rt.Store, projectID, agentName string) ([]rt.DeliveryRecord, error) {
@@ -388,6 +475,146 @@ func TestRuntimeBrokerRestartReconnect(t *testing.T) {
 	if count := manager.WatchCount(); count != 1 {
 		t.Fatalf("watch count = %d, want 1", count)
 	}
+}
+
+type managedProcess struct {
+	cmd    *exec.Cmd
+	done   chan struct{}
+	output *bytes.Buffer
+	mu     sync.Mutex
+	err    error
+}
+
+func startProcess(t *testing.T, env []string, name string, args ...string) *managedProcess {
+	t.Helper()
+
+	cmd := exec.Command(name, args...)
+	cmd.Env = env
+	output := &bytes.Buffer{}
+	cmd.Stdout = output
+	cmd.Stderr = output
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start %s %v: %v", name, args, err)
+	}
+	proc := &managedProcess{cmd: cmd, done: make(chan struct{}), output: output}
+	go func() {
+		err := cmd.Wait()
+		proc.mu.Lock()
+		proc.err = err
+		proc.mu.Unlock()
+		close(proc.done)
+	}()
+	return proc
+}
+
+func stopProcess(t *testing.T, proc *managedProcess) {
+	t.Helper()
+	if proc == nil || proc.cmd == nil || proc.cmd.Process == nil {
+		return
+	}
+
+	select {
+	case <-proc.done:
+		return
+	default:
+	}
+
+	_ = proc.cmd.Process.Signal(os.Interrupt)
+	select {
+	case <-proc.done:
+	case <-time.After(2 * time.Second):
+		_ = proc.cmd.Process.Kill()
+		<-proc.done
+	}
+}
+
+func (p *managedProcess) waitErr() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.err
+}
+
+func runCommand(t *testing.T, env []string, name string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command(name, args...)
+	cmd.Env = env
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run %s %v: %v\n%s", name, args, err, out)
+	}
+}
+
+func waitForProcessSocket(t *testing.T, proc *managedProcess, socketPath string) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case <-proc.done:
+			err := proc.waitErr()
+			output := proc.output.String()
+			if strings.Contains(output, "bind: operation not permitted") {
+				t.Skipf("sandbox denied child process Unix socket bind: %v\n%s", err, output)
+			}
+			t.Fatalf("process exited before socket was ready: %v\n%s", err, output)
+		default:
+		}
+
+		c, err := client.Connect(socketPath, 200*time.Millisecond)
+		if err == nil {
+			c.Close()
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for real broker socket; process output:\n%s", proc.output.String())
+}
+
+func waitForPresence(t *testing.T, proc *managedProcess, socketPath, runtimeStatePath, name string) {
+	t.Helper()
+
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case <-proc.done:
+			err := proc.waitErr()
+			t.Fatalf("process exited before presence was ready: %v\n%s", err, proc.output.String())
+		default:
+		}
+
+		c, err := client.Connect(socketPath, 200*time.Millisecond)
+		if err != nil {
+			time.Sleep(25 * time.Millisecond)
+			continue
+		}
+
+		resp, err := c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "_presence-process-e2e"})
+		if err != nil || !resp.OK {
+			c.Close()
+			time.Sleep(25 * time.Millisecond)
+			continue
+		}
+		resp, err = c.Send(protocol.Request{Cmd: protocol.CmdPresence})
+		c.Close()
+		if err != nil || !resp.OK {
+			time.Sleep(25 * time.Millisecond)
+			continue
+		}
+		var agents []map[string]string
+		if err := json.Unmarshal(resp.Data, &agents); err != nil {
+			time.Sleep(25 * time.Millisecond)
+			continue
+		}
+		for _, agent := range agents {
+			if agent["name"] == name && agent["state"] == "online" {
+				return
+			}
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	state, _ := os.ReadFile(runtimeStatePath)
+	t.Fatalf("timeout waiting for presence for %s\nruntime state:\n%s\nprocess output:\n%s", name, state, proc.output.String())
 }
 
 func waitForCondition(t *testing.T, name string, fn func() bool) {

--- a/e2e/runtime_integration_test.go
+++ b/e2e/runtime_integration_test.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -181,6 +183,7 @@ func TestRuntimeRealProcessesReceiveWatchedAgentMessage(t *testing.T) {
 	)
 
 	paths := config.NewPaths(projectID)
+	requireUnixSocketBind(t, filepath.Join(home, "preflight.sock"))
 	brokerProc := startProcess(t, env, bin, "start", "--foreground")
 	t.Cleanup(func() {
 		stopProcess(t, brokerProc)
@@ -553,9 +556,6 @@ func waitForProcessSocket(t *testing.T, proc *managedProcess, socketPath string)
 		case <-proc.done:
 			err := proc.waitErr()
 			output := proc.output.String()
-			if strings.Contains(output, "bind: operation not permitted") {
-				t.Skipf("sandbox denied child process Unix socket bind: %v\n%s", err, output)
-			}
 			t.Fatalf("process exited before socket was ready: %v\n%s", err, output)
 		default:
 		}
@@ -568,6 +568,24 @@ func waitForProcessSocket(t *testing.T, proc *managedProcess, socketPath string)
 		time.Sleep(25 * time.Millisecond)
 	}
 	t.Fatalf("timeout waiting for real broker socket; process output:\n%s", proc.output.String())
+}
+
+func requireUnixSocketBind(t *testing.T, socketPath string) {
+	t.Helper()
+
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		if errors.Is(err, syscall.EPERM) || errors.Is(err, syscall.EACCES) {
+			t.Skipf("environment denies Unix socket bind at %s: %v", socketPath, err)
+		}
+		t.Fatalf("preflight Unix socket bind failed at %s: %v", socketPath, err)
+	}
+	if err := listener.Close(); err != nil {
+		t.Fatalf("close preflight Unix socket: %v", err)
+	}
+	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("remove preflight Unix socket: %v", err)
+	}
 }
 
 func waitForPresence(t *testing.T, proc *managedProcess, socketPath, runtimeStatePath, name string) {

--- a/internal/adapter/bootstrap.go
+++ b/internal/adapter/bootstrap.go
@@ -57,6 +57,13 @@ func Bootstrap(input BootstrapInput) (BootstrapResult, error) {
 		source = tool + "-adapter"
 	}
 
+	result := BootstrapResult{
+		Tool:      tool,
+		ProjectID: projectID,
+		AgentName: agentName,
+		Source:    source,
+	}
+
 	runtimeRunning := rt.IsRunning(runtimePaths)
 	runtimeErr := ""
 	if !runtimeRunning {
@@ -66,10 +73,12 @@ func Bootstrap(input BootstrapInput) (BootstrapResult, error) {
 			runtimeRunning = rt.IsRunning(runtimePaths)
 		}
 	}
+	result.RuntimeRunning = runtimeRunning
+	result.RuntimeError = runtimeErr
 
 	store, err := rt.OpenStore(runtimePaths)
 	if err != nil {
-		return BootstrapResult{}, err
+		return skipRuntimeStore(result, err), nil
 	}
 	defer store.Close()
 
@@ -78,7 +87,7 @@ func Bootstrap(input BootstrapInput) (BootstrapResult, error) {
 		AgentName: agentName,
 		Source:    source,
 	}); err != nil {
-		return BootstrapResult{}, err
+		return skipRuntimeStore(result, err), nil
 	}
 
 	ppid := resolveAgentPPID()
@@ -91,7 +100,7 @@ func Bootstrap(input BootstrapInput) (BootstrapResult, error) {
 
 	records, err := store.Unread(projectID, agentName)
 	if err != nil {
-		return BootstrapResult{}, err
+		return skipRuntimeStore(result, err), nil
 	}
 
 	messageIDs := make([]int64, 0, len(records))
@@ -99,18 +108,20 @@ func Bootstrap(input BootstrapInput) (BootstrapResult, error) {
 		messageIDs = append(messageIDs, rec.MessageID)
 	}
 	if err := store.MarkSurfacedAndDismissBatch(projectID, agentName, messageIDs); err != nil {
-		return BootstrapResult{}, fmt.Errorf("mark dismissed: %w", err)
+		return skipRuntimeStore(result, fmt.Errorf("mark dismissed: %w", err)), nil
 	}
 
-	return BootstrapResult{
-		Tool:           tool,
-		ProjectID:      projectID,
-		AgentName:      agentName,
-		Source:         source,
-		RuntimeRunning: runtimeRunning,
-		RuntimeError:   runtimeErr,
-		Records:        records,
-	}, nil
+	result.Records = records
+	return result, nil
+}
+
+func skipRuntimeStore(result BootstrapResult, err error) BootstrapResult {
+	reason := fmt.Sprintf("runtime store unavailable: %v", err)
+	result.Skipped = true
+	result.SkipReason = reason
+	result.RuntimeError = reason
+	result.Records = nil
+	return result
 }
 
 func ResolveAgentName(tool, explicit, tty string, ppid, pid int) string {

--- a/internal/adapter/bootstrap_test.go
+++ b/internal/adapter/bootstrap_test.go
@@ -178,6 +178,38 @@ func TestAdapterBootstrap_SkipsGracefullyWithoutProjectContext(t *testing.T) {
 	}
 }
 
+func TestAdapterBootstrap_SkipsGracefullyWhenRuntimeStoreUnavailable(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("WAGGLE_PROJECT_ID", "proj-runtime-db-unavailable")
+	t.Setenv("WAGGLE_ADAPTER_SKIP_RUNTIME_START", "1")
+
+	waggleDir := filepath.Join(home, ".waggle")
+	if err := os.MkdirAll(waggleDir, 0o755); err != nil {
+		t.Fatalf("create .waggle: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(waggleDir, "runtime"), []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("create runtime path blocker: %v", err)
+	}
+
+	result, err := Bootstrap(BootstrapInput{
+		Tool:      "codex",
+		AgentName: "codex-test",
+	})
+	if err != nil {
+		t.Fatalf("Bootstrap should not return error when runtime store is unavailable, got: %v", err)
+	}
+	if !result.Skipped {
+		t.Fatalf("Bootstrap should set Skipped=true when runtime store is unavailable")
+	}
+	if result.SkipReason == "" || !strings.Contains(result.SkipReason, "runtime store unavailable") {
+		t.Fatalf("Bootstrap skip reason = %q, want runtime store unavailable", result.SkipReason)
+	}
+	if result.RuntimeError == "" {
+		t.Fatalf("Bootstrap should expose runtime error for diagnostics")
+	}
+}
+
 func TestWriteSessionMapping(t *testing.T) {
 	dir := t.TempDir()
 	nonce := "12345-1711843200000000000"

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -50,8 +50,6 @@ type Broker struct {
 	ackWaitersMu sync.Mutex
 }
 
-var brokersBySocket sync.Map
-
 // New creates a new broker instance
 func New(cfg Config) (*Broker, error) {
 	if err := config.ValidateDefaults(); err != nil {
@@ -144,21 +142,7 @@ func New(cfg Config) (*Broker, error) {
 		stopCh:     make(chan struct{}),
 		ackWaiters: make(map[int64]chan struct{}),
 	}
-	brokersBySocket.Store(cfg.SocketPath, b)
-
 	return b, nil
-}
-
-func LookupBySocket(socketPath string) *Broker {
-	if socketPath == "" {
-		return nil
-	}
-	if b, ok := brokersBySocket.Load(socketPath); ok {
-		if broker, ok := b.(*Broker); ok {
-			return broker
-		}
-	}
-	return nil
 }
 
 func (b *Broker) GetPushToken(agent string) string {
@@ -272,8 +256,6 @@ func (b *Broker) Serve() error {
 
 // Shutdown gracefully shuts down the broker
 func (b *Broker) Shutdown() error {
-	brokersBySocket.Delete(b.config.SocketPath)
-
 	// Kill spawned agents before stopping
 	if b.spawnMgr != nil {
 		b.spawnMgr.StopAll()

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -3173,6 +3173,61 @@ func TestBroker_PushListenerRejectedWhenBaseNeverConnected(t *testing.T) {
 	}
 }
 
+func TestBroker_PushReserveAllowsListenerWithoutBaseSession(t *testing.T) {
+	sockPath, _, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	reserver := connectClient(t, sockPath)
+	defer reserver.Close()
+	resp, err := reserver.Send(protocol.Request{
+		Cmd:  protocol.CmdPushReserve,
+		Name: "alice",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("push reserve failed: %s: %s", resp.Code, resp.Error)
+	}
+	pushToken := pushTokenFromResponse(t, resp)
+
+	listener := connectClient(t, sockPath)
+	defer listener.Close()
+	resp, err = listener.Send(protocol.Request{
+		Cmd:          protocol.CmdConnect,
+		Name:         "alice-push",
+		PushListener: true,
+		PushToken:    pushToken,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("push listener connect failed with reserved token: %s: %s", resp.Code, resp.Error)
+	}
+}
+
+func TestBroker_PushReserveRejectsPushListenerName(t *testing.T) {
+	sockPath, _, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	c := connectClient(t, sockPath)
+	defer c.Close()
+	resp, err := c.Send(protocol.Request{
+		Cmd:  protocol.CmdPushReserve,
+		Name: "alice-push",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.OK {
+		t.Fatal("expected push.reserve to reject -push listener name")
+	}
+	if resp.Code != protocol.ErrInvalidRequest {
+		t.Fatalf("response code = %q, want %q", resp.Code, protocol.ErrInvalidRequest)
+	}
+}
+
 func TestBroker_PushListenerRejectsWrongToken(t *testing.T) {
 	sockPath, b, cleanup := startTestBroker(t)
 	defer cleanup()

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -3207,6 +3207,78 @@ func TestBroker_PushReserveAllowsListenerWithoutBaseSession(t *testing.T) {
 	}
 }
 
+func TestBroker_PushReserveListenerSurvivesBaseAgentDisconnect(t *testing.T) {
+	sockPath, _, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	reserver := connectClient(t, sockPath)
+	resp, err := reserver.Send(protocol.Request{
+		Cmd:  protocol.CmdPushReserve,
+		Name: "alice",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("push reserve failed: %s: %s", resp.Code, resp.Error)
+	}
+	reservedToken := pushTokenFromResponse(t, resp)
+	reserver.Close()
+
+	listener := connectClient(t, sockPath)
+	resp, err = listener.Send(protocol.Request{
+		Cmd:          protocol.CmdConnect,
+		Name:         "alice-push",
+		PushListener: true,
+		PushToken:    reservedToken,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("push listener connect failed with reserved token: %s: %s", resp.Code, resp.Error)
+	}
+
+	base := connectClient(t, sockPath)
+	resp, err = base.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("base connect failed: %s: %s", resp.Code, resp.Error)
+	}
+	base.Close()
+
+	sender := connectClient(t, sockPath)
+	defer sender.Close()
+	resp, err = sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "sender"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("sender connect failed: %s: %s", resp.Code, resp.Error)
+	}
+	resp, err = sender.Send(protocol.Request{
+		Cmd:     protocol.CmdSend,
+		Name:    "alice",
+		Message: "hello after base disconnect",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("send failed: %s: %s", resp.Code, resp.Error)
+	}
+
+	msg, err := listener.Receive()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !msg.OK {
+		t.Fatalf("push receive failed: %s", msg.Error)
+	}
+}
+
 func TestBroker_PushReserveRejectsPushListenerName(t *testing.T) {
 	sockPath, _, cleanup := startTestBroker(t)
 	defer cleanup()

--- a/internal/broker/router.go
+++ b/internal/broker/router.go
@@ -100,6 +100,9 @@ func handlePushReserve(s *Session, req protocol.Request) protocol.Response {
 		return protocol.ErrResponse(protocol.ErrInvalidRequest, `push.reserve requires a base agent name, not a "-push" listener name`)
 	}
 
+	// The local Unix socket permission is the auth boundary. Runtime listeners
+	// reserve broker-owned tokens before any base agent session exists, and
+	// ordinary base-agent CLI connects must not take ownership of those tokens.
 	pushToken, err := s.broker.GeneratePushToken(req.Name)
 	if err != nil {
 		return protocol.ErrResponse(protocol.ErrInternalError, err.Error())

--- a/internal/broker/router.go
+++ b/internal/broker/router.go
@@ -20,9 +20,10 @@ import (
 // Commands that work without a session handshake.
 // Everything else requires connect first.
 var noSessionRequired = map[string]bool{
-	protocol.CmdConnect: true,
-	protocol.CmdStatus:  true,
-	protocol.CmdStop:    true,
+	protocol.CmdConnect:     true,
+	protocol.CmdStatus:      true,
+	protocol.CmdStop:        true,
+	protocol.CmdPushReserve: true,
 }
 
 // route dispatches a request to the appropriate handler.
@@ -77,6 +78,8 @@ func route(s *Session, req protocol.Request) protocol.Response {
 		return handleAck(s, req)
 	case protocol.CmdPresence:
 		return handlePresence(s)
+	case protocol.CmdPushReserve:
+		return handlePushReserve(s, req)
 	case protocol.CmdSpawnRegister:
 		return handleSpawnRegister(s, req)
 	case protocol.CmdSpawnUpdatePID:
@@ -84,6 +87,28 @@ func route(s *Session, req protocol.Request) protocol.Response {
 	default:
 		return protocol.ErrResponse(protocol.ErrInvalidRequest, "unknown command")
 	}
+}
+
+func handlePushReserve(s *Session, req protocol.Request) protocol.Response {
+	if req.Name == "" {
+		return protocol.ErrResponse(protocol.ErrInvalidRequest, "name required")
+	}
+	if len(req.Name) > config.Defaults.MaxFieldLength {
+		return protocol.ErrResponse(protocol.ErrInvalidRequest, fmt.Sprintf("name too long (max %d chars)", config.Defaults.MaxFieldLength))
+	}
+	if strings.HasSuffix(req.Name, "-push") {
+		return protocol.ErrResponse(protocol.ErrInvalidRequest, `push.reserve requires a base agent name, not a "-push" listener name`)
+	}
+
+	pushToken, err := s.broker.GeneratePushToken(req.Name)
+	if err != nil {
+		return protocol.ErrResponse(protocol.ErrInternalError, err.Error())
+	}
+	data, err := json.Marshal(connectResponseData{PushToken: pushToken})
+	if err != nil {
+		return protocol.ErrResponse(protocol.ErrInternalError, err.Error())
+	}
+	return protocol.OKResponse(data)
 }
 
 type connectResponseData struct {

--- a/internal/install/augment_test.go
+++ b/internal/install/augment_test.go
@@ -218,6 +218,9 @@ func TestCheckAugment_BrokenStaleCanonicalContent(t *testing.T) {
 	if len(issues) == 0 {
 		t.Fatal("expected issues for stale Augment block content, got none")
 	}
+	if !hasHealthIssueContaining(issues, "managed block content does not match expected") {
+		t.Fatalf("expected stale managed block content issue, got %+v", issues)
+	}
 }
 
 func TestCheckAugment_Broken(t *testing.T) {

--- a/internal/install/augment_test.go
+++ b/internal/install/augment_test.go
@@ -198,6 +198,28 @@ func TestCheckAugment_Healthy(t *testing.T) {
 	}
 }
 
+func TestCheckAugment_BrokenStaleCanonicalContent(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	if err := installAugment(tmpHome); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	skillPath := filepath.Join(tmpHome, ".augment", "skills", "waggle.md")
+	staleBlock := canonicalManagedBlock(augmentBlockBegin, augmentBlockEnd, "old bootstrap instructions")
+	if err := os.WriteFile(skillPath, managedBlockBytes(staleBlock, true), 0644); err != nil {
+		t.Fatalf("write stale Augment skill: %v", err)
+	}
+
+	issues, state := CheckAugment(tmpHome)
+	if state != StateBroken {
+		t.Fatalf("expected StateBroken for stale Augment block content, got %q", state)
+	}
+	if len(issues) == 0 {
+		t.Fatal("expected issues for stale Augment block content, got none")
+	}
+}
+
 func TestCheckAugment_Broken(t *testing.T) {
 	tmpHome := t.TempDir()
 	augmentDir := filepath.Join(tmpHome, ".augment", "skills")

--- a/internal/install/claude_code.go
+++ b/internal/install/claude_code.go
@@ -19,6 +19,7 @@ const wagglePushCommand = "WAGGLE_PPID=$PPID node $HOME/.claude/hooks/waggle-pus
 
 // The canonical Claude Code integration assets live in integrations/claude-code/.
 // This mirrored copy exists in-package so go:embed can bundle them for install.
+//
 //go:embed all:claude-code
 var claudeCodeFiles embed.FS
 
@@ -27,7 +28,7 @@ var claudeCodeFiles embed.FS
 // Used by both install and uninstall to prevent orphaned files.
 var hookFiles = []struct {
 	embedded, installed string
-	perm               os.FileMode
+	perm                os.FileMode
 }{
 	{"claude-code/hook.sh", "waggle-connect.sh", 0o755},
 	{"claude-code/heartbeat.sh", "waggle-heartbeat.sh", 0o755},
@@ -136,15 +137,24 @@ func uninstallClaudeCode(homeDir string) error {
 }
 
 // readSettingsJSON reads and parses settings.json.
-// Always returns a usable map — missing, empty, or corrupted files
-// produce an empty map. The file is input, not a precondition.
+// Missing or empty files are treated as empty settings. Invalid JSON returns
+// an error so callers do not silently discard unrelated user settings.
 func readSettingsJSON(path string) (map[string]interface{}, error) {
 	data, err := os.ReadFile(path)
-	if err != nil || len(data) == 0 {
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]interface{}), nil
+		}
+		return nil, fmt.Errorf("read settings.json: %w", err)
+	}
+	if len(data) == 0 {
 		return make(map[string]interface{}), nil
 	}
 	var settings map[string]interface{}
 	if err := json.Unmarshal(data, &settings); err != nil {
+		return nil, fmt.Errorf("parse settings.json: %w", err)
+	}
+	if settings == nil {
 		return make(map[string]interface{}), nil
 	}
 	return settings, nil
@@ -157,7 +167,10 @@ func registerSessionStartHook(claudeDir string) error {
 	root := filepath.Dir(claudeDir)
 
 	// Read existing settings
-	settings, _ := readSettingsJSON(settingsPath)
+	settings, err := readSettingsJSON(settingsPath)
+	if err != nil {
+		return err
+	}
 
 	// Get or create hooks section
 	hooks, _ := settings["hooks"].(map[string]interface{})
@@ -212,7 +225,10 @@ func deregisterSessionStartHook(claudeDir string) error {
 	settingsPath := filepath.Join(claudeDir, "settings.json")
 	root := filepath.Dir(claudeDir)
 
-	settings, _ := readSettingsJSON(settingsPath)
+	settings, err := readSettingsJSON(settingsPath)
+	if err != nil {
+		return err
+	}
 
 	hooks, _ := settings["hooks"].(map[string]interface{})
 	if hooks == nil {
@@ -261,7 +277,10 @@ func deregisterSessionStartHook(claudeDir string) error {
 func registerPreToolUseHook(claudeDir string) error {
 	settingsPath := filepath.Join(claudeDir, "settings.json")
 	root := filepath.Dir(claudeDir)
-	settings, _ := readSettingsJSON(settingsPath)
+	settings, err := readSettingsJSON(settingsPath)
+	if err != nil {
+		return err
+	}
 
 	hooks, _ := settings["hooks"].(map[string]interface{})
 	if hooks == nil {
@@ -302,7 +321,10 @@ func registerPreToolUseHook(claudeDir string) error {
 func deregisterPreToolUseHook(claudeDir string) error {
 	settingsPath := filepath.Join(claudeDir, "settings.json")
 	root := filepath.Dir(claudeDir)
-	settings, _ := readSettingsJSON(settingsPath)
+	settings, err := readSettingsJSON(settingsPath)
+	if err != nil {
+		return err
+	}
 
 	hooks, _ := settings["hooks"].(map[string]interface{})
 	if hooks == nil {

--- a/internal/install/claude_code.go
+++ b/internal/install/claude_code.go
@@ -59,6 +59,9 @@ func UninstallClaudeCode() error {
 // This allows testing with t.TempDir() instead of real ~/.claude/
 func installClaudeCode(homeDir string) error {
 	claudeDir := filepath.Join(homeDir, ".claude")
+	if _, err := readSettingsJSON(filepath.Join(claudeDir, "settings.json")); err != nil {
+		return err
+	}
 
 	// 1. Copy hook files (from single source of truth: hookFiles)
 	hookDir := filepath.Join(claudeDir, "hooks")
@@ -111,6 +114,9 @@ func installClaudeCode(homeDir string) error {
 // uninstallClaudeCode is the internal implementation that takes a home directory.
 func uninstallClaudeCode(homeDir string) error {
 	claudeDir := filepath.Join(homeDir, ".claude")
+	if _, err := readSettingsJSON(filepath.Join(claudeDir, "settings.json")); err != nil {
+		return err
+	}
 
 	// Remove hook files (from single source of truth: hookFiles)
 	for _, hf := range hookFiles {

--- a/internal/install/claude_code_test.go
+++ b/internal/install/claude_code_test.go
@@ -775,6 +775,58 @@ func TestInstall_CorruptedSettingsJSON(t *testing.T) {
 	if string(data) != "not json{{" {
 		t.Fatalf("corrupted settings.json should be preserved, got %q", string(data))
 	}
+
+	for _, path := range []string{
+		filepath.Join(tmpHome, ".claude", "hooks", "waggle-connect.sh"),
+		filepath.Join(tmpHome, ".claude", "hooks", "waggle-heartbeat.sh"),
+		filepath.Join(tmpHome, ".claude", "hooks", "waggle-push.js"),
+		filepath.Join(tmpHome, ".claude", "skills", "waggle"),
+		filepath.Join(tmpHome, ".waggle", "shell-hook.sh"),
+	} {
+		if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+			t.Fatalf("install should not leave partial artifact %s after invalid settings.json, stat err: %v", path, statErr)
+		}
+	}
+}
+
+func TestUninstall_CorruptedSettingsJSONPreservesArtifacts(t *testing.T) {
+	tmpHome := t.TempDir()
+	if err := installClaudeCode(tmpHome); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	claudeDir := filepath.Join(tmpHome, ".claude")
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte("not json{{"), 0644); err != nil {
+		t.Fatalf("write corrupted settings.json: %v", err)
+	}
+
+	err := uninstallClaudeCode(tmpHome)
+	if err == nil {
+		t.Fatal("expected uninstall to fail with corrupted settings.json")
+	}
+	if !strings.Contains(err.Error(), "parse settings.json") {
+		t.Fatalf("expected parse error, got: %v", err)
+	}
+
+	data, readErr := os.ReadFile(settingsPath)
+	if readErr != nil {
+		t.Fatalf("failed to read settings.json after failed uninstall: %v", readErr)
+	}
+	if string(data) != "not json{{" {
+		t.Fatalf("corrupted settings.json should be preserved, got %q", string(data))
+	}
+
+	for _, path := range []string{
+		filepath.Join(tmpHome, ".claude", "hooks", "waggle-connect.sh"),
+		filepath.Join(tmpHome, ".claude", "hooks", "waggle-heartbeat.sh"),
+		filepath.Join(tmpHome, ".claude", "hooks", "waggle-push.js"),
+		filepath.Join(tmpHome, ".claude", "skills", "waggle"),
+	} {
+		if _, statErr := os.Stat(path); statErr != nil {
+			t.Fatalf("uninstall should preserve artifact %s after invalid settings.json: %v", path, statErr)
+		}
+	}
 }
 
 func TestUninstall_EmptySettingsJSON(t *testing.T) {

--- a/internal/install/claude_code_test.go
+++ b/internal/install/claude_code_test.go
@@ -757,26 +757,23 @@ func TestInstall_CorruptedSettingsJSON(t *testing.T) {
 	tmpHome := t.TempDir()
 	claudeDir := filepath.Join(tmpHome, ".claude")
 	os.MkdirAll(claudeDir, 0755)
-	os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte("not json{{"), 0644)
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	os.WriteFile(settingsPath, []byte("not json{{"), 0644)
 
 	err := installClaudeCode(tmpHome)
-	if err != nil {
-		t.Fatalf("install failed with corrupted settings.json: %v", err)
+	if err == nil {
+		t.Fatal("expected install to fail with corrupted settings.json")
+	}
+	if !strings.Contains(err.Error(), "parse settings.json") {
+		t.Fatalf("expected parse error, got: %v", err)
 	}
 
-	// Verify settings.json is now valid with waggle hook
-	data, _ := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
-	var settings map[string]interface{}
-	if err := json.Unmarshal(data, &settings); err != nil {
-		t.Fatalf("settings.json is not valid JSON after install: %v", err)
+	data, readErr := os.ReadFile(settingsPath)
+	if readErr != nil {
+		t.Fatalf("failed to read settings.json after failed install: %v", readErr)
 	}
-	hooks, ok := settings["hooks"].(map[string]interface{})
-	if !ok {
-		t.Fatal("no hooks section in settings.json")
-	}
-	_, ok = hooks["SessionStart"].([]interface{})
-	if !ok {
-		t.Fatal("no SessionStart in hooks")
+	if string(data) != "not json{{" {
+		t.Fatalf("corrupted settings.json should be preserved, got %q", string(data))
 	}
 }
 

--- a/internal/install/gemini_test.go
+++ b/internal/install/gemini_test.go
@@ -175,6 +175,28 @@ func TestCheckGemini_Healthy(t *testing.T) {
 	}
 }
 
+func TestCheckGemini_BrokenStaleCanonicalContent(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	if err := installGemini(tmpHome); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	path := filepath.Join(tmpHome, ".gemini", "GEMINI.md")
+	staleBlock := canonicalManagedBlock(geminiBlockBegin, geminiBlockEnd, "old bootstrap instructions")
+	if err := os.WriteFile(path, managedBlockBytes(staleBlock, true), 0644); err != nil {
+		t.Fatalf("write stale GEMINI.md: %v", err)
+	}
+
+	issues, state := CheckGemini(tmpHome)
+	if state != StateBroken {
+		t.Fatalf("expected StateBroken for stale GEMINI block content, got %v", state)
+	}
+	if len(issues) == 0 {
+		t.Fatal("expected at least one issue")
+	}
+}
+
 func TestCheckGemini_BrokenTruncated(t *testing.T) {
 	tmpHome := t.TempDir()
 

--- a/internal/install/gemini_test.go
+++ b/internal/install/gemini_test.go
@@ -195,6 +195,9 @@ func TestCheckGemini_BrokenStaleCanonicalContent(t *testing.T) {
 	if len(issues) == 0 {
 		t.Fatal("expected at least one issue")
 	}
+	if !hasHealthIssueContaining(issues, "managed block content does not match expected") {
+		t.Fatalf("expected stale managed block content issue, got %+v", issues)
+	}
 }
 
 func TestCheckGemini_BrokenTruncated(t *testing.T) {

--- a/internal/install/health.go
+++ b/internal/install/health.go
@@ -1,6 +1,7 @@
 package install
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,6 +18,8 @@ const (
 	StateHealthy      AdapterState = "healthy"       // Adapter is installed and all files present
 	StateBroken       AdapterState = "broken"        // Adapter was installed but files are missing or inconsistent
 )
+
+var claudeCodeSkillFiles = []string{"waggle.md", "send.md", "inbox.md", "ack.md", "status.md", "claim.md", "done.md", "presence.md"}
 
 // HealthIssue represents a problem with an adapter installation.
 type HealthIssue struct {
@@ -136,8 +139,7 @@ func CheckClaudeCode(homeDir string) ([]HealthIssue, AdapterState) {
 			Repair:  repairCmd,
 		})
 	} else {
-		expectedSkills := []string{"waggle.md", "send.md", "inbox.md", "ack.md", "status.md", "claim.md", "done.md", "presence.md"}
-		for _, skill := range expectedSkills {
+		for _, skill := range claudeCodeSkillFiles {
 			skillPath := filepath.Join(skillDir, skill)
 			if !fileExists(skillPath) {
 				issues = append(issues, HealthIssue{
@@ -146,6 +148,25 @@ func CheckClaudeCode(homeDir string) ([]HealthIssue, AdapterState) {
 					Repair:  repairCmd,
 				})
 				break // Report only the first missing skill to avoid noise
+			}
+		}
+	}
+
+	if hookExists {
+		appendEmbeddedFileIssue(&issues, hookPath, claudeCodeFiles, "claude-code/hook.sh", "waggle-connect.sh", repairCmd)
+	}
+	if heartbeatExists {
+		appendEmbeddedFileIssue(&issues, heartbeatPath, claudeCodeFiles, "claude-code/heartbeat.sh", "waggle-heartbeat.sh", repairCmd)
+	}
+	pushPath := filepath.Join(claudeDir, "hooks", "waggle-push.js")
+	if fileExists(pushPath) {
+		appendEmbeddedFileIssue(&issues, pushPath, claudeCodeFiles, "claude-code/waggle-push.js", "waggle-push.js", repairCmd)
+	}
+	if skillDirExists {
+		for _, skill := range claudeCodeSkillFiles {
+			skillPath := filepath.Join(skillDir, skill)
+			if fileExists(skillPath) {
+				appendEmbeddedFileIssue(&issues, skillPath, claudeCodeFiles, "claude-code/skills/"+skill, "skill file "+skill, repairCmd)
 			}
 		}
 	}
@@ -223,6 +244,12 @@ func CheckCodex(homeDir string) ([]HealthIssue, AdapterState) {
 			Problem: "SKILL.md missing",
 			Repair:  repairCmd,
 		})
+	} else {
+		appendEmbeddedFileIssue(&issues, skillPath, codexFiles, "codex/skills/waggle-runtime/SKILL.md", "SKILL.md", repairCmd)
+	}
+
+	if hasBeginMarker && hasEndMarker && len(issues) == 0 {
+		appendManagedBlockContentIssue(&issues, agentsPath, string(data), codexBlockBegin, codexBlockEnd, codexFiles, "codex/AGENTS-block.md", repairCmd)
 	}
 
 	if len(issues) > 0 {
@@ -282,6 +309,10 @@ func CheckGemini(homeDir string) ([]HealthIssue, AdapterState) {
 			Problem: "managed block truncated (begin marker without end marker)",
 			Repair:  repairCmd,
 		})
+	}
+
+	if hasBeginMarker && hasEndMarker && len(issues) == 0 {
+		appendManagedBlockContentIssue(&issues, geminiFilePath, content, geminiBlockBegin, geminiBlockEnd, geminiFiles, "gemini/GEMINI-block.md", repairCmd)
 	}
 
 	if len(issues) > 0 {
@@ -397,10 +428,86 @@ func CheckAugment(homeDir string) ([]HealthIssue, AdapterState) {
 		})
 	}
 
+	if hasBeginMarker && hasEndMarker && len(issues) == 0 {
+		appendManagedBlockContentIssue(&issues, skillPath, content, augmentBlockBegin, augmentBlockEnd, augmentFiles, "augment/SKILL-block.md", repairCmd)
+	}
+
 	if len(issues) > 0 {
 		return issues, StateBroken
 	}
 	return nil, StateHealthy
+}
+
+type embeddedFileReader interface {
+	ReadFile(name string) ([]byte, error)
+}
+
+func appendEmbeddedFileIssue(issues *[]HealthIssue, path string, files embeddedFileReader, embeddedPath, assetName, repairCmd string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		*issues = append(*issues, HealthIssue{
+			Asset:   path,
+			Problem: "unable to read " + assetName + ": " + err.Error(),
+			Repair:  repairCmd,
+		})
+		return
+	}
+
+	canonical, err := files.ReadFile(embeddedPath)
+	if err != nil {
+		*issues = append(*issues, HealthIssue{
+			Asset:   path,
+			Problem: "unable to determine canonical " + assetName + " content: " + err.Error(),
+			Repair:  repairCmd,
+		})
+		return
+	}
+
+	if !bytes.Equal(data, canonical) {
+		*issues = append(*issues, HealthIssue{
+			Asset:   path,
+			Problem: assetName + " content does not match expected",
+			Repair:  repairCmd,
+		})
+	}
+}
+
+func appendManagedBlockContentIssue(issues *[]HealthIssue, path, content, begin, end string, files embeddedFileReader, embeddedPath, repairCmd string) {
+	body, ok := managedBlockBody(content, begin, end)
+	if !ok {
+		return
+	}
+
+	canonical, err := files.ReadFile(embeddedPath)
+	if err != nil {
+		*issues = append(*issues, HealthIssue{
+			Asset:   path,
+			Problem: "unable to determine canonical managed block content: " + err.Error(),
+			Repair:  repairCmd,
+		})
+		return
+	}
+
+	if strings.TrimSpace(body) != strings.TrimSpace(string(canonical)) {
+		*issues = append(*issues, HealthIssue{
+			Asset:   path,
+			Problem: "managed block content does not match expected",
+			Repair:  repairCmd,
+		})
+	}
+}
+
+func managedBlockBody(content, begin, end string) (string, bool) {
+	beginIdx := strings.Index(content, begin)
+	if beginIdx < 0 {
+		return "", false
+	}
+	bodyStart := beginIdx + len(begin)
+	endRel := strings.Index(content[bodyStart:], end)
+	if endRel < 0 {
+		return "", false
+	}
+	return content[bodyStart : bodyStart+endRel], true
 }
 
 // fileExists returns true if a path exists on disk (file or directory).

--- a/internal/install/health.go
+++ b/internal/install/health.go
@@ -47,7 +47,7 @@ func CheckClaudeCode(homeDir string) ([]HealthIssue, AdapterState) {
 	// Non-canonical references (e.g., user-edited paths) are detected separately
 	// as stale references and surfaced with repair guidance.
 	settingsPath := filepath.Join(claudeDir, "settings.json")
-	settings, _ := readSettingsJSON(settingsPath)
+	settings, settingsErr := readSettingsJSON(settingsPath)
 
 	hookRegistered := false
 	var staleRef string // non-canonical command containing "waggle-connect.sh"
@@ -77,12 +77,22 @@ func CheckClaudeCode(homeDir string) ([]HealthIssue, AdapterState) {
 	// Step 2: Check if waggle files are present on disk
 	hookPath := filepath.Join(claudeDir, "hooks", "waggle-connect.sh")
 	heartbeatPath := filepath.Join(claudeDir, "hooks", "waggle-heartbeat.sh")
+	pushPath := filepath.Join(claudeDir, "hooks", "waggle-push.js")
 	skillDir := filepath.Join(claudeDir, "skills", "waggle")
 
 	hookExists := fileExists(hookPath)
 	heartbeatExists := fileExists(heartbeatPath)
+	pushExists := fileExists(pushPath)
 	skillDirExists := fileExists(skillDir)
-	anyFileExists := hookExists || heartbeatExists || skillDirExists
+	anyFileExists := hookExists || heartbeatExists || pushExists || skillDirExists
+
+	if settingsErr != nil {
+		return []HealthIssue{{
+			Asset:   settingsPath,
+			Problem: "cannot parse settings.json: " + settingsErr.Error(),
+			Repair:  "fix or remove invalid settings.json, then run " + repairCmd,
+		}}, StateBroken
+	}
 
 	// Step 3: Derive state from fingerprint × files matrix
 	if !hookRegistered && !anyFileExists {
@@ -132,6 +142,14 @@ func CheckClaudeCode(homeDir string) ([]HealthIssue, AdapterState) {
 		})
 	}
 
+	if !pushExists {
+		issues = append(issues, HealthIssue{
+			Asset:   pushPath,
+			Problem: "waggle-push.js missing",
+			Repair:  repairCmd,
+		})
+	}
+
 	if !skillDirExists {
 		issues = append(issues, HealthIssue{
 			Asset:   skillDir,
@@ -158,8 +176,7 @@ func CheckClaudeCode(homeDir string) ([]HealthIssue, AdapterState) {
 	if heartbeatExists {
 		appendEmbeddedFileIssue(&issues, heartbeatPath, claudeCodeFiles, "claude-code/heartbeat.sh", "waggle-heartbeat.sh", repairCmd)
 	}
-	pushPath := filepath.Join(claudeDir, "hooks", "waggle-push.js")
-	if fileExists(pushPath) {
+	if pushExists {
 		appendEmbeddedFileIssue(&issues, pushPath, claudeCodeFiles, "claude-code/waggle-push.js", "waggle-push.js", repairCmd)
 	}
 	if skillDirExists {

--- a/internal/install/health_test.go
+++ b/internal/install/health_test.go
@@ -3,6 +3,7 @@ package install
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -114,6 +115,15 @@ func TestCheckClaudeCode_HealthyWithStaleReference(t *testing.T) {
 	}
 }
 
+func hasHealthIssueContaining(issues []HealthIssue, problem string) bool {
+	for _, issue := range issues {
+		if strings.Contains(issue.Problem, problem) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestCheckClaudeCode_Healthy(t *testing.T) {
 	tmpHome := t.TempDir()
 
@@ -150,6 +160,30 @@ func TestCheckClaudeCode_BrokenStaleCanonicalContent(t *testing.T) {
 	}
 	if len(issues) == 0 {
 		t.Fatal("expected health issues for stale hook content, got none")
+	}
+	if !hasHealthIssueContaining(issues, "waggle-connect.sh content does not match expected") {
+		t.Fatalf("expected stale hook content issue, got %+v", issues)
+	}
+}
+
+func TestCheckClaudeCode_BrokenInvalidSettingsJSON(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	if err := installClaudeCode(tmpHome); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	settingsPath := filepath.Join(tmpHome, ".claude", "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(`{"hooks":`), 0644); err != nil {
+		t.Fatalf("write invalid settings.json: %v", err)
+	}
+
+	issues, state := CheckClaudeCode(tmpHome)
+	if state != StateBroken {
+		t.Fatalf("expected StateBroken for invalid settings.json, got %q", state)
+	}
+	if !hasHealthIssueContaining(issues, "cannot parse settings.json") {
+		t.Fatalf("expected invalid settings.json issue, got %+v", issues)
 	}
 }
 
@@ -223,6 +257,27 @@ func TestCheckClaudeCode_BrokenMissingHeartbeat(t *testing.T) {
 	}
 	if !foundHeartbeatIssue {
 		t.Errorf("did not find heartbeat issue in: %+v", issues)
+	}
+}
+
+func TestCheckClaudeCode_BrokenMissingPushHook(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	if err := installClaudeCode(tmpHome); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	pushPath := filepath.Join(tmpHome, ".claude", "hooks", "waggle-push.js")
+	if err := os.Remove(pushPath); err != nil {
+		t.Fatalf("failed to delete push hook: %v", err)
+	}
+
+	issues, state := CheckClaudeCode(tmpHome)
+	if state != StateBroken {
+		t.Fatalf("expected StateBroken for missing push hook, got %q", state)
+	}
+	if !hasHealthIssueContaining(issues, "waggle-push.js missing") {
+		t.Fatalf("expected missing push hook issue, got %+v", issues)
 	}
 }
 
@@ -410,6 +465,9 @@ func TestCheckCodex_BrokenStaleCanonicalContent(t *testing.T) {
 	}
 	if len(issues) == 0 {
 		t.Fatal("expected health issues for stale AGENTS block content, got none")
+	}
+	if !hasHealthIssueContaining(issues, "managed block content does not match expected") {
+		t.Fatalf("expected stale managed block content issue, got %+v", issues)
 	}
 }
 

--- a/internal/install/health_test.go
+++ b/internal/install/health_test.go
@@ -132,6 +132,27 @@ func TestCheckClaudeCode_Healthy(t *testing.T) {
 	}
 }
 
+func TestCheckClaudeCode_BrokenStaleCanonicalContent(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	if err := installClaudeCode(tmpHome); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	hookPath := filepath.Join(tmpHome, ".claude", "hooks", "waggle-connect.sh")
+	if err := os.WriteFile(hookPath, []byte("#!/bin/sh\nwaggle runtime start\n"), 0755); err != nil {
+		t.Fatalf("write stale hook: %v", err)
+	}
+
+	issues, state := CheckClaudeCode(tmpHome)
+	if state != StateBroken {
+		t.Fatalf("expected StateBroken for stale hook content, got %q", state)
+	}
+	if len(issues) == 0 {
+		t.Fatal("expected health issues for stale hook content, got none")
+	}
+}
+
 func TestCheckClaudeCode_BrokenMissingHook(t *testing.T) {
 	tmpHome := t.TempDir()
 
@@ -370,6 +391,28 @@ func TestCheckCodex_Healthy(t *testing.T) {
 	}
 }
 
+func TestCheckCodex_BrokenStaleCanonicalContent(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	if err := installCodex(tmpHome); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	agentsPath := filepath.Join(tmpHome, ".codex", "AGENTS.md")
+	staleBlock := canonicalManagedBlock(codexBlockBegin, codexBlockEnd, "old bootstrap instructions")
+	if err := os.WriteFile(agentsPath, managedBlockBytes(staleBlock, true), 0644); err != nil {
+		t.Fatalf("write stale AGENTS.md: %v", err)
+	}
+
+	issues, state := CheckCodex(tmpHome)
+	if state != StateBroken {
+		t.Fatalf("expected StateBroken for stale AGENTS block content, got %q", state)
+	}
+	if len(issues) == 0 {
+		t.Fatal("expected health issues for stale AGENTS block content, got none")
+	}
+}
+
 func TestCheckCodex_Broken(t *testing.T) {
 	tmpHome := t.TempDir()
 
@@ -490,6 +533,7 @@ func TestCheckCodex_BrokenOrphanedInstall(t *testing.T) {
 		t.Errorf("did not find managed block issue in: %+v", issues)
 	}
 }
+
 // Topology-aware managed block validation tests for CheckCodex.
 // These verify that health matches the mutation contract: if validateMarkerTopology
 // would reject the file, health must report StateBroken (not StateHealthy).

--- a/internal/protocol/codes.go
+++ b/internal/protocol/codes.go
@@ -2,10 +2,10 @@ package protocol
 
 // Command constants — the `cmd` field values in Request
 const (
-	CmdConnect  = "connect"
+	CmdConnect    = "connect"
 	CmdDisconnect = "disconnect"
-	CmdPublish  = "publish"
-	CmdSubscribe = "subscribe"
+	CmdPublish    = "publish"
+	CmdSubscribe  = "subscribe"
 
 	CmdTaskCreate    = "task.create"
 	CmdTaskList      = "task.list"
@@ -28,24 +28,25 @@ const (
 	CmdAck      = "ack"
 	CmdPresence = "presence"
 
+	CmdPushReserve = "push.reserve"
+
 	CmdSpawnRegister  = "spawn.register"
 	CmdSpawnUpdatePID = "spawn.update-pid"
 )
 
 // Error code constants — the `code` field values in Response
 const (
-	ErrBrokerNotRunning         = "BROKER_NOT_RUNNING"
-	ErrAlreadyConnected         = "ALREADY_CONNECTED"
-	ErrNotConnected             = "NOT_CONNECTED"
-	ErrResourceLocked           = "RESOURCE_LOCKED"
-	ErrTaskNotFound             = "TASK_NOT_FOUND"
-	ErrInvalidToken             = "INVALID_TOKEN"
-	ErrNoEligibleTask           = "NO_ELIGIBLE_TASK"
-	ErrInvalidRequest           = "INVALID_REQUEST"
-	ErrDuplicateIdempotencyKey  = "DUPLICATE_IDEMPOTENCY_KEY"
-	ErrInternalError            = "INTERNAL_ERROR"
-	ErrMessageNotFound          = "MESSAGE_NOT_FOUND"
-	ErrForbidden                = "FORBIDDEN"
-	ErrTimeout                  = "TIMEOUT"
+	ErrBrokerNotRunning        = "BROKER_NOT_RUNNING"
+	ErrAlreadyConnected        = "ALREADY_CONNECTED"
+	ErrNotConnected            = "NOT_CONNECTED"
+	ErrResourceLocked          = "RESOURCE_LOCKED"
+	ErrTaskNotFound            = "TASK_NOT_FOUND"
+	ErrInvalidToken            = "INVALID_TOKEN"
+	ErrNoEligibleTask          = "NO_ELIGIBLE_TASK"
+	ErrInvalidRequest          = "INVALID_REQUEST"
+	ErrDuplicateIdempotencyKey = "DUPLICATE_IDEMPOTENCY_KEY"
+	ErrInternalError           = "INTERNAL_ERROR"
+	ErrMessageNotFound         = "MESSAGE_NOT_FOUND"
+	ErrForbidden               = "FORBIDDEN"
+	ErrTimeout                 = "TIMEOUT"
 )
-

--- a/internal/protocol/message_test.go
+++ b/internal/protocol/message_test.go
@@ -187,6 +187,7 @@ func TestCommandConstants_Unique(t *testing.T) {
 		CmdTaskCreate, CmdTaskList, CmdTaskClaim, CmdTaskComplete, CmdTaskFail,
 		CmdTaskHeartbeat, CmdTaskCancel, CmdTaskGet, CmdTaskUpdate,
 		CmdLock, CmdUnlock, CmdLocks, CmdStatus, CmdStop,
+		CmdPushReserve,
 	}
 
 	seen := make(map[string]bool)

--- a/internal/runtime/listener.go
+++ b/internal/runtime/listener.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/seungpyoson/waggle/internal/broker"
 	"github.com/seungpyoson/waggle/internal/client"
 	"github.com/seungpyoson/waggle/internal/config"
 	"github.com/seungpyoson/waggle/internal/protocol"
@@ -217,12 +216,34 @@ func sendDisconnect(c *client.Client, context string) {
 }
 
 func pushTokenForAgent(socketPath, agent string) (string, error) {
-	b := broker.LookupBySocket(socketPath)
-	if b == nil {
-		return "", fmt.Errorf("no in-process broker available for %s", agent)
+	c, err := client.Connect(socketPath, config.Defaults.ConnectTimeout)
+	if err != nil {
+		return "", err
 	}
-	if token := b.GetPushToken(agent); token != "" {
-		return token, nil
+	defer c.Close()
+
+	if err := c.SetDeadline(config.Defaults.ConnectTimeout); err != nil {
+		return "", fmt.Errorf("set push reserve deadline: %w", err)
 	}
-	return b.GeneratePushToken(agent)
+	resp, err := c.Send(protocol.Request{
+		Cmd:  protocol.CmdPushReserve,
+		Name: agent,
+	})
+	if err != nil {
+		return "", err
+	}
+	if !resp.OK {
+		return "", fmt.Errorf("%s: %s", resp.Code, resp.Error)
+	}
+
+	var data struct {
+		PushToken string `json:"push_token"`
+	}
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		return "", fmt.Errorf("parse push reserve response: %w", err)
+	}
+	if data.PushToken == "" {
+		return "", fmt.Errorf("push reserve response missing token")
+	}
+	return data.PushToken, nil
 }

--- a/internal/runtime/listener_test.go
+++ b/internal/runtime/listener_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -97,6 +98,7 @@ func TestBrokerListenerListenReceivesPushWithoutBaseConnection(t *testing.T) {
 	if !resp.OK {
 		t.Fatalf("sender connect failed: %s", resp.Error)
 	}
+	waitForRuntimePresence(t, sender, "alice")
 
 	sendResp, err := sender.Send(protocol.Request{
 		Cmd:     protocol.CmdSend,
@@ -179,4 +181,29 @@ func TestBrokerListenerCatchUpReadsInboxWithoutBaseConnection(t *testing.T) {
 	if got[0].Body != "catch-up delivery" {
 		t.Fatalf("delivery.Body = %q, want %q", got[0].Body, "catch-up delivery")
 	}
+}
+
+func waitForRuntimePresence(t *testing.T, c *client.Client, name string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := c.Send(protocol.Request{Cmd: protocol.CmdPresence})
+		if err != nil {
+			t.Fatalf("presence: %v", err)
+		}
+		if !resp.OK {
+			t.Fatalf("presence failed: %s", resp.Error)
+		}
+		var agents []map[string]string
+		if err := json.Unmarshal(resp.Data, &agents); err != nil {
+			t.Fatalf("parse presence: %v", err)
+		}
+		for _, agent := range agents {
+			if agent["name"] == name {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for runtime listener %q in presence", name)
 }


### PR DESCRIPTION
## Summary

- Preserve invalid Claude settings by failing install/uninstall before mutating managed artifacts.
- Make startup-path adapter bootstrap degrade cleanly when the runtime store cannot be opened or written.
- Replace in-process runtime push-token lookup with broker-owned `push.reserve` protocol flow.
- Add strict canonical-content health checks for Claude Code, Codex, Gemini, and Augment.
- Add real-process broker/runtime e2e coverage for watched-agent message delivery through the runtime listener path.
- Address review gaps: invalid Claude settings health diagnosis, missing `waggle-push.js` health detection, precise stale-content assertions, explicit `push.reserve` listener lifecycle coverage, and narrower e2e socket-bind skip behavior.

## Verification

- `GOCACHE=/tmp/go-build-cache go test ./internal/install -count=1`
- `GOCACHE=/tmp/go-build-cache go test ./internal/broker -run 'TestBroker_PushReserve|TestBroker_PushListener|TestBroker_ListenerDoesNotBlockAgentCLI|TestBroker_GeneratePushTokenReusesExistingToken|TestBroker_DeletePushTokenRevokesListenerToken' -count=1` (outside sandbox: passed)
- `GOCACHE=/tmp/go-build-cache go test ./e2e -run TestRuntimeRealProcessesReceiveWatchedAgentMessage -count=1 -v` (sandbox run skips only direct Unix socket bind permission denial)
- `GOCACHE=/tmp/go-build-cache go test ./e2e -run TestRuntimeRealProcessesReceiveWatchedAgentMessage -count=1 -v` (outside sandbox: passed)
- `GOCACHE=/tmp/go-build-cache go test ./... -count=1` (outside sandbox: passed)
- `GOCACHE=/tmp/go-build-cache go build -o waggle .` (outside sandbox: passed)
- `git diff --check`