### PR TITLE
fix: add safe lifecycle purge cleanup

### DIFF
--- a/cmd/adapter_test.go
+++ b/cmd/adapter_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/seungpyoson/waggle/internal/config"
+	"github.com/seungpyoson/waggle/internal/install"
 	rt "github.com/seungpyoson/waggle/internal/runtime"
 )
 
@@ -18,6 +19,7 @@ func TestAdapterBootstrapRegistersWatchAndDerivesTTYAgentName(t *testing.T) {
 	t.Setenv("TTY", "/dev/ttys009")
 	t.Setenv("WAGGLE_PROJECT_ID", "proj-bootstrap")
 	t.Setenv("WAGGLE_ADAPTER_SKIP_RUNTIME_START", "1")
+	installCodexForAdapterCommandTest(t)
 
 	stdout, stderr := executeRootCommandForTest(t, "adapter", "bootstrap", "codex")
 	if stderr != "" {
@@ -77,6 +79,7 @@ func TestAdapterBootstrapReturnsUnreadRecordsAndMarksThemSurfaced(t *testing.T) 
 	t.Setenv("HOME", home)
 	t.Setenv("WAGGLE_PROJECT_ID", "proj-bootstrap")
 	t.Setenv("WAGGLE_ADAPTER_SKIP_RUNTIME_START", "1")
+	installCodexForAdapterCommandTest(t)
 
 	store := openRuntimeStoreForTest(t)
 	now := time.Now().UTC().Round(time.Second)
@@ -123,6 +126,7 @@ func TestAdapterBootstrapMarkdownUsesExplicitOverrides(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("WAGGLE_PROJECT_ID", "proj-default")
 	t.Setenv("WAGGLE_ADAPTER_SKIP_RUNTIME_START", "1")
+	installCodexForAdapterCommandTest(t)
 
 	stdout, stderr := executeRootCommandForTest(
 		t,
@@ -158,6 +162,7 @@ func TestAdapterBootstrapDoesNotLeakFlagStateAcrossExecutions(t *testing.T) {
 	t.Setenv("WAGGLE_PROJECT_ID", "proj-bootstrap")
 	t.Setenv("TTY", "/dev/ttys009")
 	t.Setenv("WAGGLE_ADAPTER_SKIP_RUNTIME_START", "1")
+	installCodexForAdapterCommandTest(t)
 
 	stdout, stderr := executeRootCommandForTest(
 		t,
@@ -205,6 +210,7 @@ func TestAdapterBootstrapMarkdownSilentWhenRuntimeStoreUnavailable(t *testing.T)
 	t.Setenv("HOME", home)
 	t.Setenv("WAGGLE_PROJECT_ID", "proj-runtime-db-unavailable")
 	t.Setenv("WAGGLE_ADAPTER_SKIP_RUNTIME_START", "1")
+	installCodexForAdapterCommandTest(t)
 	blockRuntimeDirForTest(t, home)
 
 	stdout, stderr := executeRootCommandForTest(t, "adapter", "bootstrap", "codex", "--format", "markdown")
@@ -221,6 +227,7 @@ func TestAdapterBootstrapJSONReportsSkippedWhenRuntimeStoreUnavailable(t *testin
 	t.Setenv("HOME", home)
 	t.Setenv("WAGGLE_PROJECT_ID", "proj-runtime-db-unavailable")
 	t.Setenv("WAGGLE_ADAPTER_SKIP_RUNTIME_START", "1")
+	installCodexForAdapterCommandTest(t)
 	blockRuntimeDirForTest(t, home)
 
 	stdout, stderr := executeRootCommandForTest(t, "adapter", "bootstrap", "codex")
@@ -248,6 +255,43 @@ func TestAdapterBootstrapJSONReportsSkippedWhenRuntimeStoreUnavailable(t *testin
 	}
 	if resp.Tool != "codex" {
 		t.Fatalf("tool = %q, want codex", resp.Tool)
+	}
+}
+
+func TestAdapterBootstrapSkipsUninstalledIntegrationWithoutCreatingState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("WAGGLE_PROJECT_ID", "proj-bootstrap")
+	t.Setenv("WAGGLE_ADAPTER_SKIP_RUNTIME_START", "1")
+
+	stdout, stderr := executeRootCommandForTest(t, "adapter", "bootstrap", "codex")
+	if stderr != "" {
+		t.Fatalf("adapter bootstrap stderr = %q, want empty", stderr)
+	}
+
+	var resp struct {
+		OK         bool   `json:"ok"`
+		Skipped    bool   `json:"skipped"`
+		SkipReason string `json:"skip_reason"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &resp); err != nil {
+		t.Fatalf("unmarshal skipped bootstrap response: %v", err)
+	}
+	if resp.OK || !resp.Skipped {
+		t.Fatalf("bootstrap response = %+v, want skipped", resp)
+	}
+	if !strings.Contains(resp.SkipReason, "integration is not installed") {
+		t.Fatalf("skip_reason = %q, want not installed", resp.SkipReason)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".waggle")); !os.IsNotExist(err) {
+		t.Fatalf(".waggle should not be recreated for stale bootstrap, stat err = %v", err)
+	}
+}
+
+func installCodexForAdapterCommandTest(t *testing.T) {
+	t.Helper()
+	if err := install.InstallCodex(); err != nil {
+		t.Fatalf("install Codex integration: %v", err)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -107,7 +107,7 @@ func printErr(code, message string) {
 func isBrokerIndependentCommand(cmd *cobra.Command) bool {
 	for current := cmd; current != nil; current = current.Parent() {
 		switch current.Name() {
-		case "start", "install", "help", "version", "runtime", "adapter", "status":
+		case "start", "install", "uninstall", "help", "version", "runtime", "adapter", "status":
 			return true
 		}
 	}

--- a/cmd/runtime_start.go
+++ b/cmd/runtime_start.go
@@ -136,7 +136,7 @@ var runtimeStopCmd = &cobra.Command{
 			if time.Now().After(deadline) {
 				return fmt.Errorf("runtime still running after SIGTERM")
 			}
-			time.Sleep(config.Defaults.StartupPollInterval)
+			time.Sleep(config.Defaults.ShutdownPollInterval)
 		}
 
 		printJSON(map[string]any{

--- a/cmd/runtime_test.go
+++ b/cmd/runtime_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/seungpyoson/waggle/internal/broker"
 	"github.com/seungpyoson/waggle/internal/config"
 	"github.com/seungpyoson/waggle/internal/install"
 	rt "github.com/seungpyoson/waggle/internal/runtime"
@@ -538,6 +539,41 @@ func TestUninstallPurgeStopsRuntimeBeforeRemovingState(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "runtime-daemon") || !strings.Contains(stdout, "stop if running") {
 		t.Fatalf("uninstall stdout = %q, want runtime stop action", stdout)
+	}
+}
+
+func TestStopRuntimeForUninstallTreatsMissingPIDAfterRunningCheckAsStopped(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	runtimePaths := config.NewPaths("")
+	if err := os.MkdirAll(runtimePaths.RuntimeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := broker.WritePID(runtimePaths.RuntimePID); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.SaveState(runtimePaths, rt.State{
+		PID:       os.Getpid(),
+		Running:   true,
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !rt.IsRunning(runtimePaths) {
+		t.Fatal("test setup expected runtime to report running")
+	}
+
+	originalReadPID := uninstallReadPID
+	t.Cleanup(func() {
+		uninstallReadPID = originalReadPID
+	})
+	uninstallReadPID = func(string) (int, error) {
+		return 0, os.ErrNotExist
+	}
+
+	if err := stopRuntimeForUninstall(); err != nil {
+		t.Fatalf("stopRuntimeForUninstall error = %v, want nil for disappeared pid file", err)
 	}
 }
 

--- a/cmd/runtime_test.go
+++ b/cmd/runtime_test.go
@@ -351,6 +351,43 @@ func TestUninstallAllPurgeDryRunDoesNotMutate(t *testing.T) {
 	}
 }
 
+func TestUninstallPurgeStopsRuntimeBeforeRemovingState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := os.MkdirAll(filepath.Join(home, ".waggle", "runtime"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".waggle", "runtime", "runtime.db"), []byte("state"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	originalStopRuntime := uninstallStopRuntime
+	t.Cleanup(func() {
+		uninstallStopRuntime = originalStopRuntime
+	})
+
+	stoppedBeforeRemove := false
+	uninstallStopRuntime = func() error {
+		if _, err := os.Stat(filepath.Join(home, ".waggle")); err != nil {
+			t.Fatalf("runtime stop ran after state removal: %v", err)
+		}
+		stoppedBeforeRemove = true
+		return nil
+	}
+
+	stdout, stderr := executeRootCommandForTest(t, "uninstall", "--purge")
+	if stderr != "" {
+		t.Fatalf("uninstall stderr = %q, want empty", stderr)
+	}
+	if !stoppedBeforeRemove {
+		t.Fatal("runtime stop was not called before purge")
+	}
+	if !strings.Contains(stdout, "runtime-daemon") || !strings.Contains(stdout, "stop if running") {
+		t.Fatalf("uninstall stdout = %q, want runtime stop action", stdout)
+	}
+}
+
 type commandTestState struct {
 	paths config.Paths
 }

--- a/cmd/runtime_test.go
+++ b/cmd/runtime_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -287,6 +288,66 @@ func TestExecuteRootCommandForTestDoesNotLeakInstallUninstallFlag(t *testing.T) 
 	}
 	if !strings.Contains(stdout, `"Codex integration installed. Restart Codex to activate."`) {
 		t.Fatalf("install stdout = %q, want install message", stdout)
+	}
+}
+
+func TestUninstallAllPurgeRemovesIntegrationsAndState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if stdout, stderr := executeRootCommandForTest(t, "install", "codex"); stderr != "" || !strings.Contains(stdout, `"ok": true`) {
+		t.Fatalf("install codex stdout=%q stderr=%q", stdout, stderr)
+	}
+	if stdout, stderr := executeRootCommandForTest(t, "install", "gemini"); stderr != "" || !strings.Contains(stdout, `"ok": true`) {
+		t.Fatalf("install gemini stdout=%q stderr=%q", stdout, stderr)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".waggle", "runtime"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".waggle", "runtime", "runtime.db"), []byte("state"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr := executeRootCommandForTest(t, "uninstall", "--all", "--purge")
+	if stderr != "" {
+		t.Fatalf("uninstall stderr = %q, want empty", stderr)
+	}
+	for _, want := range []string{"claude-code", "codex", "gemini", "auggie", "augment", "shell-hook", ".waggle"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("uninstall stdout = %q, want action for %q", stdout, want)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex", "skills", "waggle-runtime")); !os.IsNotExist(err) {
+		t.Fatalf("Codex skill should be removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".waggle")); !os.IsNotExist(err) {
+		t.Fatalf(".waggle should be removed, stat err = %v", err)
+	}
+}
+
+func TestUninstallAllPurgeDryRunDoesNotMutate(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if stdout, stderr := executeRootCommandForTest(t, "install", "codex"); stderr != "" || !strings.Contains(stdout, `"ok": true`) {
+		t.Fatalf("install codex stdout=%q stderr=%q", stdout, stderr)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".waggle", "runtime"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr := executeRootCommandForTest(t, "uninstall", "--all", "--purge", "--dry-run")
+	if stderr != "" {
+		t.Fatalf("uninstall dry-run stderr = %q, want empty", stderr)
+	}
+	if !strings.Contains(stdout, `"dry_run": true`) || !strings.Contains(stdout, "would remove state") {
+		t.Fatalf("uninstall dry-run stdout = %q, want dry-run planned actions", stdout)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex", "skills", "waggle-runtime", "SKILL.md")); err != nil {
+		t.Fatalf("Codex skill should remain after dry-run: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".waggle")); err != nil {
+		t.Fatalf(".waggle should remain after dry-run: %v", err)
 	}
 }
 

--- a/cmd/runtime_test.go
+++ b/cmd/runtime_test.go
@@ -353,6 +353,55 @@ func TestUninstallAllPurgeDryRunDoesNotMutate(t *testing.T) {
 	}
 }
 
+func TestRunUninstallAllAttemptsEveryIntegrationBeforeReturningErrors(t *testing.T) {
+	originalTargets := uninstallTargets
+	t.Cleanup(func() {
+		uninstallTargets = originalTargets
+	})
+
+	var called []string
+	uninstallTargets = []struct {
+		name string
+		fn   func() error
+	}{
+		{
+			name: "first",
+			fn: func() error {
+				called = append(called, "first")
+				return fmt.Errorf("first failed")
+			},
+		},
+		{
+			name: "second",
+			fn: func() error {
+				called = append(called, "second")
+				return nil
+			},
+		},
+		{
+			name: "third",
+			fn: func() error {
+				called = append(called, "third")
+				return fmt.Errorf("third failed")
+			},
+		},
+	}
+
+	actions, err := runUninstall(t.TempDir(), true, false, false)
+	if err == nil {
+		t.Fatal("runUninstall error = nil, want joined uninstall errors")
+	}
+	if !strings.Contains(err.Error(), "uninstall first") || !strings.Contains(err.Error(), "uninstall third") {
+		t.Fatalf("runUninstall error = %v, want both uninstall failures", err)
+	}
+	if strings.Join(called, ",") != "first,second,third" {
+		t.Fatalf("called targets = %v, want all targets attempted", called)
+	}
+	if len(actions) != 3 {
+		t.Fatalf("actions len = %d, want 3", len(actions))
+	}
+}
+
 func TestUninstallPurgeStopsRuntimeBeforeRemovingState(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/cmd/runtime_test.go
+++ b/cmd/runtime_test.go
@@ -3,9 +3,11 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -385,6 +387,18 @@ func TestUninstallPurgeStopsRuntimeBeforeRemovingState(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "runtime-daemon") || !strings.Contains(stdout, "stop if running") {
 		t.Fatalf("uninstall stdout = %q, want runtime stop action", stdout)
+	}
+}
+
+func TestIsAlreadyExitedProcessError(t *testing.T) {
+	if !isAlreadyExitedProcessError(os.ErrProcessDone) {
+		t.Fatal("os.ErrProcessDone should be treated as already exited")
+	}
+	if !isAlreadyExitedProcessError(fmt.Errorf("wrapped: %w", syscall.ESRCH)) {
+		t.Fatal("wrapped ESRCH should be treated as already exited")
+	}
+	if isAlreadyExitedProcessError(syscall.EPERM) {
+		t.Fatal("EPERM should not be treated as already exited")
 	}
 }
 

--- a/cmd/runtime_test.go
+++ b/cmd/runtime_test.go
@@ -474,9 +474,12 @@ func TestUninstallAllPurgeReportsActionsAfterIntegrationErrors(t *testing.T) {
 		return nil
 	}
 
-	stdout, _, err := executeRootCommandForTestWithError(t, "uninstall", "--all", "--purge")
+	stdout, stderr, err := executeRootCommandForTestWithError(t, "uninstall", "--all", "--purge")
 	if err == nil {
 		t.Fatal("uninstall error = nil, want integration failure")
+	}
+	if stderr != "" {
+		t.Fatalf("uninstall stderr = %q, want empty", stderr)
 	}
 
 	var resp struct {

--- a/cmd/runtime_test.go
+++ b/cmd/runtime_test.go
@@ -445,6 +445,60 @@ func TestRunUninstallAllPurgeRemovesStateAfterIntegrationErrors(t *testing.T) {
 	}
 }
 
+func TestUninstallAllPurgeReportsActionsAfterIntegrationErrors(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, ".waggle", "runtime"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	originalTargets := uninstallTargets
+	originalStopRuntime := uninstallStopRuntime
+	t.Cleanup(func() {
+		uninstallTargets = originalTargets
+		uninstallStopRuntime = originalStopRuntime
+	})
+
+	uninstallTargets = []struct {
+		name string
+		fn   func() error
+	}{
+		{
+			name: "failing",
+			fn: func() error {
+				return fmt.Errorf("integration failed")
+			},
+		},
+	}
+	uninstallStopRuntime = func() error {
+		return nil
+	}
+
+	stdout, _, err := executeRootCommandForTestWithError(t, "uninstall", "--all", "--purge")
+	if err == nil {
+		t.Fatal("uninstall error = nil, want integration failure")
+	}
+
+	var resp struct {
+		OK      bool             `json:"ok"`
+		Code    string           `json:"code"`
+		Error   string           `json:"error"`
+		Actions []map[string]any `json:"actions"`
+	}
+	if unmarshalErr := json.Unmarshal([]byte(stdout), &resp); unmarshalErr != nil {
+		t.Fatalf("unmarshal uninstall response: %v\nstdout=%s", unmarshalErr, stdout)
+	}
+	if resp.OK || resp.Code != "UNINSTALL_ERROR" || !strings.Contains(resp.Error, "uninstall failing") {
+		t.Fatalf("uninstall response = %+v, want structured uninstall error", resp)
+	}
+	if len(resp.Actions) != 3 {
+		t.Fatalf("actions len = %d, want integration, runtime stop, and state removal", len(resp.Actions))
+	}
+	if _, statErr := os.Stat(filepath.Join(home, ".waggle")); !os.IsNotExist(statErr) {
+		t.Fatalf(".waggle stat error = %v, want removed", statErr)
+	}
+}
+
 func TestUninstallPurgeStopsRuntimeBeforeRemovingState(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -524,7 +578,16 @@ func resetFlagToDefault(flag *pflag.Flag) {
 
 func executeRootCommandForTest(t *testing.T, args ...string) (string, string) {
 	t.Helper()
+	stdout, stderr, err := executeRootCommandForTestWithError(t, args...)
+	if err != nil {
+		t.Fatalf("execute %v: %v", args, err)
+	}
 
+	return stdout, stderr
+}
+
+func executeRootCommandForTestWithError(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
 	originalState := captureCommandTestState()
 	defer func() {
 		originalState.restore()
@@ -542,11 +605,8 @@ func executeRootCommandForTest(t *testing.T, args ...string) (string, string) {
 	rootCmd.SetErr(&stderr)
 	rootCmd.SetArgs(args)
 
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("execute %v: %v", args, err)
-	}
-
-	return stdout.String(), stderr.String()
+	err := rootCmd.Execute()
+	return stdout.String(), stderr.String(), err
 }
 
 func openRuntimeStoreForTest(t *testing.T) *rt.Store {

--- a/cmd/runtime_test.go
+++ b/cmd/runtime_test.go
@@ -402,6 +402,49 @@ func TestRunUninstallAllAttemptsEveryIntegrationBeforeReturningErrors(t *testing
 	}
 }
 
+func TestRunUninstallAllPurgeRemovesStateAfterIntegrationErrors(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".waggle", "runtime"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	originalTargets := uninstallTargets
+	originalStopRuntime := uninstallStopRuntime
+	t.Cleanup(func() {
+		uninstallTargets = originalTargets
+		uninstallStopRuntime = originalStopRuntime
+	})
+
+	uninstallTargets = []struct {
+		name string
+		fn   func() error
+	}{
+		{
+			name: "failing",
+			fn: func() error {
+				return fmt.Errorf("integration failed")
+			},
+		},
+	}
+	uninstallStopRuntime = func() error {
+		return nil
+	}
+
+	actions, err := runUninstall(home, true, true, false)
+	if err == nil {
+		t.Fatal("runUninstall error = nil, want integration error")
+	}
+	if !strings.Contains(err.Error(), "uninstall failing") {
+		t.Fatalf("runUninstall error = %v, want uninstall failure", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(home, ".waggle")); !os.IsNotExist(statErr) {
+		t.Fatalf(".waggle stat error = %v, want removed", statErr)
+	}
+	if len(actions) != 3 {
+		t.Fatalf("actions len = %d, want integration, runtime stop, and state removal", len(actions))
+	}
+}
+
 func TestUninstallPurgeStopsRuntimeBeforeRemovingState(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -72,6 +72,7 @@ var uninstallCmd = &cobra.Command{
 
 func runUninstall(home string, all, purge, dryRun bool) ([]map[string]any, error) {
 	var actions []map[string]any
+	var topErr error
 	record := func(target, action string) {
 		actions = append(actions, map[string]any{"target": target, "action": action})
 	}
@@ -87,7 +88,7 @@ func runUninstall(home string, all, purge, dryRun bool) ([]map[string]any, error
 			}
 		}
 		if err := errors.Join(uninstallErrs...); err != nil {
-			return actions, err
+			topErr = err
 		}
 	}
 
@@ -95,7 +96,7 @@ func runUninstall(home string, all, purge, dryRun bool) ([]map[string]any, error
 		record("runtime-daemon", plannedAction(dryRun, "stop if running"))
 		if !dryRun {
 			if err := uninstallStopRuntime(); err != nil {
-				return actions, err
+				return actions, errors.Join(topErr, err)
 			}
 		}
 
@@ -103,12 +104,12 @@ func runUninstall(home string, all, purge, dryRun bool) ([]map[string]any, error
 		record(waggleDir, plannedAction(dryRun, "remove state"))
 		if !dryRun {
 			if err := removeOwnedTree(waggleDir, home); err != nil {
-				return actions, err
+				topErr = errors.Join(topErr, err)
 			}
 		}
 	}
 
-	return actions, nil
+	return actions, topErr
 }
 
 func plannedAction(dryRun bool, action string) string {

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -43,8 +43,9 @@ func init() {
 }
 
 var uninstallCmd = &cobra.Command{
-	Use:   "uninstall",
-	Short: "Remove waggle integrations and optionally purge local state",
+	Use:          "uninstall",
+	Short:        "Remove waggle integrations and optionally purge local state",
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 0 {
 			return fmt.Errorf("uninstall accepts flags only")
@@ -58,14 +59,18 @@ var uninstallCmd = &cobra.Command{
 			return fmt.Errorf("getting home dir: %w", err)
 		}
 		actions, err := runUninstall(home, uninstallAll, uninstallPurge, uninstallDryRun)
-		if err != nil {
-			return err
-		}
-		printJSON(map[string]any{
-			"ok":      true,
+		result := map[string]any{
+			"ok":      err == nil,
 			"dry_run": uninstallDryRun,
 			"actions": actions,
-		})
+		}
+		if err != nil {
+			result["code"] = "UNINSTALL_ERROR"
+			result["error"] = err.Error()
+			printJSON(result)
+			return err
+		}
+		printJSON(result)
 		return nil
 	},
 }

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -147,6 +148,9 @@ func stopRuntimeForUninstall() error {
 		return fmt.Errorf("find runtime process: %w", err)
 	}
 	if err := process.Signal(syscall.SIGTERM); err != nil {
+		if isAlreadyExitedProcessError(err) {
+			return nil
+		}
 		return fmt.Errorf("signal runtime process: %w", err)
 	}
 
@@ -158,4 +162,8 @@ func stopRuntimeForUninstall() error {
 		time.Sleep(config.Defaults.StartupPollInterval)
 	}
 	return nil
+}
+
+func isAlreadyExitedProcessError(err error) bool {
+	return errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH)
 }

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -43,9 +43,10 @@ func init() {
 }
 
 var uninstallCmd = &cobra.Command{
-	Use:          "uninstall",
-	Short:        "Remove waggle integrations and optionally purge local state",
-	SilenceUsage: true,
+	Use:           "uninstall",
+	Short:         "Remove waggle integrations and optionally purge local state",
+	SilenceUsage:  true,
+	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 0 {
 			return fmt.Errorf("uninstall accepts flags only")

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -5,8 +5,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
+	"time"
 
+	"github.com/seungpyoson/waggle/internal/broker"
+	"github.com/seungpyoson/waggle/internal/config"
 	"github.com/seungpyoson/waggle/internal/install"
+	rt "github.com/seungpyoson/waggle/internal/runtime"
 	"github.com/spf13/cobra"
 )
 
@@ -14,6 +19,8 @@ var (
 	uninstallAll    bool
 	uninstallPurge  bool
 	uninstallDryRun bool
+
+	uninstallStopRuntime = stopRuntimeForUninstall
 )
 
 func init() {
@@ -79,6 +86,13 @@ func runUninstall(home string, all, purge, dryRun bool) ([]map[string]any, error
 	}
 
 	if purge {
+		record("runtime-daemon", plannedAction(dryRun, "stop if running"))
+		if !dryRun {
+			if err := uninstallStopRuntime(); err != nil {
+				return actions, err
+			}
+		}
+
 		waggleDir := filepath.Join(home, ".waggle")
 		record(waggleDir, plannedAction(dryRun, "remove state"))
 		if !dryRun {
@@ -113,4 +127,35 @@ func removeOwnedTree(path, root string) error {
 		return fmt.Errorf("lstat %s: %w", path, err)
 	}
 	return os.RemoveAll(path)
+}
+
+func stopRuntimeForUninstall() error {
+	runtimePaths, err := resolveRuntimePaths()
+	if err != nil {
+		return err
+	}
+	if !rt.IsRunning(runtimePaths) {
+		return nil
+	}
+
+	pid, err := broker.ReadPID(runtimePaths.RuntimePID)
+	if err != nil {
+		return fmt.Errorf("read runtime pid: %w", err)
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("find runtime process: %w", err)
+	}
+	if err := process.Signal(syscall.SIGTERM); err != nil {
+		return fmt.Errorf("signal runtime process: %w", err)
+	}
+
+	deadline := time.Now().Add(config.Defaults.ShutdownTimeout)
+	for rt.IsRunning(runtimePaths) {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("runtime still running after SIGTERM")
+		}
+		time.Sleep(config.Defaults.StartupPollInterval)
+	}
+	return nil
 }

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -22,6 +22,17 @@ var (
 	uninstallDryRun bool
 
 	uninstallStopRuntime = stopRuntimeForUninstall
+	uninstallTargets     = []struct {
+		name string
+		fn   func() error
+	}{
+		{"claude-code", install.UninstallClaudeCode},
+		{"codex", install.UninstallCodex},
+		{"gemini", install.UninstallGemini},
+		{"auggie", install.UninstallAuggie},
+		{"augment", install.UninstallAugment},
+		{"shell-hook", install.UninstallShellHook},
+	}
 )
 
 func init() {
@@ -40,7 +51,7 @@ var uninstallCmd = &cobra.Command{
 		}
 		if !uninstallAll && !uninstallPurge {
 			printErr("INVALID_REQUEST", "pass --all and/or --purge")
-			return nil
+			return fmt.Errorf("pass --all and/or --purge")
 		}
 		home, err := os.UserHomeDir()
 		if err != nil {
@@ -66,23 +77,17 @@ func runUninstall(home string, all, purge, dryRun bool) ([]map[string]any, error
 	}
 
 	if all {
-		for _, item := range []struct {
-			name string
-			fn   func() error
-		}{
-			{"claude-code", install.UninstallClaudeCode},
-			{"codex", install.UninstallCodex},
-			{"gemini", install.UninstallGemini},
-			{"auggie", install.UninstallAuggie},
-			{"augment", install.UninstallAugment},
-			{"shell-hook", install.UninstallShellHook},
-		} {
+		var uninstallErrs []error
+		for _, item := range uninstallTargets {
 			record(item.name, plannedAction(dryRun, "remove integration"))
 			if !dryRun {
 				if err := item.fn(); err != nil {
-					return actions, fmt.Errorf("uninstall %s: %w", item.name, err)
+					uninstallErrs = append(uninstallErrs, fmt.Errorf("uninstall %s: %w", item.name, err))
 				}
 			}
+		}
+		if err := errors.Join(uninstallErrs...); err != nil {
+			return actions, err
 		}
 	}
 
@@ -94,7 +99,7 @@ func runUninstall(home string, all, purge, dryRun bool) ([]map[string]any, error
 			}
 		}
 
-		waggleDir := filepath.Join(home, ".waggle")
+		waggleDir := filepath.Join(home, config.Defaults.DirName)
 		record(waggleDir, plannedAction(dryRun, "remove state"))
 		if !dryRun {
 			if err := removeOwnedTree(waggleDir, home); err != nil {

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -159,7 +159,7 @@ func stopRuntimeForUninstall() error {
 		if time.Now().After(deadline) {
 			return fmt.Errorf("runtime still running after SIGTERM")
 		}
-		time.Sleep(config.Defaults.StartupPollInterval)
+		time.Sleep(config.Defaults.ShutdownPollInterval)
 	}
 	return nil
 }

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -1,0 +1,116 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/seungpyoson/waggle/internal/install"
+	"github.com/spf13/cobra"
+)
+
+var (
+	uninstallAll    bool
+	uninstallPurge  bool
+	uninstallDryRun bool
+)
+
+func init() {
+	uninstallCmd.Flags().BoolVar(&uninstallAll, "all", false, "Remove all supported integrations")
+	uninstallCmd.Flags().BoolVar(&uninstallPurge, "purge", false, "Remove Waggle runtime and broker state")
+	uninstallCmd.Flags().BoolVar(&uninstallDryRun, "dry-run", false, "Report planned removals without changing files")
+	rootCmd.AddCommand(uninstallCmd)
+}
+
+var uninstallCmd = &cobra.Command{
+	Use:   "uninstall",
+	Short: "Remove waggle integrations and optionally purge local state",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 {
+			return fmt.Errorf("uninstall accepts flags only")
+		}
+		if !uninstallAll && !uninstallPurge {
+			printErr("INVALID_REQUEST", "pass --all and/or --purge")
+			return nil
+		}
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("getting home dir: %w", err)
+		}
+		actions, err := runUninstall(home, uninstallAll, uninstallPurge, uninstallDryRun)
+		if err != nil {
+			return err
+		}
+		printJSON(map[string]any{
+			"ok":      true,
+			"dry_run": uninstallDryRun,
+			"actions": actions,
+		})
+		return nil
+	},
+}
+
+func runUninstall(home string, all, purge, dryRun bool) ([]map[string]any, error) {
+	var actions []map[string]any
+	record := func(target, action string) {
+		actions = append(actions, map[string]any{"target": target, "action": action})
+	}
+
+	if all {
+		for _, item := range []struct {
+			name string
+			fn   func() error
+		}{
+			{"claude-code", install.UninstallClaudeCode},
+			{"codex", install.UninstallCodex},
+			{"gemini", install.UninstallGemini},
+			{"auggie", install.UninstallAuggie},
+			{"augment", install.UninstallAugment},
+			{"shell-hook", install.UninstallShellHook},
+		} {
+			record(item.name, plannedAction(dryRun, "remove integration"))
+			if !dryRun {
+				if err := item.fn(); err != nil {
+					return actions, fmt.Errorf("uninstall %s: %w", item.name, err)
+				}
+			}
+		}
+	}
+
+	if purge {
+		waggleDir := filepath.Join(home, ".waggle")
+		record(waggleDir, plannedAction(dryRun, "remove state"))
+		if !dryRun {
+			if err := removeOwnedTree(waggleDir, home); err != nil {
+				return actions, err
+			}
+		}
+	}
+
+	return actions, nil
+}
+
+func plannedAction(dryRun bool, action string) string {
+	if dryRun {
+		return "would " + action
+	}
+	return action
+}
+
+func removeOwnedTree(path, root string) error {
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == "." || rel == ".." || rel == "" || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("refusing to remove path outside home: %s", path)
+	}
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to remove symlink: %s", path)
+		}
+	} else if os.IsNotExist(err) {
+		return nil
+	} else {
+		return fmt.Errorf("lstat %s: %w", path, err)
+	}
+	return os.RemoveAll(path)
+}

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -22,6 +22,7 @@ var (
 	uninstallDryRun bool
 
 	uninstallStopRuntime = stopRuntimeForUninstall
+	uninstallReadPID     = broker.ReadPID
 	uninstallTargets     = []struct {
 		name string
 		fn   func() error
@@ -151,8 +152,11 @@ func stopRuntimeForUninstall() error {
 		return nil
 	}
 
-	pid, err := broker.ReadPID(runtimePaths.RuntimePID)
+	pid, err := uninstallReadPID(runtimePaths.RuntimePID)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return fmt.Errorf("read runtime pid: %w", err)
 	}
 	process, err := os.FindProcess(pid)

--- a/internal/adapter/bootstrap.go
+++ b/internal/adapter/bootstrap.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/seungpyoson/waggle/internal/broker"
 	"github.com/seungpyoson/waggle/internal/config"
+	"github.com/seungpyoson/waggle/internal/install"
 	rt "github.com/seungpyoson/waggle/internal/runtime"
 )
 
@@ -39,6 +40,10 @@ func Bootstrap(input BootstrapInput) (BootstrapResult, error) {
 	tool := sanitizeToken(input.Tool)
 	if tool == "" {
 		return BootstrapResult{}, fmt.Errorf("tool required")
+	}
+
+	if skipReason := uninstalledToolSkipReason(tool); skipReason != "" {
+		return BootstrapResult{Tool: tool, Skipped: true, SkipReason: skipReason}, nil
 	}
 
 	runtimePaths, err := resolveRuntimePaths()
@@ -113,6 +118,18 @@ func Bootstrap(input BootstrapInput) (BootstrapResult, error) {
 
 	result.Records = records
 	return result, nil
+}
+
+func uninstalledToolSkipReason(tool string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Sprintf("cannot determine adapter install state: %v", err)
+	}
+	_, state, known := install.CheckTool(home, tool)
+	if known && state == install.StateNotInstalled {
+		return fmt.Sprintf("%s integration is not installed", tool)
+	}
+	return ""
 }
 
 func skipRuntimeStore(result BootstrapResult, err error) BootstrapResult {

--- a/internal/adapter/bootstrap.go
+++ b/internal/adapter/bootstrap.go
@@ -123,7 +123,7 @@ func Bootstrap(input BootstrapInput) (BootstrapResult, error) {
 func uninstalledToolSkipReason(tool string) string {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return fmt.Sprintf("cannot determine adapter install state: %v", err)
+		return ""
 	}
 	_, state, known := install.CheckTool(home, tool)
 	if known && state == install.StateNotInstalled {

--- a/internal/adapter/bootstrap.go
+++ b/internal/adapter/bootstrap.go
@@ -129,6 +129,8 @@ func uninstalledToolSkipReason(tool string) string {
 	if known && state == install.StateNotInstalled {
 		return fmt.Sprintf("%s integration is not installed", tool)
 	}
+	// StateBroken still enters bootstrap so existing sessions can surface
+	// diagnostics and receive recovery messages instead of silently going dark.
 	return ""
 }
 

--- a/internal/adapter/bootstrap.go
+++ b/internal/adapter/bootstrap.go
@@ -123,6 +123,7 @@ func Bootstrap(input BootstrapInput) (BootstrapResult, error) {
 func uninstalledToolSkipReason(tool string) string {
 	home, err := os.UserHomeDir()
 	if err != nil {
+		log.Printf("warning: cannot determine adapter install state: %v", err)
 		return ""
 	}
 	_, state, known := install.CheckTool(home, tool)

--- a/internal/adapter/bootstrap_test.go
+++ b/internal/adapter/bootstrap_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/seungpyoson/waggle/internal/config"
+	"github.com/seungpyoson/waggle/internal/install"
 	rt "github.com/seungpyoson/waggle/internal/runtime"
 )
 
@@ -81,6 +82,7 @@ func TestAdapterBootstrap_RoundTrip(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("WAGGLE_PROJECT_ID", "proj-roundtrip")
 	t.Setenv("WAGGLE_ADAPTER_SKIP_RUNTIME_START", "1")
+	installCodexForBootstrapTest(t)
 
 	// Open store for test manipulation
 	store, err := rt.OpenStore(config.NewPaths(""))
@@ -153,6 +155,7 @@ func TestAdapterBootstrap_SkipsGracefullyWithoutProjectContext(t *testing.T) {
 	t.Setenv("WAGGLE_PROJECT_ID", "")
 	t.Setenv("WAGGLE_ROOT", "")
 	t.Setenv("WAGGLE_ADAPTER_SKIP_RUNTIME_START", "1")
+	installCodexForBootstrapTest(t)
 
 	// Change to a non-git directory so project resolution fails.
 	origDir, _ := os.Getwd()
@@ -183,6 +186,7 @@ func TestAdapterBootstrap_SkipsGracefullyWhenRuntimeStoreUnavailable(t *testing.
 	t.Setenv("HOME", home)
 	t.Setenv("WAGGLE_PROJECT_ID", "proj-runtime-db-unavailable")
 	t.Setenv("WAGGLE_ADAPTER_SKIP_RUNTIME_START", "1")
+	installCodexForBootstrapTest(t)
 
 	waggleDir := filepath.Join(home, ".waggle")
 	if err := os.MkdirAll(waggleDir, 0o755); err != nil {
@@ -207,6 +211,27 @@ func TestAdapterBootstrap_SkipsGracefullyWhenRuntimeStoreUnavailable(t *testing.
 	}
 	if result.RuntimeError == "" {
 		t.Fatalf("Bootstrap should expose runtime error for diagnostics")
+	}
+}
+
+func TestAdapterBootstrapSkipsWhenIntegrationNotInstalledWithoutCreatingState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("WAGGLE_PROJECT_ID", "proj-uninstalled")
+	t.Setenv("WAGGLE_ADAPTER_SKIP_RUNTIME_START", "1")
+
+	result, err := Bootstrap(BootstrapInput{Tool: "codex"})
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if !result.Skipped {
+		t.Fatalf("Bootstrap skipped = false, want true for uninstalled integration")
+	}
+	if !strings.Contains(result.SkipReason, "integration is not installed") {
+		t.Fatalf("skip reason = %q, want not installed", result.SkipReason)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".waggle")); !os.IsNotExist(err) {
+		t.Fatalf(".waggle should not be recreated for stale bootstrap, stat err = %v", err)
 	}
 }
 
@@ -297,6 +322,7 @@ func TestBootstrap_LogsWhenSessionMappingWriteFails(t *testing.T) {
 	t.Setenv("WAGGLE_PROJECT_ID", "proj-log-warning")
 	t.Setenv("WAGGLE_ADAPTER_SKIP_RUNTIME_START", "1")
 	t.Setenv("WAGGLE_AGENT_PPID", "4242")
+	installCodexForBootstrapTest(t)
 
 	runtimeDir := config.NewPaths("").RuntimeDir
 	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
@@ -331,6 +357,13 @@ func TestBootstrap_LogsWhenSessionMappingWriteFails(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), "push delivery degraded") {
 		t.Fatalf("expected push delivery degraded detail, got %q", buf.String())
+	}
+}
+
+func installCodexForBootstrapTest(t *testing.T) {
+	t.Helper()
+	if err := install.InstallCodex(); err != nil {
+		t.Fatalf("install Codex integration: %v", err)
 	}
 }
 

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -256,9 +256,10 @@ func (b *Broker) Serve() error {
 
 // Shutdown gracefully shuts down the broker
 func (b *Broker) Shutdown() error {
-	// Kill spawned agents before stopping
+	// Broker shutdown forgets spawn registrations but must not kill coding-agent
+	// sessions by default. Those processes are owned by the host/user.
 	if b.spawnMgr != nil {
-		b.spawnMgr.StopAll()
+		b.spawnMgr.ForgetAll()
 	}
 
 	close(b.stopCh)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,6 +88,7 @@ var Defaults = struct {
 	LeaseCheckPeriod                      time.Duration
 	IdleCheckInterval                     time.Duration
 	StartupPollInterval                   time.Duration
+	ShutdownPollInterval                  time.Duration
 	StartupTimeout                        time.Duration
 	DisconnectTimeout                     time.Duration
 	CatchUpMaxRetries                     int
@@ -155,6 +156,7 @@ var Defaults = struct {
 	LeaseCheckPeriod:                      30 * time.Second,
 	IdleCheckInterval:                     1 * time.Second,
 	StartupPollInterval:                   100 * time.Millisecond,
+	ShutdownPollInterval:                  100 * time.Millisecond,
 	StartupTimeout:                        2 * time.Second,
 	DisconnectTimeout:                     2 * time.Second,
 	CatchUpMaxRetries:                     3,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -417,6 +417,12 @@ func TestDefaults_StartupPollInterval(t *testing.T) {
 	}
 }
 
+func TestDefaults_ShutdownPollInterval(t *testing.T) {
+	if Defaults.ShutdownPollInterval != 100*time.Millisecond {
+		t.Fatalf("ShutdownPollInterval = %v, want 100ms", Defaults.ShutdownPollInterval)
+	}
+}
+
 func TestDefaults_StartupTimeout(t *testing.T) {
 	if Defaults.StartupTimeout != 2*time.Second {
 		t.Fatalf("StartupTimeout = %v, want 2s", Defaults.StartupTimeout)

--- a/internal/install/health.go
+++ b/internal/install/health.go
@@ -455,6 +455,28 @@ func CheckAugment(homeDir string) ([]HealthIssue, AdapterState) {
 	return nil, StateHealthy
 }
 
+func CheckTool(homeDir, tool string) ([]HealthIssue, AdapterState, bool) {
+	switch tool {
+	case "claude-code":
+		issues, state := CheckClaudeCode(homeDir)
+		return issues, state, true
+	case "codex":
+		issues, state := CheckCodex(homeDir)
+		return issues, state, true
+	case "gemini":
+		issues, state := CheckGemini(homeDir)
+		return issues, state, true
+	case "auggie":
+		issues, state := CheckAuggie(homeDir)
+		return issues, state, true
+	case "augment":
+		issues, state := CheckAugment(homeDir)
+		return issues, state, true
+	default:
+		return nil, "", false
+	}
+}
+
 type embeddedFileReader interface {
 	ReadFile(name string) ([]byte, error)
 }

--- a/internal/spawn/manager.go
+++ b/internal/spawn/manager.go
@@ -153,6 +153,12 @@ func (m *Manager) StopAll() error {
 	return nil
 }
 
+func (m *Manager) ForgetAll() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.agents = make(map[string]*Agent)
+}
+
 // isPIDAlive checks if a PID is still running
 func isPIDAlive(pid int) bool {
 	if pid <= 0 {
@@ -163,4 +169,3 @@ func isPIDAlive(pid int) bool {
 	err := syscall.Kill(pid, syscall.Signal(0))
 	return err == nil
 }
-

--- a/internal/spawn/manager.go
+++ b/internal/spawn/manager.go
@@ -153,6 +153,7 @@ func (m *Manager) StopAll() error {
 	return nil
 }
 
+// ForgetAll clears all agent registrations without stopping underlying processes.
 func (m *Manager) ForgetAll() {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/spawn/manager_test.go
+++ b/internal/spawn/manager_test.go
@@ -200,6 +200,32 @@ func TestManager_StopAllWithDeadPID(t *testing.T) {
 	}
 }
 
+func TestManager_ForgetAllDoesNotSignalProcesses(t *testing.T) {
+	m := NewManager()
+
+	cmd := exec.Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		cmd.Process.Kill()
+		cmd.Wait()
+	})
+
+	if err := m.Add("worker-1", "claude", cmd.Process.Pid); err != nil {
+		t.Fatalf("Add() error = %v, want nil", err)
+	}
+
+	m.ForgetAll()
+
+	if agents := m.List(); len(agents) != 0 {
+		t.Fatalf("List() len = %d, want 0 after ForgetAll", len(agents))
+	}
+	if err := cmd.Process.Signal(syscall.Signal(0)); err != nil {
+		t.Fatalf("process should still be alive after ForgetAll: %v", err)
+	}
+}
+
 // TestManager_ListEmpty — empty manager returns empty slice (not nil)
 func TestManager_ListEmpty(t *testing.T) {
 	m := NewManager()
@@ -253,4 +279,3 @@ func TestManager_UpdatePID_NotFound(t *testing.T) {
 		t.Fatal("expected error for nonexistent agent")
 	}
 }
-


### PR DESCRIPTION
## Summary

Closes #125.

Phase-one lifecycle cleanup only:

- Broker shutdown now forgets spawned-process registrations instead of killing host-owned coding-agent sessions.
- Adds `waggle uninstall --all --purge` with `--dry-run` for current active adapter integrations, shell hook state, and current-home `~/.waggle` runtime/broker state.
- Stops the machine-local Waggle runtime daemon before purging `~/.waggle`, so in-memory watches cannot immediately recreate purged state.
- Makes `uninstall` broker-independent so cleanup does not auto-start a broker.
- Makes stale `waggle adapter bootstrap <tool>` calls no-op when the integration is no longer installed, preventing old prompt/history snippets from recreating `~/.waggle` after purge.
- Keeps partial-failure structured output parseable and suppresses duplicate Cobra error text.
- Treats already-vanished runtime PID files during purge as already stopped, so a natural daemon exit between runtime checks does not abort state removal.

## Related, Not Closed

Related to #112 and #106, but does not close either. Those are broader follow-up umbrellas and should be decomposed into additional narrow issues/PRs.

## Verification

- `go test ./cmd -run 'TestStopRuntimeForUninstallTreatsMissingPIDAfterRunningCheckAsStopped|TestUninstall|TestRunUninstall|TestIsAlready' -count=1`
- `go test ./cmd -run 'TestUninstallAllPurgeReportsActionsAfterIntegrationErrors' -count=1`
- `go test ./cmd ./internal/adapter ./internal/broker ./internal/spawn ./internal/install ./internal/config -count=1`
- `git diff --check`

## Explicit Non-Goals

This PR does not implement complete artifact inventory/classification, legacy `.waggle*` scans, binary inventory, project-local `.waggle` scans, automatic watch expiry, task TTL policy, full daemon/session garbage collection, or `waggle clean`.