### PR TITLE
fix: release reserved runtime push tokens

### DIFF
--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -1949,14 +1949,19 @@ func TestBroker_AwaitAckBrokerShutdown(t *testing.T) {
 
 	// Alice sends with await-ack (long timeout)
 	sendDone := make(chan *protocol.Response)
+	sendErr := make(chan error)
 	go func() {
-		resp, _ := c1.Send(protocol.Request{
+		resp, err := c1.Send(protocol.Request{
 			Cmd:      protocol.CmdSend,
 			Name:     "bob",
 			Message:  "shutdown test",
 			AwaitAck: true,
 			Timeout:  30,
 		})
+		if err != nil {
+			sendErr <- err
+			return
+		}
 		sendDone <- resp
 	}()
 
@@ -1970,6 +1975,7 @@ func TestBroker_AwaitAckBrokerShutdown(t *testing.T) {
 		if resp.OK {
 			t.Error("send should fail on broker shutdown")
 		}
+	case <-sendErr:
 	case <-time.After(2 * time.Second):
 		t.Fatal("send did not return after broker shutdown")
 	}
@@ -3207,6 +3213,392 @@ func TestBroker_PushReserveAllowsListenerWithoutBaseSession(t *testing.T) {
 	}
 }
 
+func TestBroker_PushReserveReturnsSameTokenForDuplicateReserve(t *testing.T) {
+	sockPath, _, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	first := connectClient(t, sockPath)
+	defer first.Close()
+	resp, err := first.Send(protocol.Request{
+		Cmd:  protocol.CmdPushReserve,
+		Name: "alice",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("first push reserve failed: %s: %s", resp.Code, resp.Error)
+	}
+	firstToken := pushTokenFromResponse(t, resp)
+
+	second := connectClient(t, sockPath)
+	defer second.Close()
+	resp, err = second.Send(protocol.Request{
+		Cmd:  protocol.CmdPushReserve,
+		Name: "alice",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("second push reserve failed: %s: %s", resp.Code, resp.Error)
+	}
+	secondToken := pushTokenFromResponse(t, resp)
+
+	if secondToken != firstToken {
+		t.Fatalf("duplicate push reserve token = %q, want %q", secondToken, firstToken)
+	}
+}
+
+func TestBroker_PushReserveReturnsConnectedBaseToken(t *testing.T) {
+	sockPath, _, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	base := connectClient(t, sockPath)
+	defer base.Close()
+	resp, err := base.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("base connect failed: %s: %s", resp.Code, resp.Error)
+	}
+	baseToken := pushTokenFromResponse(t, resp)
+
+	reserver := connectClient(t, sockPath)
+	defer reserver.Close()
+	resp, err = reserver.Send(protocol.Request{
+		Cmd:  protocol.CmdPushReserve,
+		Name: "alice",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("push reserve failed: %s: %s", resp.Code, resp.Error)
+	}
+	reservedToken := pushTokenFromResponse(t, resp)
+
+	if reservedToken != baseToken {
+		t.Fatalf("reserved token = %q, want connected base token %q", reservedToken, baseToken)
+	}
+}
+
+func TestBroker_PushReleaseDeletesReservedToken(t *testing.T) {
+	sockPath, b, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	reserver := connectClient(t, sockPath)
+	defer reserver.Close()
+	resp, err := reserver.Send(protocol.Request{
+		Cmd:  protocol.CmdPushReserve,
+		Name: "alice",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("push reserve failed: %s: %s", resp.Code, resp.Error)
+	}
+	token := pushTokenFromResponse(t, resp)
+
+	resp, err = reserver.Send(protocol.Request{
+		Cmd:       protocol.CmdPushRelease,
+		Name:      "alice",
+		PushToken: token,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("push release failed: %s: %s", resp.Code, resp.Error)
+	}
+	if got := b.GetPushToken("alice"); got != "" {
+		t.Fatalf("GetPushToken() after release = %q, want empty", got)
+	}
+
+	listener := connectClient(t, sockPath)
+	defer listener.Close()
+	resp, err = listener.Send(protocol.Request{
+		Cmd:          protocol.CmdConnect,
+		Name:         "alice-push",
+		PushListener: true,
+		PushToken:    token,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.OK {
+		t.Fatal("expected released token to be rejected")
+	}
+	if resp.Code != protocol.ErrForbidden {
+		t.Fatalf("response code = %q, want %q", resp.Code, protocol.ErrForbidden)
+	}
+}
+
+func TestBroker_PushReleaseRejectsWrongToken(t *testing.T) {
+	sockPath, b, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	reserver := connectClient(t, sockPath)
+	defer reserver.Close()
+	resp, err := reserver.Send(protocol.Request{
+		Cmd:  protocol.CmdPushReserve,
+		Name: "alice",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("push reserve failed: %s: %s", resp.Code, resp.Error)
+	}
+	token := pushTokenFromResponse(t, resp)
+
+	resp, err = reserver.Send(protocol.Request{
+		Cmd:       protocol.CmdPushRelease,
+		Name:      "alice",
+		PushToken: "wrong-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.OK {
+		t.Fatal("expected push release with wrong token to fail")
+	}
+	if resp.Code != protocol.ErrForbidden {
+		t.Fatalf("response code = %q, want %q", resp.Code, protocol.ErrForbidden)
+	}
+	if got := b.GetPushToken("alice"); got != token {
+		t.Fatalf("GetPushToken() after failed release = %q, want %q", got, token)
+	}
+}
+
+func TestBroker_PushReleaseRejectsUnknownReservation(t *testing.T) {
+	sockPath, _, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	releaser := connectClient(t, sockPath)
+	defer releaser.Close()
+	resp, err := releaser.Send(protocol.Request{
+		Cmd:       protocol.CmdPushRelease,
+		Name:      "alice",
+		PushToken: "never-issued-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.OK {
+		t.Fatal("expected push release with no reservation to fail")
+	}
+	if resp.Code != protocol.ErrForbidden {
+		t.Fatalf("response code = %q, want %q", resp.Code, protocol.ErrForbidden)
+	}
+}
+
+func TestBroker_PushReleaseRevokesTokenWithoutDisconnectingActiveListener(t *testing.T) {
+	sockPath, b, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	reserver := connectClient(t, sockPath)
+	defer reserver.Close()
+	resp, err := reserver.Send(protocol.Request{
+		Cmd:  protocol.CmdPushReserve,
+		Name: "alice",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("push reserve failed: %s: %s", resp.Code, resp.Error)
+	}
+	token := pushTokenFromResponse(t, resp)
+
+	listener := connectClient(t, sockPath)
+	defer listener.Close()
+	resp, err = listener.Send(protocol.Request{
+		Cmd:          protocol.CmdConnect,
+		Name:         "alice-push",
+		PushListener: true,
+		PushToken:    token,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("listener connect failed: %s: %s", resp.Code, resp.Error)
+	}
+
+	resp, err = reserver.Send(protocol.Request{
+		Cmd:       protocol.CmdPushRelease,
+		Name:      "alice",
+		PushToken: token,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("push release failed: %s: %s", resp.Code, resp.Error)
+	}
+	if got := b.GetPushToken("alice"); got != "" {
+		t.Fatalf("GetPushToken() after release = %q, want empty", got)
+	}
+
+	sender := connectClient(t, sockPath)
+	defer sender.Close()
+	resp, err = sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "sender"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("sender connect failed: %s: %s", resp.Code, resp.Error)
+	}
+	resp, err = sender.Send(protocol.Request{
+		Cmd:     protocol.CmdSend,
+		Name:    "alice",
+		Message: "active listener still receives",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("send failed: %s: %s", resp.Code, resp.Error)
+	}
+
+	msg, err := listener.Receive()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !msg.OK {
+		t.Fatalf("push receive failed: %s", msg.Error)
+	}
+}
+
+func connectPushListenerEventually(t *testing.T, sockPath, name, token string) *client.Client {
+	t.Helper()
+	deadline := time.Now().Add(config.Defaults.StartupTimeout)
+	for {
+		listener := connectClient(t, sockPath)
+		resp, err := listener.Send(protocol.Request{
+			Cmd:          protocol.CmdConnect,
+			Name:         name,
+			PushListener: true,
+			PushToken:    token,
+		})
+		if err != nil {
+			listener.Close()
+			t.Fatal(err)
+		}
+		if resp.OK {
+			return listener
+		}
+		listener.Close()
+		if resp.Code != protocol.ErrAlreadyConnected || time.Now().After(deadline) {
+			t.Fatalf("push listener connect failed: %s: %s", resp.Code, resp.Error)
+		}
+		time.Sleep(config.Defaults.StartupPollInterval)
+	}
+}
+
+func TestBroker_PushReleaseThenReserveSurvivesBaseDisconnect(t *testing.T) {
+	sockPath, _, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	base := connectClient(t, sockPath)
+	resp, err := base.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("base connect failed: %s: %s", resp.Code, resp.Error)
+	}
+	baseOwnedToken := pushTokenFromResponse(t, resp)
+
+	firstListener := connectClient(t, sockPath)
+	resp, err = firstListener.Send(protocol.Request{
+		Cmd:          protocol.CmdConnect,
+		Name:         "alice-push",
+		PushListener: true,
+		PushToken:    baseOwnedToken,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("first listener connect failed: %s: %s", resp.Code, resp.Error)
+	}
+	firstListener.Close()
+
+	releaser := connectClient(t, sockPath)
+	defer releaser.Close()
+	resp, err = releaser.Send(protocol.Request{
+		Cmd:       protocol.CmdPushRelease,
+		Name:      "alice",
+		PushToken: baseOwnedToken,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("push release failed: %s: %s", resp.Code, resp.Error)
+	}
+
+	reserver := connectClient(t, sockPath)
+	defer reserver.Close()
+	resp, err = reserver.Send(protocol.Request{
+		Cmd:  protocol.CmdPushReserve,
+		Name: "alice",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("push reserve failed: %s: %s", resp.Code, resp.Error)
+	}
+	reservedToken := pushTokenFromResponse(t, resp)
+
+	secondListener := connectPushListenerEventually(t, sockPath, "alice-push", reservedToken)
+	defer secondListener.Close()
+
+	resp, err = base.Send(protocol.Request{Cmd: protocol.CmdDisconnect})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("base disconnect failed: %s: %s", resp.Code, resp.Error)
+	}
+	base.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	sender := connectClient(t, sockPath)
+	defer sender.Close()
+	resp, err = sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "sender"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("sender connect failed: %s: %s", resp.Code, resp.Error)
+	}
+	resp, err = sender.Send(protocol.Request{
+		Cmd:     protocol.CmdSend,
+		Name:    "alice",
+		Message: "hello after base-owned release",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("send failed: %s: %s", resp.Code, resp.Error)
+	}
+
+	msg, err := secondListener.Receive()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !msg.OK {
+		t.Fatalf("push receive failed: %s", msg.Error)
+	}
+}
+
 func TestBroker_PushReserveListenerSurvivesBaseAgentDisconnect(t *testing.T) {
 	sockPath, _, cleanup := startTestBroker(t)
 	defer cleanup()
@@ -3226,6 +3618,7 @@ func TestBroker_PushReserveListenerSurvivesBaseAgentDisconnect(t *testing.T) {
 	reserver.Close()
 
 	listener := connectClient(t, sockPath)
+	defer listener.Close()
 	resp, err = listener.Send(protocol.Request{
 		Cmd:          protocol.CmdConnect,
 		Name:         "alice-push",
@@ -3262,6 +3655,88 @@ func TestBroker_PushReserveListenerSurvivesBaseAgentDisconnect(t *testing.T) {
 		Cmd:     protocol.CmdSend,
 		Name:    "alice",
 		Message: "hello after base disconnect",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("send failed: %s: %s", resp.Code, resp.Error)
+	}
+
+	msg, err := listener.Receive()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !msg.OK {
+		t.Fatalf("push receive failed: %s", msg.Error)
+	}
+}
+
+func TestBroker_PushReserveListenerSurvivesRepeatedBaseReconnects(t *testing.T) {
+	sockPath, _, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	reserver := connectClient(t, sockPath)
+	resp, err := reserver.Send(protocol.Request{
+		Cmd:  protocol.CmdPushReserve,
+		Name: "alice",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("push reserve failed: %s: %s", resp.Code, resp.Error)
+	}
+	reservedToken := pushTokenFromResponse(t, resp)
+	reserver.Close()
+
+	listener := connectClient(t, sockPath)
+	resp, err = listener.Send(protocol.Request{
+		Cmd:          protocol.CmdConnect,
+		Name:         "alice-push",
+		PushListener: true,
+		PushToken:    reservedToken,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("push listener connect failed with reserved token: %s: %s", resp.Code, resp.Error)
+	}
+
+	for i := 0; i < 3; i++ {
+		base := connectClient(t, sockPath)
+		resp, err = base.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !resp.OK {
+			t.Fatalf("base connect %d failed: %s: %s", i, resp.Code, resp.Error)
+		}
+		resp, err = base.Send(protocol.Request{Cmd: protocol.CmdDisconnect})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !resp.OK {
+			t.Fatalf("base disconnect %d failed: %s: %s", i, resp.Code, resp.Error)
+		}
+		base.Close()
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	sender := connectClient(t, sockPath)
+	defer sender.Close()
+	resp, err = sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "sender"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("sender connect failed: %s: %s", resp.Code, resp.Error)
+	}
+	resp, err = sender.Send(protocol.Request{
+		Cmd:     protocol.CmdSend,
+		Name:    "alice",
+		Message: "hello after repeated base reconnects",
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/broker/router.go
+++ b/internal/broker/router.go
@@ -24,6 +24,7 @@ var noSessionRequired = map[string]bool{
 	protocol.CmdStatus:      true,
 	protocol.CmdStop:        true,
 	protocol.CmdPushReserve: true,
+	protocol.CmdPushRelease: true,
 }
 
 // route dispatches a request to the appropriate handler.
@@ -80,6 +81,8 @@ func route(s *Session, req protocol.Request) protocol.Response {
 		return handlePresence(s)
 	case protocol.CmdPushReserve:
 		return handlePushReserve(s, req)
+	case protocol.CmdPushRelease:
+		return handlePushRelease(s, req)
 	case protocol.CmdSpawnRegister:
 		return handleSpawnRegister(s, req)
 	case protocol.CmdSpawnUpdatePID:
@@ -112,6 +115,35 @@ func handlePushReserve(s *Session, req protocol.Request) protocol.Response {
 		return protocol.ErrResponse(protocol.ErrInternalError, err.Error())
 	}
 	return protocol.OKResponse(data)
+}
+
+func handlePushRelease(s *Session, req protocol.Request) protocol.Response {
+	if req.Name == "" {
+		return protocol.ErrResponse(protocol.ErrInvalidRequest, "name required")
+	}
+	if len(req.Name) > config.Defaults.MaxFieldLength {
+		return protocol.ErrResponse(protocol.ErrInvalidRequest, fmt.Sprintf("name too long (max %d chars)", config.Defaults.MaxFieldLength))
+	}
+	if strings.HasSuffix(req.Name, "-push") {
+		return protocol.ErrResponse(protocol.ErrInvalidRequest, `push.release requires a base agent name, not a "-push" listener name`)
+	}
+	if req.PushToken == "" {
+		return protocol.ErrResponse(protocol.ErrInvalidRequest, "push token required")
+	}
+
+	s.broker.mu.Lock()
+	expectedToken, exists := s.broker.pushTokens[req.Name]
+	if !exists || subtle.ConstantTimeCompare([]byte(req.PushToken), []byte(expectedToken)) != 1 {
+		s.broker.mu.Unlock()
+		return protocol.ErrResponse(protocol.ErrForbidden, "invalid push listener token")
+	}
+	delete(s.broker.pushTokens, req.Name)
+	if base, ok := s.broker.sessions[req.Name]; ok && !strings.HasSuffix(base.name, "-push") {
+		base.ownsPushToken = false
+	}
+	s.broker.mu.Unlock()
+
+	return protocol.OKResponse(nil)
 }
 
 type connectResponseData struct {

--- a/internal/protocol/codes.go
+++ b/internal/protocol/codes.go
@@ -29,6 +29,7 @@ const (
 	CmdPresence = "presence"
 
 	CmdPushReserve = "push.reserve"
+	CmdPushRelease = "push.release"
 
 	CmdSpawnRegister  = "spawn.register"
 	CmdSpawnUpdatePID = "spawn.update-pid"

--- a/internal/protocol/message_test.go
+++ b/internal/protocol/message_test.go
@@ -187,7 +187,7 @@ func TestCommandConstants_Unique(t *testing.T) {
 		CmdTaskCreate, CmdTaskList, CmdTaskClaim, CmdTaskComplete, CmdTaskFail,
 		CmdTaskHeartbeat, CmdTaskCancel, CmdTaskGet, CmdTaskUpdate,
 		CmdLock, CmdUnlock, CmdLocks, CmdStatus, CmdStop,
-		CmdPushReserve,
+		CmdPushReserve, CmdPushRelease,
 	}
 
 	seen := make(map[string]bool)

--- a/internal/runtime/listener.go
+++ b/internal/runtime/listener.go
@@ -55,12 +55,20 @@ func (f *BrokerListenerFactory) CatchUp(w Watch, handler DeliveryHandler) error 
 
 	c, err := client.Connect(paths.Socket, config.Defaults.ConnectTimeout)
 	if err != nil {
+		releasePushTokenForAgent(paths.Socket, w.AgentName, pushToken)
 		return err
 	}
+	connected := false
+	releaseOnReturn := true
 	defer func() {
 		// Clean disconnect prevents task requeue and lock release.
-		sendDisconnect(c, fmt.Sprintf("catch-up %q/%q", w.ProjectID, w.AgentName))
+		if connected {
+			sendDisconnect(c, fmt.Sprintf("catch-up %q/%q", w.ProjectID, w.AgentName))
+		}
 		c.Close()
+		if releaseOnReturn {
+			releasePushTokenForAgent(paths.Socket, w.AgentName, pushToken)
+		}
 	}()
 
 	// Set deadline for the entire catch-up operation (handshake + inbox + disconnect).
@@ -79,8 +87,10 @@ func (f *BrokerListenerFactory) CatchUp(w Watch, handler DeliveryHandler) error 
 	if !resp.OK {
 		// protocol.ErrAlreadyConnected is transient during restarts or duplicate workers;
 		// Manager.runWatch treats the returned Listen error as retryable and reconnects.
+		releaseOnReturn = false
 		return fmt.Errorf("%s: %s", resp.Code, resp.Error)
 	}
+	connected = true
 
 	resp, err = c.Send(protocol.Request{Cmd: protocol.CmdInbox})
 	if err != nil {
@@ -133,9 +143,16 @@ func (l *brokerListener) Listen(ctx context.Context, handler DeliveryHandler) er
 
 	c, err := client.Connect(l.socketPath, config.Defaults.ConnectTimeout)
 	if err != nil {
+		releasePushTokenForAgent(l.socketPath, l.agentName, pushToken)
 		return err
 	}
-	defer disconnectClient(c)
+	releaseOnReturn := true
+	defer func() {
+		c.Close()
+		if releaseOnReturn {
+			releasePushTokenForAgent(l.socketPath, l.agentName, pushToken)
+		}
+	}()
 
 	if err := c.SetDeadline(config.Defaults.ConnectTimeout); err != nil {
 		return fmt.Errorf("set handshake deadline: %w", err)
@@ -150,6 +167,7 @@ func (l *brokerListener) Listen(ctx context.Context, handler DeliveryHandler) er
 		return err
 	}
 	if !resp.OK {
+		releaseOnReturn = false
 		return fmt.Errorf("%s: %s", resp.Code, resp.Error)
 	}
 	if err := c.ClearDeadline(); err != nil {
@@ -246,4 +264,33 @@ func pushTokenForAgent(socketPath, agent string) (string, error) {
 		return "", fmt.Errorf("push reserve response missing token")
 	}
 	return data.PushToken, nil
+}
+
+func releasePushTokenForAgent(socketPath, agent, pushToken string) {
+	if socketPath == "" || agent == "" || pushToken == "" {
+		return
+	}
+	c, err := client.Connect(socketPath, config.Defaults.ConnectTimeout)
+	if err != nil {
+		log.Printf("warning: release push token for %s: %v", agent, err)
+		return
+	}
+	defer c.Close()
+
+	if err := c.SetDeadline(config.Defaults.DisconnectTimeout); err != nil {
+		log.Printf("warning: set push release deadline for %s: %v", agent, err)
+		return
+	}
+	resp, err := c.Send(protocol.Request{
+		Cmd:       protocol.CmdPushRelease,
+		Name:      agent,
+		PushToken: pushToken,
+	})
+	if err != nil {
+		log.Printf("warning: release push token for %s: %v", agent, err)
+		return
+	}
+	if !resp.OK {
+		log.Printf("warning: release push token for %s: %s: %s", agent, resp.Code, resp.Error)
+	}
 }

--- a/internal/runtime/listener_test.go
+++ b/internal/runtime/listener_test.go
@@ -134,6 +134,139 @@ func TestBrokerListenerListenReceivesPushWithoutBaseConnection(t *testing.T) {
 	}
 }
 
+func TestBrokerListenerListenReleasesPushTokenOnShutdown(t *testing.T) {
+	socketPath, cleanup := startRuntimeTestBroker(t, "proj-listen-release")
+	defer cleanup()
+
+	token, err := pushTokenForAgent(socketPath, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listener, err := NewBrokerListenerFactory().NewListener(Watch{
+		ProjectID: "proj-listen-release",
+		AgentName: "alice",
+		Source:    "hook",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- listener.Listen(ctx, func(d Delivery) error {
+			cancel()
+			return nil
+		})
+	}()
+
+	sender := connectRuntimeClient(t, socketPath)
+	defer sender.Close()
+	resp, err := sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "sender"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("sender connect failed: %s", resp.Error)
+	}
+	waitForRuntimePresence(t, sender, "alice")
+
+	sendResp, err := sender.Send(protocol.Request{
+		Cmd:     protocol.CmdSend,
+		Name:    "alice",
+		Message: "release after delivery",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sendResp.OK {
+		t.Fatalf("send failed: %s", sendResp.Error)
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Listen() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for listener shutdown")
+	}
+
+	waitForPushTokenRejected(t, socketPath, "alice-push", token)
+}
+
+func TestBrokerListenerFailedHandshakeDoesNotReleaseActiveListenerToken(t *testing.T) {
+	socketPath, cleanup := startRuntimeTestBroker(t, "proj-listen-duplicate")
+	defer cleanup()
+
+	token, err := pushTokenForAgent(socketPath, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	active := connectRuntimeClient(t, socketPath)
+	defer active.Close()
+	resp, err := active.Send(protocol.Request{
+		Cmd:          protocol.CmdConnect,
+		Name:         "alice-push",
+		PushListener: true,
+		PushToken:    token,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("active listener connect failed: %s: %s", resp.Code, resp.Error)
+	}
+
+	listener, err := NewBrokerListenerFactory().NewListener(Watch{
+		ProjectID: "proj-listen-duplicate",
+		AgentName: "alice",
+		Source:    "hook",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = listener.Listen(context.Background(), func(d Delivery) error {
+		t.Fatal("duplicate listener unexpectedly received delivery")
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected duplicate listener handshake to fail")
+	}
+
+	sender := connectRuntimeClient(t, socketPath)
+	defer sender.Close()
+	resp, err = sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "sender"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("sender connect failed: %s: %s", resp.Code, resp.Error)
+	}
+	resp, err = sender.Send(protocol.Request{
+		Cmd:     protocol.CmdSend,
+		Name:    "alice",
+		Message: "still active",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("send failed: %s: %s", resp.Code, resp.Error)
+	}
+
+	msg, err := active.Receive()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !msg.OK {
+		t.Fatalf("active listener receive failed: %s", msg.Error)
+	}
+}
+
 func TestBrokerListenerCatchUpReadsInboxWithoutBaseConnection(t *testing.T) {
 	socketPath, cleanup := startRuntimeTestBroker(t, "proj-catchup")
 	defer cleanup()
@@ -183,6 +316,55 @@ func TestBrokerListenerCatchUpReadsInboxWithoutBaseConnection(t *testing.T) {
 	}
 }
 
+func TestBrokerListenerCatchUpReleasesPushToken(t *testing.T) {
+	socketPath, cleanup := startRuntimeTestBroker(t, "proj-catchup-release")
+	defer cleanup()
+
+	token, err := pushTokenForAgent(socketPath, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sender := connectRuntimeClient(t, socketPath)
+	defer sender.Close()
+	resp, err := sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "sender"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("sender connect failed: %s", resp.Error)
+	}
+
+	sendResp, err := sender.Send(protocol.Request{
+		Cmd:     protocol.CmdSend,
+		Name:    "alice",
+		Message: "catch-up release delivery",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sendResp.OK {
+		t.Fatalf("send failed: %s", sendResp.Error)
+	}
+
+	var got []Delivery
+	if err := NewBrokerListenerFactory().CatchUp(Watch{
+		ProjectID: "proj-catchup-release",
+		AgentName: "alice",
+		Source:    "hook",
+	}, func(d Delivery) error {
+		got = append(got, d)
+		return nil
+	}); err != nil {
+		t.Fatalf("CatchUp() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("CatchUp() deliveries = %d, want 1", len(got))
+	}
+
+	waitForPushTokenRejected(t, socketPath, "alice-push", token)
+}
+
 func waitForRuntimePresence(t *testing.T, c *client.Client, name string) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
@@ -206,4 +388,30 @@ func waitForRuntimePresence(t *testing.T, c *client.Client, name string) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("timed out waiting for runtime listener %q in presence", name)
+}
+
+func waitForPushTokenRejected(t *testing.T, socketPath, listenerName, token string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		c := connectRuntimeClient(t, socketPath)
+		resp, err := c.Send(protocol.Request{
+			Cmd:          protocol.CmdConnect,
+			Name:         listenerName,
+			PushListener: true,
+			PushToken:    token,
+		})
+		c.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !resp.OK && resp.Code == protocol.ErrForbidden {
+			return
+		}
+		if resp.OK {
+			t.Fatal("expected released push token to be rejected")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for released push token to be rejected for %q", listenerName)
 }


### PR DESCRIPTION
## Summary

- Add `push.release` to reclaim broker-owned runtime push tokens by base name and token.
- Have broker runtime listeners release their reserved token on listener shutdown instead of leaving reserved-only tokens until broker restart.
- Add protocol/lifecycle coverage for duplicate reserves, reserve while base is connected, release validation, and repeated base reconnects.

Closes #115.

## Verification

- `go test ./... -count=1 -timeout=120s`
- `go test ./internal/broker ./internal/runtime ./internal/protocol -count=1 -timeout=60s`
- `go build -o waggle .`
- `git diff --check`