### PR TITLE
fix: synchronize clean disconnect state

### DIFF
--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -3395,6 +3395,84 @@ func TestBroker_PushReleaseRejectsUnknownReservation(t *testing.T) {
 	}
 }
 
+func TestBroker_PushReleaseRejectsEmptyToken(t *testing.T) {
+	sockPath, _, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	releaser := connectClient(t, sockPath)
+	defer releaser.Close()
+	resp, err := releaser.Send(protocol.Request{
+		Cmd:  protocol.CmdPushRelease,
+		Name: "alice",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.OK {
+		t.Fatal("expected push release with empty token to fail")
+	}
+	if resp.Code != protocol.ErrInvalidRequest {
+		t.Fatalf("response code = %q, want %q", resp.Code, protocol.ErrInvalidRequest)
+	}
+}
+
+func TestBroker_PushReleaseRejectsDoubleReleaseWithoutMutatingNewReservation(t *testing.T) {
+	sockPath, b, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	releaser := connectClient(t, sockPath)
+	defer releaser.Close()
+	resp, err := releaser.Send(protocol.Request{
+		Cmd:  protocol.CmdPushReserve,
+		Name: "alice",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("push reserve failed: %s: %s", resp.Code, resp.Error)
+	}
+	oldToken := pushTokenFromResponse(t, resp)
+
+	resp, err = releaser.Send(protocol.Request{
+		Cmd:       protocol.CmdPushRelease,
+		Name:      "alice",
+		PushToken: oldToken,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("push release failed: %s: %s", resp.Code, resp.Error)
+	}
+
+	newToken, err := b.GeneratePushToken("alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newToken == oldToken {
+		t.Fatal("new reservation reused released token")
+	}
+
+	resp, err = releaser.Send(protocol.Request{
+		Cmd:       protocol.CmdPushRelease,
+		Name:      "alice",
+		PushToken: oldToken,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.OK {
+		t.Fatal("expected double release with stale token to fail")
+	}
+	if resp.Code != protocol.ErrForbidden {
+		t.Fatalf("response code = %q, want %q", resp.Code, protocol.ErrForbidden)
+	}
+	if got := b.GetPushToken("alice"); got != newToken {
+		t.Fatalf("GetPushToken() after stale double release = %q, want %q", got, newToken)
+	}
+}
+
 func TestBroker_PushReleaseRevokesTokenWithoutDisconnectingActiveListener(t *testing.T) {
 	sockPath, b, cleanup := startTestBroker(t)
 	defer cleanup()

--- a/internal/broker/router.go
+++ b/internal/broker/router.go
@@ -210,7 +210,7 @@ func handleConnect(s *Session, req protocol.Request) protocol.Response {
 }
 
 func handleDisconnect(s *Session) protocol.Response {
-	s.cleanDisconnect = true
+	s.cleanDisconnect.Store(true)
 	// Don't call cleanup() here — readLoop will return after encoding
 	// this response (see cleanDisconnect check), triggering deferred cleanup.
 	// Calling cleanup here closes the conn before the OK response is sent.

--- a/internal/broker/session.go
+++ b/internal/broker/session.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 
 	"github.com/seungpyoson/waggle/internal/config"
@@ -22,7 +23,7 @@ type Session struct {
 	scan            *bufio.Scanner
 	broker          *Broker
 	ownsPushToken   bool
-	cleanDisconnect bool // Set to true when disconnect command is received
+	cleanDisconnect atomic.Bool // Set to true when disconnect command is received
 	cleanupOnce     sync.Once
 	writeMu         sync.Mutex // protects enc writes
 }
@@ -62,21 +63,21 @@ func (s *Session) readLoop() {
 		s.writeMu.Unlock()
 		if err != nil {
 			// Suppress errors after disconnect — client may have already closed
-			if !s.cleanDisconnect {
+			if !s.cleanDisconnect.Load() {
 				log.Printf("session %s: error encoding response: %v", s.name, err)
 			}
 			return
 		}
 
 		// After clean disconnect, stop reading — client is closing
-		if s.cleanDisconnect {
+		if s.cleanDisconnect.Load() {
 			return
 		}
 	}
 
 	if err := s.scan.Err(); err != nil {
 		// Suppress expected EOF/closed connection errors
-		if !s.cleanDisconnect && !isConnectionClosed(err) {
+		if !s.cleanDisconnect.Load() && !isConnectionClosed(err) {
 			log.Printf("session %s: scan error: %v", s.name, err)
 		}
 	}
@@ -93,8 +94,8 @@ func isConnectionClosed(err error) bool {
 		errors.Is(err, syscall.EPIPE)
 }
 
-// cleanup releases resources on disconnect. Safe to call multiple times —
-// handleDisconnect calls it eagerly, and readLoop defers it as a safety net.
+// cleanup releases resources on disconnect. Safe to call multiple times:
+// readLoop defers it, and paired-session teardown may call it directly.
 func (s *Session) cleanup() {
 	s.cleanupOnce.Do(s.doCleanup)
 }
@@ -108,7 +109,7 @@ func (s *Session) doCleanup() {
 		// Re-queue tasks claimed by this session
 		// Only requeue on unclean disconnect (connection dropped without disconnect command)
 		// Clean disconnect means the client intentionally disconnected and wants to keep tasks claimed
-		if !s.cleanDisconnect {
+		if !s.cleanDisconnect.Load() {
 			count, err := s.broker.store.RequeueByOwner(s.name)
 			if err != nil {
 				log.Printf("session: error requeuing tasks for %s: %v", s.name, err)
@@ -138,7 +139,7 @@ func (s *Session) doCleanup() {
 		// Base agent disconnects should tear down the paired push listener, too.
 		// Close it outside broker.mu so its cleanup can safely mutate broker state.
 		if pushListener != nil {
-			pushListener.cleanDisconnect = true
+			pushListener.cleanDisconnect.Store(true)
 			pushListener.cleanup()
 		}
 

--- a/internal/runtime/listener.go
+++ b/internal/runtime/listener.go
@@ -212,14 +212,6 @@ func pushedMessageToDelivery(msg client.PushedMessage) (Delivery, error) {
 	}, nil
 }
 
-func disconnectClient(c *client.Client) {
-	if c == nil {
-		return
-	}
-	sendDisconnect(c, "listener")
-	c.Close()
-}
-
 func sendDisconnect(c *client.Client, context string) {
 	if c == nil {
 		return
@@ -291,6 +283,10 @@ func releasePushTokenForAgent(socketPath, agent, pushToken string) {
 		return
 	}
 	if !resp.OK {
+		// Best-effort release can race with base disconnect or external release.
+		if resp.Code == protocol.ErrForbidden {
+			return
+		}
 		log.Printf("warning: release push token for %s: %s: %s", agent, resp.Code, resp.Error)
 	}
 }

--- a/internal/runtime/listener_test.go
+++ b/internal/runtime/listener_test.go
@@ -1,10 +1,13 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -237,34 +240,49 @@ func TestBrokerListenerFailedHandshakeDoesNotReleaseActiveListenerToken(t *testi
 		t.Fatal("expected duplicate listener handshake to fail")
 	}
 
-	sender := connectRuntimeClient(t, socketPath)
-	defer sender.Close()
-	resp, err = sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "sender"})
+	assertPushTokenStillAccepted(t, socketPath, active, "alice-push", token, "failed Listen handshake")
+}
+
+func TestBrokerListenerCatchUpFailedHandshakeDoesNotReleaseActiveListenerToken(t *testing.T) {
+	socketPath, cleanup := startRuntimeTestBroker(t, "proj-catchup-duplicate")
+	defer cleanup()
+
+	token, err := pushTokenForAgent(socketPath, "alice")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !resp.OK {
-		t.Fatalf("sender connect failed: %s: %s", resp.Code, resp.Error)
-	}
-	resp, err = sender.Send(protocol.Request{
-		Cmd:     protocol.CmdSend,
-		Name:    "alice",
-		Message: "still active",
+
+	active := connectRuntimeClient(t, socketPath)
+	defer active.Close()
+	resp, err := active.Send(protocol.Request{
+		Cmd:          protocol.CmdConnect,
+		Name:         "alice-push",
+		PushListener: true,
+		PushToken:    token,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !resp.OK {
-		t.Fatalf("send failed: %s: %s", resp.Code, resp.Error)
+		t.Fatalf("active listener connect failed: %s: %s", resp.Code, resp.Error)
 	}
 
-	msg, err := active.Receive()
-	if err != nil {
-		t.Fatal(err)
+	err = NewBrokerListenerFactory().CatchUp(Watch{
+		ProjectID: "proj-catchup-duplicate",
+		AgentName: "alice",
+		Source:    "hook",
+	}, func(d Delivery) error {
+		t.Fatal("duplicate catch-up unexpectedly received delivery")
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected duplicate catch-up handshake to fail")
 	}
-	if !msg.OK {
-		t.Fatalf("active listener receive failed: %s", msg.Error)
+	if !strings.Contains(err.Error(), string(protocol.ErrAlreadyConnected)) {
+		t.Fatalf("CatchUp() error = %v, want %s", err, protocol.ErrAlreadyConnected)
 	}
+
+	assertPushTokenStillAccepted(t, socketPath, active, "alice-push", token, "failed CatchUp handshake")
 }
 
 func TestBrokerListenerCatchUpReadsInboxWithoutBaseConnection(t *testing.T) {
@@ -365,6 +383,41 @@ func TestBrokerListenerCatchUpReleasesPushToken(t *testing.T) {
 	waitForPushTokenRejected(t, socketPath, "alice-push", token)
 }
 
+func TestReleasePushTokenForAgentSuppressesAlreadyRevokedTokenWarning(t *testing.T) {
+	socketPath, cleanup := startRuntimeTestBroker(t, "proj-release-warning")
+	defer cleanup()
+
+	token, err := pushTokenForAgent(socketPath, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	releaser := connectRuntimeClient(t, socketPath)
+	resp, err := releaser.Send(protocol.Request{
+		Cmd:       protocol.CmdPushRelease,
+		Name:      "alice",
+		PushToken: token,
+	})
+	releaser.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("push release failed: %s: %s", resp.Code, resp.Error)
+	}
+
+	var logs bytes.Buffer
+	previousOutput := log.Writer()
+	log.SetOutput(&logs)
+	defer log.SetOutput(previousOutput)
+
+	releasePushTokenForAgent(socketPath, "alice", token)
+
+	if strings.Contains(logs.String(), "warning: release push token") {
+		t.Fatalf("unexpected warning for already-revoked token: %s", logs.String())
+	}
+}
+
 func waitForRuntimePresence(t *testing.T, c *client.Client, name string) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
@@ -414,4 +467,35 @@ func waitForPushTokenRejected(t *testing.T, socketPath, listenerName, token stri
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("timed out waiting for released push token to be rejected for %q", listenerName)
+}
+
+func assertPushTokenStillAccepted(t *testing.T, socketPath string, active *client.Client, listenerName, token, context string) {
+	t.Helper()
+
+	active.Close()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		reconnect := connectRuntimeClient(t, socketPath)
+		resp, err := reconnect.Send(protocol.Request{
+			Cmd:          protocol.CmdConnect,
+			Name:         listenerName,
+			PushListener: true,
+			PushToken:    token,
+		})
+		reconnect.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.OK {
+			return
+		}
+		if resp.Code == protocol.ErrForbidden {
+			t.Fatalf("token was incorrectly released after %s: %s", context, resp.Error)
+		}
+		if resp.Code != protocol.ErrAlreadyConnected {
+			t.Fatalf("reconnect response code = %q, want OK or %q", resp.Code, protocol.ErrAlreadyConnected)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting to reconnect with token preserved after %s", context)
 }


### PR DESCRIPTION
## Summary

- Fix the `Session.cleanDisconnect` data race by storing the flag in an atomic bool.
- Remove the now-unused `disconnectClient` helper.
- Add follow-up coverage for `push.release` validation/double-release, CatchUp handshake failure token preservation, and already-revoked release warning suppression.
- Suppress benign `FORBIDDEN` warnings when best-effort `push.release` finds the token already gone.

Closes #117.

## Verification

- `go test -race ./internal/broker -run TestBroker_PushListenerDisconnectedWhenBaseDisconnects -count=1 -timeout=60s`
- `go test ./internal/runtime -run 'TestReleasePushTokenForAgentSuppressesAlreadyRevokedTokenWarning|TestBrokerListenerCatchUpFailedHandshakeDoesNotReleaseActiveListenerToken' -count=1 -timeout=60s`
- `go test ./internal/broker -run 'TestBroker_PushReleaseRejectsEmptyToken|TestBroker_PushReleaseRejectsDoubleReleaseWithoutMutatingNewReservation' -count=1 -timeout=60s`
- `go test -race ./internal/broker -run 'TestBroker_PushListenerDisconnectedWhenBaseDisconnects|TestBroker_PushRelease' -count=1 -timeout=120s`
- `go test -race ./internal/runtime -count=1 -timeout=120s`
- `go test ./... -count=1 -timeout=120s`
- `go build -o waggle .` (exit 0; sandbox stat-cache warning only)
- `git diff --check`