### PR TITLE
fix: auto-install detected adapters on startup

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -15,85 +15,104 @@ func init() {
 }
 
 var installCmd = &cobra.Command{
-	Use:   "install <platform>",
+	Use:   "install [platform]",
 	Short: "Install waggle integration for a platform",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		platform := args[0]
-		switch platform {
-		case "claude-code":
+		if len(args) == 0 {
 			if installUninstall {
-				if err := install.UninstallClaudeCode(); err != nil {
-					printErr("INSTALL_ERROR", err.Error())
-					return nil
-				}
-				printJSON(map[string]any{"ok": true, "message": "Claude Code integration removed"})
-			} else {
-				if err := install.InstallClaudeCode(); err != nil {
-					printErr("INSTALL_ERROR", err.Error())
-					return nil
-				}
-				printJSON(map[string]any{"ok": true, "message": "Claude Code integration installed. Restart Claude Code to activate."})
+				printErr("INVALID_REQUEST", "install --uninstall requires a platform")
+				return nil
 			}
-		case "codex":
-			if installUninstall {
-				if err := install.UninstallCodex(); err != nil {
-					printErr("INSTALL_ERROR", err.Error())
+			for _, platform := range []string{"claude-code", "codex", "gemini", "auggie", "augment"} {
+				if !installPlatform(platform) {
 					return nil
 				}
-				printJSON(map[string]any{"ok": true, "message": "Codex integration removed"})
-			} else {
-				if err := install.InstallCodex(); err != nil {
-					printErr("INSTALL_ERROR", err.Error())
-					return nil
-				}
-				printJSON(map[string]any{"ok": true, "message": "Codex integration installed. Restart Codex to activate."})
 			}
-		case "gemini":
-			if installUninstall {
-				if err := install.UninstallGemini(); err != nil {
-					printErr("INSTALL_ERROR", err.Error())
-					return nil
-				}
-				printJSON(map[string]any{"ok": true, "message": "Gemini integration removed"})
-			} else {
-				if err := install.InstallGemini(); err != nil {
-					printErr("INSTALL_ERROR", err.Error())
-					return nil
-				}
-				printJSON(map[string]any{"ok": true, "message": "Gemini integration installed. Restart Gemini to activate."})
-			}
-		case "auggie":
-			if installUninstall {
-				if err := install.UninstallAuggie(); err != nil {
-					printErr("INSTALL_ERROR", err.Error())
-					return nil
-				}
-				printJSON(map[string]any{"ok": true, "message": "Auggie integration removed"})
-			} else {
-				if err := install.InstallAuggie(); err != nil {
-					printErr("INSTALL_ERROR", err.Error())
-					return nil
-				}
-				printJSON(map[string]any{"ok": true, "message": "Auggie integration installed. Restart Auggie to activate."})
-			}
-		case "augment":
-			if installUninstall {
-				if err := install.UninstallAugment(); err != nil {
-					printErr("INSTALL_ERROR", err.Error())
-					return nil
-				}
-				printJSON(map[string]any{"ok": true, "message": "Augment integration removed"})
-			} else {
-				if err := install.InstallAugment(); err != nil {
-					printErr("INSTALL_ERROR", err.Error())
-					return nil
-				}
-				printJSON(map[string]any{"ok": true, "message": "Augment integration installed. Restart Augment to activate."})
-			}
-		default:
-			printErr("INVALID_REQUEST", fmt.Sprintf("unknown platform: %s (supported: claude-code, codex, gemini, auggie, augment)", platform))
+			return nil
 		}
+
+		platform := args[0]
+		installPlatform(platform)
 		return nil
 	},
+}
+
+func installPlatform(platform string) bool {
+	switch platform {
+	case "claude-code":
+		if installUninstall {
+			if err := install.UninstallClaudeCode(); err != nil {
+				printErr("INSTALL_ERROR", err.Error())
+				return false
+			}
+			printJSON(map[string]any{"ok": true, "message": "Claude Code integration removed"})
+		} else {
+			if err := install.InstallClaudeCode(); err != nil {
+				printErr("INSTALL_ERROR", err.Error())
+				return false
+			}
+			printJSON(map[string]any{"ok": true, "message": "Claude Code integration installed. Restart Claude Code to activate."})
+		}
+	case "codex":
+		if installUninstall {
+			if err := install.UninstallCodex(); err != nil {
+				printErr("INSTALL_ERROR", err.Error())
+				return false
+			}
+			printJSON(map[string]any{"ok": true, "message": "Codex integration removed"})
+		} else {
+			if err := install.InstallCodex(); err != nil {
+				printErr("INSTALL_ERROR", err.Error())
+				return false
+			}
+			printJSON(map[string]any{"ok": true, "message": "Codex integration installed. Restart Codex to activate."})
+		}
+	case "gemini":
+		if installUninstall {
+			if err := install.UninstallGemini(); err != nil {
+				printErr("INSTALL_ERROR", err.Error())
+				return false
+			}
+			printJSON(map[string]any{"ok": true, "message": "Gemini integration removed"})
+		} else {
+			if err := install.InstallGemini(); err != nil {
+				printErr("INSTALL_ERROR", err.Error())
+				return false
+			}
+			printJSON(map[string]any{"ok": true, "message": "Gemini integration installed. Restart Gemini to activate."})
+		}
+	case "auggie":
+		if installUninstall {
+			if err := install.UninstallAuggie(); err != nil {
+				printErr("INSTALL_ERROR", err.Error())
+				return false
+			}
+			printJSON(map[string]any{"ok": true, "message": "Auggie integration removed"})
+		} else {
+			if err := install.InstallAuggie(); err != nil {
+				printErr("INSTALL_ERROR", err.Error())
+				return false
+			}
+			printJSON(map[string]any{"ok": true, "message": "Auggie integration installed. Restart Auggie to activate."})
+		}
+	case "augment":
+		if installUninstall {
+			if err := install.UninstallAugment(); err != nil {
+				printErr("INSTALL_ERROR", err.Error())
+				return false
+			}
+			printJSON(map[string]any{"ok": true, "message": "Augment integration removed"})
+		} else {
+			if err := install.InstallAugment(); err != nil {
+				printErr("INSTALL_ERROR", err.Error())
+				return false
+			}
+			printJSON(map[string]any{"ok": true, "message": "Augment integration installed. Restart Augment to activate."})
+		}
+	default:
+		printErr("INVALID_REQUEST", fmt.Sprintf("unknown platform: %s (supported: claude-code, codex, gemini, auggie, augment)", platform))
+		return false
+	}
+	return true
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -40,7 +40,9 @@ var installCmd = &cobra.Command{
 		}
 
 		platform := args[0]
-		installPlatform(platform)
+		if !installPlatform(platform) {
+			return nil
+		}
 		return nil
 	},
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -19,11 +20,9 @@ func init() {
 }
 
 var installCmd = &cobra.Command{
-	Use:           "install [platform]",
-	Short:         "Install waggle integration for a platform",
-	Args:          cobra.MaximumNArgs(1),
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	Use:   "install [platform]",
+	Short: "Install waggle integration for a platform",
+	Args:  installArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			if installUninstall {
@@ -32,21 +31,24 @@ var installCmd = &cobra.Command{
 			}
 			results, err := installDetected()
 			if err != nil {
-				printJSON(map[string]any{
+				printInstallError(cmd, "INSTALL_ERROR", err.Error(), map[string]any{
 					"ok":                 false,
-					"code":               "INSTALL_ERROR",
-					"error":              err.Error(),
 					"installed_adapters": installResultPlatforms(results),
 				})
+				cmd.SilenceErrors = true
+				cmd.SilenceUsage = true
 				return err
 			}
 			if len(results) == 0 {
 				printJSON(map[string]any{"ok": true, "message": "no supported adapters detected"})
 				return nil
 			}
-			for _, result := range results {
-				printJSON(map[string]any{"ok": true, "message": result.Message, "platform": result.Platform})
-			}
+			printJSON(map[string]any{
+				"ok":                 true,
+				"message":            "detected adapters installed",
+				"installed_adapters": installResultPlatforms(results),
+				"results":            results,
+			})
 			return nil
 		}
 
@@ -56,6 +58,17 @@ var installCmd = &cobra.Command{
 		}
 		return nil
 	},
+}
+
+func installArgs(cmd *cobra.Command, args []string) error {
+	if len(args) <= 1 {
+		return nil
+	}
+	err := fmt.Errorf("accepts at most 1 arg(s), received %d", len(args))
+	printInstallError(cmd, "INVALID_REQUEST", err.Error(), nil)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	return err
 }
 
 func installPlatform(platform string) bool {
@@ -143,4 +156,17 @@ func installResultPlatforms(results []install.InstallResult) []string {
 		platforms = append(platforms, result.Platform)
 	}
 	return platforms
+}
+
+func printInstallError(cmd *cobra.Command, code, message string, fields map[string]any) {
+	resp := map[string]any{
+		"ok":    false,
+		"code":  code,
+		"error": message,
+	}
+	for key, value := range fields {
+		resp[key] = value
+	}
+	data, _ := json.MarshalIndent(resp, "", "  ")
+	fmt.Fprintln(cmd.ErrOrStderr(), string(data))
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -2,12 +2,16 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/seungpyoson/waggle/internal/install"
 	"github.com/spf13/cobra"
 )
 
-var installUninstall bool
+var (
+	installUninstall bool
+	installDetected  = install.InstallDetected
+)
 
 func init() {
 	installCmd.Flags().BoolVar(&installUninstall, "uninstall", false, "Remove integration")
@@ -15,19 +19,26 @@ func init() {
 }
 
 var installCmd = &cobra.Command{
-	Use:   "install [platform]",
-	Short: "Install waggle integration for a platform",
-	Args:  cobra.MaximumNArgs(1),
+	Use:           "install [platform]",
+	Short:         "Install waggle integration for a platform",
+	Args:          cobra.MaximumNArgs(1),
+	SilenceErrors: true,
+	SilenceUsage:  true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			if installUninstall {
 				printErr("INVALID_REQUEST", "install --uninstall requires a platform")
 				return nil
 			}
-			results, err := install.InstallDetected()
+			results, err := installDetected()
 			if err != nil {
-				printErr("INSTALL_ERROR", err.Error())
-				return nil
+				printJSON(map[string]any{
+					"ok":                 false,
+					"code":               "INSTALL_ERROR",
+					"error":              err.Error(),
+					"installed_adapters": installResultPlatforms(results),
+				})
+				return err
 			}
 			if len(results) == 0 {
 				printJSON(map[string]any{"ok": true, "message": "no supported adapters detected"})
@@ -49,7 +60,7 @@ var installCmd = &cobra.Command{
 
 func installPlatform(platform string) bool {
 	switch platform {
-	case "claude-code":
+	case install.PlatformClaudeCode:
 		if installUninstall {
 			if err := install.UninstallClaudeCode(); err != nil {
 				printErr("INSTALL_ERROR", err.Error())
@@ -63,7 +74,7 @@ func installPlatform(platform string) bool {
 			}
 			printJSON(map[string]any{"ok": true, "message": "Claude Code integration installed. Restart Claude Code to activate."})
 		}
-	case "codex":
+	case install.PlatformCodex:
 		if installUninstall {
 			if err := install.UninstallCodex(); err != nil {
 				printErr("INSTALL_ERROR", err.Error())
@@ -77,7 +88,7 @@ func installPlatform(platform string) bool {
 			}
 			printJSON(map[string]any{"ok": true, "message": "Codex integration installed. Restart Codex to activate."})
 		}
-	case "gemini":
+	case install.PlatformGemini:
 		if installUninstall {
 			if err := install.UninstallGemini(); err != nil {
 				printErr("INSTALL_ERROR", err.Error())
@@ -91,7 +102,7 @@ func installPlatform(platform string) bool {
 			}
 			printJSON(map[string]any{"ok": true, "message": "Gemini integration installed. Restart Gemini to activate."})
 		}
-	case "auggie":
+	case install.PlatformAuggie:
 		if installUninstall {
 			if err := install.UninstallAuggie(); err != nil {
 				printErr("INSTALL_ERROR", err.Error())
@@ -105,7 +116,7 @@ func installPlatform(platform string) bool {
 			}
 			printJSON(map[string]any{"ok": true, "message": "Auggie integration installed. Restart Auggie to activate."})
 		}
-	case "augment":
+	case install.PlatformAugment:
 		if installUninstall {
 			if err := install.UninstallAugment(); err != nil {
 				printErr("INSTALL_ERROR", err.Error())
@@ -120,8 +131,16 @@ func installPlatform(platform string) bool {
 			printJSON(map[string]any{"ok": true, "message": "Augment integration installed. Restart Augment to activate."})
 		}
 	default:
-		printErr("INVALID_REQUEST", fmt.Sprintf("unknown platform: %s (supported: claude-code, codex, gemini, auggie, augment)", platform))
+		printErr("INVALID_REQUEST", fmt.Sprintf("unknown platform: %s (supported: %s)", platform, strings.Join(install.SupportedPlatforms(), ", ")))
 		return false
 	}
 	return true
+}
+
+func installResultPlatforms(results []install.InstallResult) []string {
+	platforms := make([]string, 0, len(results))
+	for _, result := range results {
+		platforms = append(platforms, result.Platform)
+	}
+	return platforms
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -24,10 +24,17 @@ var installCmd = &cobra.Command{
 				printErr("INVALID_REQUEST", "install --uninstall requires a platform")
 				return nil
 			}
-			for _, platform := range []string{"claude-code", "codex", "gemini", "auggie", "augment"} {
-				if !installPlatform(platform) {
-					return nil
-				}
+			results, err := install.InstallDetected()
+			if err != nil {
+				printErr("INSTALL_ERROR", err.Error())
+				return nil
+			}
+			if len(results) == 0 {
+				printJSON(map[string]any{"ok": true, "message": "no supported adapters detected"})
+				return nil
+			}
+			for _, result := range results {
+				printJSON(map[string]any{"ok": true, "message": result.Message, "platform": result.Platform})
 			}
 			return nil
 		}

--- a/cmd/runtime_test.go
+++ b/cmd/runtime_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -290,24 +291,75 @@ func TestExecuteRootCommandForTestDoesNotLeakInstallUninstallFlag(t *testing.T) 
 	}
 }
 
-func TestInstallNoArgsInstallsAllSupportedIntegrations(t *testing.T) {
+func TestInstallNoArgsInstallsDetectedIntegrations(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+	if err := os.Mkdir(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	stdout, stderr := executeRootCommandForTest(t, "install")
 	if stderr != "" {
 		t.Fatalf("install stderr = %q, want empty", stderr)
 	}
-	for _, want := range []string{
-		"Claude Code integration installed",
-		"Codex integration installed",
-		"Gemini integration installed",
-		"Auggie integration installed",
-		"Augment integration installed",
-	} {
-		if !strings.Contains(stdout, want) {
-			t.Fatalf("install stdout = %q, want %q", stdout, want)
+	if !strings.Contains(stdout, "Codex integration installed") {
+		t.Fatalf("install stdout = %q, want Codex install message", stdout)
+	}
+	for _, unwanted := range []string{"Claude Code integration installed", "Gemini integration installed", "Auggie integration installed", "Augment integration installed"} {
+		if strings.Contains(stdout, unwanted) {
+			t.Fatalf("install stdout = %q, did not expect %q", stdout, unwanted)
 		}
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex", "skills", "waggle-runtime", "SKILL.md")); err != nil {
+		t.Fatalf("Codex skill not installed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".gemini", "GEMINI.md")); !os.IsNotExist(err) {
+		t.Fatalf("Gemini should not have been installed, stat err = %v", err)
+	}
+}
+
+func TestStartAutoInstallsDetectedIntegrationsBeforeDaemonStart(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("WAGGLE_PROJECT_ID", "auto-install-start")
+	if err := os.Mkdir(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	originalAutoInstall := startAutoInstallDetected
+	originalIsRunning := startBrokerIsRunning
+	originalReadPID := startBrokerReadPID
+	originalCleanupStale := startBrokerCleanupStale
+	originalStartDaemon := startBrokerStartDaemon
+	originalWaitForReady := startBrokerWaitForReady
+	t.Cleanup(func() {
+		startAutoInstallDetected = originalAutoInstall
+		startBrokerIsRunning = originalIsRunning
+		startBrokerReadPID = originalReadPID
+		startBrokerCleanupStale = originalCleanupStale
+		startBrokerStartDaemon = originalStartDaemon
+		startBrokerWaitForReady = originalWaitForReady
+	})
+
+	startBrokerIsRunning = func(string) bool { return false }
+	startBrokerReadPID = func(string) (int, error) { return 4242, nil }
+	startBrokerCleanupStale = func(string, string) error { return nil }
+	startBrokerWaitForReady = func(string, time.Duration, time.Duration) error { return nil }
+	startBrokerStartDaemon = func(string, string, string, string, []string) error {
+		if _, err := os.Stat(filepath.Join(home, ".codex", "skills", "waggle-runtime", "SKILL.md")); err != nil {
+			t.Fatalf("Codex integration was not installed before daemon start: %v", err)
+		}
+		return nil
+	}
+
+	stdout, stderr := executeRootCommandForTest(t, "start")
+	if stderr != "" {
+		t.Fatalf("start stderr = %q, want empty", stderr)
+	}
+	if !strings.Contains(stdout, `"auto_installed_adapters":`) || !strings.Contains(stdout, `"codex"`) {
+		t.Fatalf("start stdout = %q, want auto-installed Codex adapter", stdout)
 	}
 }
 

--- a/cmd/runtime_test.go
+++ b/cmd/runtime_test.go
@@ -321,6 +321,39 @@ func TestInstallNoArgsInstallsDetectedIntegrations(t *testing.T) {
 	}
 }
 
+func TestInstallNoArgsReportsPartialResultsOnError(t *testing.T) {
+	originalInstallDetected := installDetected
+	t.Cleanup(func() {
+		installDetected = originalInstallDetected
+	})
+
+	installDetected = func() ([]install.InstallResult, error) {
+		return []install.InstallResult{{
+			Platform: install.PlatformCodex,
+			Message:  "Codex integration installed. Restart Codex to activate.",
+		}}, errors.New("install gemini: permission denied")
+	}
+
+	stdout, stderr, err := executeRootCommandForTestWithError(t, "install")
+	if err == nil {
+		t.Fatal("install returned nil error, want partial install error")
+	}
+	if stderr != "" {
+		t.Fatalf("install stderr = %q, want empty", stderr)
+	}
+	for _, want := range []string{
+		`"ok": false`,
+		`"code": "INSTALL_ERROR"`,
+		`"error": "install gemini: permission denied"`,
+		`"installed_adapters":`,
+		`"codex"`,
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("install stdout = %q, want %q", stdout, want)
+		}
+	}
+}
+
 func TestStartAutoInstallsDetectedIntegrationsBeforeDaemonStart(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -442,6 +475,17 @@ func resetFlagToDefault(flag *pflag.Flag) {
 func executeRootCommandForTest(t *testing.T, args ...string) (string, string) {
 	t.Helper()
 
+	stdout, stderr, err := executeRootCommandForTestWithError(t, args...)
+	if err != nil {
+		t.Fatalf("execute %v: %v", args, err)
+	}
+
+	return stdout, stderr
+}
+
+func executeRootCommandForTestWithError(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+
 	originalState := captureCommandTestState()
 	defer func() {
 		originalState.restore()
@@ -459,11 +503,8 @@ func executeRootCommandForTest(t *testing.T, args ...string) (string, string) {
 	rootCmd.SetErr(&stderr)
 	rootCmd.SetArgs(args)
 
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("execute %v: %v", args, err)
-	}
-
-	return stdout.String(), stderr.String()
+	err := rootCmd.Execute()
+	return stdout.String(), stderr.String(), err
 }
 
 func openRuntimeStoreForTest(t *testing.T) *rt.Store {

--- a/cmd/runtime_test.go
+++ b/cmd/runtime_test.go
@@ -290,6 +290,27 @@ func TestExecuteRootCommandForTestDoesNotLeakInstallUninstallFlag(t *testing.T) 
 	}
 }
 
+func TestInstallNoArgsInstallsAllSupportedIntegrations(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	stdout, stderr := executeRootCommandForTest(t, "install")
+	if stderr != "" {
+		t.Fatalf("install stderr = %q, want empty", stderr)
+	}
+	for _, want := range []string{
+		"Claude Code integration installed",
+		"Codex integration installed",
+		"Gemini integration installed",
+		"Auggie integration installed",
+		"Augment integration installed",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("install stdout = %q, want %q", stdout, want)
+		}
+	}
+}
+
 type commandTestState struct {
 	paths config.Paths
 }

--- a/cmd/runtime_test.go
+++ b/cmd/runtime_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/seungpyoson/waggle/internal/config"
+	"github.com/seungpyoson/waggle/internal/install"
 	rt "github.com/seungpyoson/waggle/internal/runtime"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -360,6 +362,52 @@ func TestStartAutoInstallsDetectedIntegrationsBeforeDaemonStart(t *testing.T) {
 	}
 	if !strings.Contains(stdout, `"auto_installed_adapters":`) || !strings.Contains(stdout, `"codex"`) {
 		t.Fatalf("start stdout = %q, want auto-installed Codex adapter", stdout)
+	}
+}
+
+func TestStartReportsAutoInstallFailureButStillStartsDaemon(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("WAGGLE_PROJECT_ID", "auto-install-start-fail-open")
+
+	originalAutoInstall := startAutoInstallDetected
+	originalIsRunning := startBrokerIsRunning
+	originalReadPID := startBrokerReadPID
+	originalCleanupStale := startBrokerCleanupStale
+	originalStartDaemon := startBrokerStartDaemon
+	originalWaitForReady := startBrokerWaitForReady
+	t.Cleanup(func() {
+		startAutoInstallDetected = originalAutoInstall
+		startBrokerIsRunning = originalIsRunning
+		startBrokerReadPID = originalReadPID
+		startBrokerCleanupStale = originalCleanupStale
+		startBrokerStartDaemon = originalStartDaemon
+		startBrokerWaitForReady = originalWaitForReady
+	})
+
+	daemonStarted := false
+	startAutoInstallDetected = func() ([]install.InstallResult, error) {
+		return nil, errors.New("auto-install unavailable")
+	}
+	startBrokerIsRunning = func(string) bool { return false }
+	startBrokerReadPID = func(string) (int, error) { return 4242, nil }
+	startBrokerCleanupStale = func(string, string) error { return nil }
+	startBrokerWaitForReady = func(string, time.Duration, time.Duration) error { return nil }
+	startBrokerStartDaemon = func(string, string, string, string, []string) error {
+		daemonStarted = true
+		return nil
+	}
+
+	stdout, stderr := executeRootCommandForTest(t, "start")
+	if stderr != "" {
+		t.Fatalf("start stderr = %q, want empty", stderr)
+	}
+	if !daemonStarted {
+		t.Fatal("daemon was not started after auto-install failure")
+	}
+	if !strings.Contains(stdout, `"auto_install_error": "auto-install unavailable"`) {
+		t.Fatalf("start stdout = %q, want auto_install_error", stdout)
 	}
 }
 

--- a/cmd/runtime_test.go
+++ b/cmd/runtime_test.go
@@ -308,6 +308,17 @@ func TestInstallNoArgsInstallsDetectedIntegrations(t *testing.T) {
 	if !strings.Contains(stdout, "Codex integration installed") {
 		t.Fatalf("install stdout = %q, want Codex install message", stdout)
 	}
+	var response struct {
+		OK                bool                    `json:"ok"`
+		InstalledAdapters []string                `json:"installed_adapters"`
+		Results           []install.InstallResult `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("install stdout is not a single JSON object: %v\n%s", err, stdout)
+	}
+	if !response.OK || len(response.InstalledAdapters) != 1 || response.InstalledAdapters[0] != install.PlatformCodex {
+		t.Fatalf("install response = %+v, want ok with only Codex installed", response)
+	}
 	for _, unwanted := range []string{"Claude Code integration installed", "Gemini integration installed", "Auggie integration installed", "Augment integration installed"} {
 		if strings.Contains(stdout, unwanted) {
 			t.Fatalf("install stdout = %q, did not expect %q", stdout, unwanted)
@@ -338,8 +349,8 @@ func TestInstallNoArgsReportsPartialResultsOnError(t *testing.T) {
 	if err == nil {
 		t.Fatal("install returned nil error, want partial install error")
 	}
-	if stderr != "" {
-		t.Fatalf("install stderr = %q, want empty", stderr)
+	if stdout != "" {
+		t.Fatalf("install stdout = %q, want empty", stdout)
 	}
 	for _, want := range []string{
 		`"ok": false`,
@@ -348,9 +359,22 @@ func TestInstallNoArgsReportsPartialResultsOnError(t *testing.T) {
 		`"installed_adapters":`,
 		`"codex"`,
 	} {
-		if !strings.Contains(stdout, want) {
-			t.Fatalf("install stdout = %q, want %q", stdout, want)
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("install stderr = %q, want %q", stderr, want)
 		}
+	}
+}
+
+func TestInstallTooManyArgsReportsCobraError(t *testing.T) {
+	stdout, stderr, err := executeRootCommandForTestWithError(t, "install", "codex", "gemini")
+	if err == nil {
+		t.Fatal("install returned nil error, want too-many-args error")
+	}
+	if stdout != "" {
+		t.Fatalf("install stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "accepts at most 1 arg") {
+		t.Fatalf("install stderr = %q, want Cobra argument error", stderr)
 	}
 }
 
@@ -489,6 +513,8 @@ func executeRootCommandForTestWithError(t *testing.T, args ...string) (string, s
 	originalState := captureCommandTestState()
 	defer func() {
 		originalState.restore()
+		installCmd.SilenceErrors = false
+		installCmd.SilenceUsage = false
 		rootCmd.SetOut(os.Stdout)
 		rootCmd.SetErr(os.Stderr)
 		rootCmd.SetArgs(nil)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -7,11 +7,18 @@ import (
 
 	"github.com/seungpyoson/waggle/internal/broker"
 	"github.com/seungpyoson/waggle/internal/config"
+	"github.com/seungpyoson/waggle/internal/install"
 	"github.com/spf13/cobra"
 )
 
 var (
-	foreground bool
+	foreground               bool
+	startAutoInstallDetected = install.InstallDetected
+	startBrokerIsRunning     = broker.IsRunning
+	startBrokerReadPID       = broker.ReadPID
+	startBrokerCleanupStale  = broker.CleanupStale
+	startBrokerStartDaemon   = broker.StartDaemon
+	startBrokerWaitForReady  = broker.WaitForReady
 )
 
 func init() {
@@ -65,42 +72,52 @@ var startCmd = &cobra.Command{
 			return nil
 		}
 
+		installed, err := startAutoInstallDetected()
+		if err != nil {
+			return fmt.Errorf("auto-installing detected integrations: %w", err)
+		}
+		installedPlatforms := make([]string, 0, len(installed))
+		for _, result := range installed {
+			installedPlatforms = append(installedPlatforms, result.Platform)
+		}
+
 		// Check if already running
-		if broker.IsRunning(paths.PID) {
-			pid, _ := broker.ReadPID(paths.PID)
+		if startBrokerIsRunning(paths.PID) {
+			pid, _ := startBrokerReadPID(paths.PID)
 			printJSON(map[string]any{
-				"ok":      true,
-				"message": fmt.Sprintf("broker already running (PID %d)", pid),
+				"ok":                      true,
+				"message":                 fmt.Sprintf("broker already running (PID %d)", pid),
+				"auto_installed_adapters": installedPlatforms,
 			})
 			return nil
 		}
 
 		// Cleanup stale files
-		if err := broker.CleanupStale(paths.PID, paths.Socket); err != nil {
+		if err := startBrokerCleanupStale(paths.PID, paths.Socket); err != nil {
 			return fmt.Errorf("cleaning up stale files: %w", err)
 		}
 
 		// Start daemon
 		socketDir := filepath.Dir(paths.Socket)
 		daemonArgs := []string{os.Args[0], "start", "--foreground"}
-		if err := broker.StartDaemon(paths.DataDir, socketDir, paths.Log, projectID, daemonArgs); err != nil {
+		if err := startBrokerStartDaemon(paths.DataDir, socketDir, paths.Log, projectID, daemonArgs); err != nil {
 			return fmt.Errorf("starting daemon: %w", err)
 		}
 
 		// Wait for broker to start
-		if err := broker.WaitForReady(paths.PID, config.Defaults.StartupTimeout, config.Defaults.StartupPollInterval); err != nil {
+		if err := startBrokerWaitForReady(paths.PID, config.Defaults.StartupTimeout, config.Defaults.StartupPollInterval); err != nil {
 			return fmt.Errorf("broker failed to start (check %s): %w", paths.Log, err)
 		}
 
-		pid, err := broker.ReadPID(paths.PID)
+		pid, err := startBrokerReadPID(paths.PID)
 		if err != nil {
 			return fmt.Errorf("broker started but cannot read PID: %w", err)
 		}
 		printJSON(map[string]any{
-			"ok":      true,
-			"message": fmt.Sprintf("broker started (PID %d)", pid),
+			"ok":                      true,
+			"message":                 fmt.Sprintf("broker started (PID %d)", pid),
+			"auto_installed_adapters": installedPlatforms,
 		})
 		return nil
 	},
 }
-

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -72,23 +72,28 @@ var startCmd = &cobra.Command{
 			return nil
 		}
 
-		installed, err := startAutoInstallDetected()
-		if err != nil {
-			return fmt.Errorf("auto-installing detected integrations: %w", err)
-		}
+		installed, autoInstallErr := startAutoInstallDetected()
 		installedPlatforms := make([]string, 0, len(installed))
 		for _, result := range installed {
 			installedPlatforms = append(installedPlatforms, result.Platform)
+		}
+		autoInstallError := ""
+		if autoInstallErr != nil {
+			autoInstallError = autoInstallErr.Error()
 		}
 
 		// Check if already running
 		if startBrokerIsRunning(paths.PID) {
 			pid, _ := startBrokerReadPID(paths.PID)
-			printJSON(map[string]any{
+			result := map[string]any{
 				"ok":                      true,
 				"message":                 fmt.Sprintf("broker already running (PID %d)", pid),
 				"auto_installed_adapters": installedPlatforms,
-			})
+			}
+			if autoInstallError != "" {
+				result["auto_install_error"] = autoInstallError
+			}
+			printJSON(result)
 			return nil
 		}
 
@@ -113,11 +118,15 @@ var startCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("broker started but cannot read PID: %w", err)
 		}
-		printJSON(map[string]any{
+		result := map[string]any{
 			"ok":                      true,
 			"message":                 fmt.Sprintf("broker started (PID %d)", pid),
 			"auto_installed_adapters": installedPlatforms,
-		})
+		}
+		if autoInstallError != "" {
+			result["auto_install_error"] = autoInstallError
+		}
+		printJSON(result)
 		return nil
 	},
 }

--- a/internal/install/detect.go
+++ b/internal/install/detect.go
@@ -1,7 +1,6 @@
 package install
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -123,5 +122,5 @@ func detectPlatform(homeDir string, lookPath LookPathFunc, name string, dirs []s
 
 func pathExists(path string) bool {
 	_, err := os.Stat(path)
-	return err == nil || !errors.Is(err, os.ErrNotExist)
+	return err == nil
 }

--- a/internal/install/detect.go
+++ b/internal/install/detect.go
@@ -1,0 +1,127 @@
+package install
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+const (
+	PlatformClaudeCode = "claude-code"
+	PlatformCodex      = "codex"
+	PlatformGemini     = "gemini"
+	PlatformAuggie     = "auggie"
+	PlatformAugment    = "augment"
+)
+
+type PlatformDetection struct {
+	Name     string
+	Found    bool
+	Evidence string
+}
+
+type InstallResult struct {
+	Platform string
+	Message  string
+}
+
+type LookPathFunc func(string) (string, error)
+
+func SupportedPlatforms() []string {
+	return []string{PlatformClaudeCode, PlatformCodex, PlatformGemini, PlatformAuggie, PlatformAugment}
+}
+
+func DetectPlatforms(homeDir string, lookPath LookPathFunc) []PlatformDetection {
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+	return []PlatformDetection{
+		detectPlatform(homeDir, lookPath, PlatformClaudeCode, []string{".claude"}, []string{"claude", "claude-code"}),
+		detectPlatform(homeDir, lookPath, PlatformCodex, []string{".codex"}, []string{"codex"}),
+		detectPlatform(homeDir, lookPath, PlatformGemini, []string{".gemini"}, []string{"gemini"}),
+		detectPlatform(homeDir, lookPath, PlatformAuggie, []string{".augment/rules"}, []string{"auggie"}),
+		detectPlatform(homeDir, lookPath, PlatformAugment, []string{".augment/skills"}, []string{"augment"}),
+	}
+}
+
+func InstallDetected() ([]InstallResult, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("getting home dir: %w", err)
+	}
+	return InstallDetectedInHome(home, exec.LookPath)
+}
+
+func InstallDetectedInHome(homeDir string, lookPath LookPathFunc) ([]InstallResult, error) {
+	detections := DetectPlatforms(homeDir, lookPath)
+	results := make([]InstallResult, 0, len(detections))
+	for _, detection := range detections {
+		if !detection.Found {
+			continue
+		}
+		if err := InstallPlatformInHome(homeDir, detection.Name); err != nil {
+			return results, err
+		}
+		results = append(results, InstallResult{
+			Platform: detection.Name,
+			Message:  installMessage(detection.Name),
+		})
+	}
+	return results, nil
+}
+
+func InstallPlatformInHome(homeDir, platform string) error {
+	switch platform {
+	case PlatformClaudeCode:
+		return installClaudeCode(homeDir)
+	case PlatformCodex:
+		return installCodex(homeDir)
+	case PlatformGemini:
+		return installGemini(homeDir)
+	case PlatformAuggie:
+		return installAuggie(homeDir)
+	case PlatformAugment:
+		return installAugment(homeDir)
+	default:
+		return fmt.Errorf("unknown platform: %s", platform)
+	}
+}
+
+func installMessage(platform string) string {
+	switch platform {
+	case PlatformClaudeCode:
+		return "Claude Code integration installed. Restart Claude Code to activate."
+	case PlatformCodex:
+		return "Codex integration installed. Restart Codex to activate."
+	case PlatformGemini:
+		return "Gemini integration installed. Restart Gemini to activate."
+	case PlatformAuggie:
+		return "Auggie integration installed. Restart Auggie to activate."
+	case PlatformAugment:
+		return "Augment integration installed. Restart Augment to activate."
+	default:
+		return fmt.Sprintf("%s integration installed", platform)
+	}
+}
+
+func detectPlatform(homeDir string, lookPath LookPathFunc, name string, dirs []string, binaries []string) PlatformDetection {
+	for _, dir := range dirs {
+		if pathExists(filepath.Join(homeDir, filepath.FromSlash(dir))) {
+			return PlatformDetection{Name: name, Found: true, Evidence: dir}
+		}
+	}
+	for _, binary := range binaries {
+		path, err := lookPath(binary)
+		if err == nil {
+			return PlatformDetection{Name: name, Found: true, Evidence: path}
+		}
+	}
+	return PlatformDetection{Name: name}
+}
+
+func pathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil || !errors.Is(err, os.ErrNotExist)
+}

--- a/internal/install/detect_test.go
+++ b/internal/install/detect_test.go
@@ -36,6 +36,27 @@ func TestDetectPlatformsUsesHomeAndPathEvidence(t *testing.T) {
 	}
 }
 
+func TestPathExistsReturnsFalseOnPermissionError(t *testing.T) {
+	parent := filepath.Join(t.TempDir(), "parent")
+	if err := os.Mkdir(parent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	child := filepath.Join(parent, "child")
+	if err := os.Mkdir(child, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(parent, 0); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(parent, 0o755)
+	})
+
+	if pathExists(child) {
+		t.Fatal("pathExists should return false when stat fails with permission denied")
+	}
+}
+
 func TestInstallDetectedInHomeInstallsOnlyDetectedPlatforms(t *testing.T) {
 	home := t.TempDir()
 	if err := os.Mkdir(filepath.Join(home, ".codex"), 0o755); err != nil {

--- a/internal/install/detect_test.go
+++ b/internal/install/detect_test.go
@@ -1,0 +1,60 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestDetectPlatformsUsesHomeAndPathEvidence(t *testing.T) {
+	home := t.TempDir()
+	if err := os.Mkdir(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(home, ".gemini"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	lookPath := func(name string) (string, error) {
+		if name == "claude" {
+			return "/usr/local/bin/claude", nil
+		}
+		return "", os.ErrNotExist
+	}
+
+	detections := DetectPlatforms(home, lookPath)
+	var got []string
+	for _, detection := range detections {
+		if detection.Found {
+			got = append(got, detection.Name)
+		}
+	}
+	want := []string{PlatformClaudeCode, PlatformCodex, PlatformGemini}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("detected platforms = %v, want %v", got, want)
+	}
+}
+
+func TestInstallDetectedInHomeInstallsOnlyDetectedPlatforms(t *testing.T) {
+	home := t.TempDir()
+	if err := os.Mkdir(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := InstallDetectedInHome(home, func(string) (string, error) {
+		return "", os.ErrNotExist
+	})
+	if err != nil {
+		t.Fatalf("InstallDetectedInHome: %v", err)
+	}
+	if len(results) != 1 || results[0].Platform != PlatformCodex {
+		t.Fatalf("results = %+v, want only Codex", results)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex", "skills", "waggle-runtime", "SKILL.md")); err != nil {
+		t.Fatalf("Codex skill not installed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".gemini", "GEMINI.md")); !os.IsNotExist(err) {
+		t.Fatalf("Gemini should not have been installed, stat err = %v", err)
+	}
+}

--- a/internal/install/health.go
+++ b/internal/install/health.go
@@ -111,14 +111,18 @@ func CheckClaudeCode(homeDir string) ([]HealthIssue, AdapterState) {
 
 	// Step 3: Derive state from fingerprint × files matrix
 	if !hookRegistered && !anyFileExists {
+		if len(issues) > 0 {
+			return issues, StateBroken
+		}
 		if staleRef != "" {
 			// No canonical fingerprint, no files, but a stale waggle reference
 			// exists in settings.json — surface it with repair guidance
-			return []HealthIssue{{
+			issues = append(issues, HealthIssue{
 				Asset:   settingsPath,
 				Problem: "stale waggle hook reference in settings.json: " + staleRef,
 				Repair:  repairCmd,
-			}}, StateBroken
+			})
+			return issues, StateBroken
 		}
 		return nil, StateNotInstalled
 	}

--- a/internal/install/health.go
+++ b/internal/install/health.go
@@ -79,6 +79,7 @@ func CheckClaudeCode(homeDir string) ([]HealthIssue, AdapterState) {
 	heartbeatPath := filepath.Join(claudeDir, "hooks", "waggle-heartbeat.sh")
 	pushPath := filepath.Join(claudeDir, "hooks", "waggle-push.js")
 	skillDir := filepath.Join(claudeDir, "skills", "waggle")
+	unsafePaths := make(map[string]bool)
 
 	for _, item := range []struct {
 		path string
@@ -91,6 +92,7 @@ func CheckClaudeCode(homeDir string) ([]HealthIssue, AdapterState) {
 	} {
 		if issue := unsafePathIssue(item.path, homeDir, item.name, repairCmd); issue != nil {
 			issues = append(issues, *issue)
+			unsafePaths[item.path] = true
 		}
 	}
 
@@ -145,7 +147,7 @@ func CheckClaudeCode(homeDir string) ([]HealthIssue, AdapterState) {
 		})
 	}
 
-	if !hookExists {
+	if !hookExists && !unsafePaths[hookPath] {
 		issues = append(issues, HealthIssue{
 			Asset:   hookPath,
 			Problem: "waggle-connect.sh missing",
@@ -153,7 +155,7 @@ func CheckClaudeCode(homeDir string) ([]HealthIssue, AdapterState) {
 		})
 	}
 
-	if !heartbeatExists {
+	if !heartbeatExists && !unsafePaths[heartbeatPath] {
 		issues = append(issues, HealthIssue{
 			Asset:   heartbeatPath,
 			Problem: "waggle-heartbeat.sh missing",
@@ -161,7 +163,7 @@ func CheckClaudeCode(homeDir string) ([]HealthIssue, AdapterState) {
 		})
 	}
 
-	if !pushExists {
+	if !pushExists && !unsafePaths[pushPath] {
 		issues = append(issues, HealthIssue{
 			Asset:   pushPath,
 			Problem: "waggle-push.js missing",
@@ -169,7 +171,7 @@ func CheckClaudeCode(homeDir string) ([]HealthIssue, AdapterState) {
 		})
 	}
 
-	if !skillDirExists {
+	if !skillDirExists && !unsafePaths[skillDir] {
 		issues = append(issues, HealthIssue{
 			Asset:   skillDir,
 			Problem: "skills directory missing",

--- a/internal/install/health.go
+++ b/internal/install/health.go
@@ -207,7 +207,17 @@ func CheckCodex(homeDir string) ([]HealthIssue, AdapterState) {
 
 	// Step 1: Check for fingerprint (WAGGLE-CODEX-BEGIN marker in AGENTS.md)
 	agentsPath := filepath.Join(codexDir, "AGENTS.md")
+	if issue := unsafePathIssue(agentsPath, homeDir, "AGENTS.md", repairCmd); issue != nil {
+		return []HealthIssue{*issue}, StateBroken
+	}
 	data, err := os.ReadFile(agentsPath)
+	if err != nil && !os.IsNotExist(err) {
+		return []HealthIssue{{
+			Asset:   agentsPath,
+			Problem: "failed to read AGENTS.md: " + err.Error(),
+			Repair:  repairCmd,
+		}}, StateBroken
+	}
 
 	hasBeginMarker := err == nil && strings.Contains(string(data), codexBlockBegin)
 	hasEndMarker := err == nil && strings.Contains(string(data), codexBlockEnd)
@@ -215,6 +225,9 @@ func CheckCodex(homeDir string) ([]HealthIssue, AdapterState) {
 	// Step 2: Check if waggle files are present on disk
 	skillPath := filepath.Join(codexDir, "skills", "waggle-runtime", "SKILL.md")
 	skillExists := fileExists(skillPath)
+	if issue := unsafePathIssue(skillPath, homeDir, "SKILL.md", repairCmd); issue != nil {
+		issues = append(issues, *issue)
+	}
 
 	// Step 3: Validate marker topology before deriving state.
 	// Any marker presence (begin OR end) means the file has waggle artifacts.
@@ -284,6 +297,9 @@ func CheckGemini(homeDir string) ([]HealthIssue, AdapterState) {
 	var issues []HealthIssue
 	geminiDir := filepath.Join(homeDir, ".gemini")
 	geminiFilePath := filepath.Join(geminiDir, "GEMINI.md")
+	if issue := unsafePathIssue(geminiFilePath, homeDir, "GEMINI.md", repairCmd); issue != nil {
+		return []HealthIssue{*issue}, StateBroken
+	}
 
 	// Step 1: Read file
 	data, err := os.ReadFile(geminiFilePath)
@@ -404,6 +420,9 @@ func CheckAugment(homeDir string) ([]HealthIssue, AdapterState) {
 	const repairCmd = "waggle install augment"
 	var issues []HealthIssue
 	skillPath := filepath.Join(homeDir, ".augment", "skills", "waggle.md")
+	if issue := unsafePathIssue(skillPath, homeDir, "waggle.md", repairCmd); issue != nil {
+		return []HealthIssue{*issue}, StateBroken
+	}
 
 	data, err := os.ReadFile(skillPath)
 	if err != nil {
@@ -487,6 +506,35 @@ func appendEmbeddedFileIssue(issues *[]HealthIssue, path string, files embeddedF
 			Repair:  repairCmd,
 		})
 	}
+}
+
+func unsafePathIssue(path, root, assetName, repairCmd string) *HealthIssue {
+	if fsutil.HasAncestorSymlink(path, root) {
+		return &HealthIssue{
+			Asset:   path,
+			Problem: "symlink in ancestor path for " + assetName,
+			Repair:  repairCmd,
+		}
+	}
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return &HealthIssue{
+			Asset:   path,
+			Problem: "cannot inspect " + assetName + ": " + err.Error(),
+			Repair:  repairCmd,
+		}
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return &HealthIssue{
+			Asset:   path,
+			Problem: assetName + " is a symlink; refusing to trust symlinked integration file",
+			Repair:  repairCmd,
+		}
+	}
+	return nil
 }
 
 func appendManagedBlockContentIssue(issues *[]HealthIssue, path, content, begin, end string, files embeddedFileReader, embeddedPath, repairCmd string) {

--- a/internal/install/health.go
+++ b/internal/install/health.go
@@ -101,11 +101,12 @@ func CheckClaudeCode(homeDir string) ([]HealthIssue, AdapterState) {
 	anyFileExists := hookExists || heartbeatExists || pushExists || skillDirExists
 
 	if settingsErr != nil {
-		return []HealthIssue{{
+		issues = append(issues, HealthIssue{
 			Asset:   settingsPath,
 			Problem: "cannot parse settings.json: " + settingsErr.Error(),
 			Repair:  "fix or remove invalid settings.json, then run " + repairCmd,
-		}}, StateBroken
+		})
+		return issues, StateBroken
 	}
 
 	// Step 3: Derive state from fingerprint × files matrix

--- a/internal/install/health.go
+++ b/internal/install/health.go
@@ -176,6 +176,7 @@ func CheckClaudeCode(homeDir string) ([]HealthIssue, AdapterState) {
 			skillPath := filepath.Join(skillDir, skill)
 			if issue := unsafePathIssue(skillPath, homeDir, "skill file "+skill, repairCmd); issue != nil {
 				issues = append(issues, *issue)
+				break // Report the unsafe path itself; avoid misleading "missing" noise.
 			}
 			if !fileExists(skillPath) {
 				issues = append(issues, HealthIssue{
@@ -243,8 +244,10 @@ func CheckCodex(homeDir string) ([]HealthIssue, AdapterState) {
 	// Step 2: Check if waggle files are present on disk
 	skillPath := filepath.Join(codexDir, "skills", "waggle-runtime", "SKILL.md")
 	skillExists := fileExists(skillPath)
+	skillUnsafe := false
 	if issue := unsafePathIssue(skillPath, homeDir, "SKILL.md", repairCmd); issue != nil {
 		issues = append(issues, *issue)
+		skillUnsafe = true
 	}
 
 	// Step 3: Validate marker topology before deriving state.
@@ -286,13 +289,13 @@ func CheckCodex(homeDir string) ([]HealthIssue, AdapterState) {
 		})
 	}
 
-	if !skillExists {
+	if !skillExists && !skillUnsafe {
 		issues = append(issues, HealthIssue{
 			Asset:   skillPath,
 			Problem: "SKILL.md missing",
 			Repair:  repairCmd,
 		})
-	} else {
+	} else if skillExists && !skillUnsafe {
 		appendEmbeddedFileIssue(&issues, skillPath, codexFiles, "codex/skills/waggle-runtime/SKILL.md", "SKILL.md", repairCmd)
 	}
 

--- a/internal/install/health.go
+++ b/internal/install/health.go
@@ -80,6 +80,20 @@ func CheckClaudeCode(homeDir string) ([]HealthIssue, AdapterState) {
 	pushPath := filepath.Join(claudeDir, "hooks", "waggle-push.js")
 	skillDir := filepath.Join(claudeDir, "skills", "waggle")
 
+	for _, item := range []struct {
+		path string
+		name string
+	}{
+		{hookPath, "waggle-connect.sh"},
+		{heartbeatPath, "waggle-heartbeat.sh"},
+		{pushPath, "waggle-push.js"},
+		{skillDir, "skills directory"},
+	} {
+		if issue := unsafePathIssue(item.path, homeDir, item.name, repairCmd); issue != nil {
+			issues = append(issues, *issue)
+		}
+	}
+
 	hookExists := fileExists(hookPath)
 	heartbeatExists := fileExists(heartbeatPath)
 	pushExists := fileExists(pushPath)
@@ -159,6 +173,9 @@ func CheckClaudeCode(homeDir string) ([]HealthIssue, AdapterState) {
 	} else {
 		for _, skill := range claudeCodeSkillFiles {
 			skillPath := filepath.Join(skillDir, skill)
+			if issue := unsafePathIssue(skillPath, homeDir, "skill file "+skill, repairCmd); issue != nil {
+				issues = append(issues, *issue)
+			}
 			if !fileExists(skillPath) {
 				issues = append(issues, HealthIssue{
 					Asset:   skillPath,

--- a/internal/install/health_test.go
+++ b/internal/install/health_test.go
@@ -428,6 +428,23 @@ func TestCheckCodex_NotInstalled_NoMarker(t *testing.T) {
 	}
 }
 
+func TestCheckCodex_BrokenUnreadableAgentsFile(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	agentsPath := filepath.Join(tmpHome, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(agentsPath, 0755); err != nil {
+		t.Fatalf("failed to create unreadable AGENTS.md stand-in: %v", err)
+	}
+
+	issues, state := CheckCodex(tmpHome)
+	if state != StateBroken {
+		t.Fatalf("expected StateBroken for unreadable AGENTS.md, got %q", state)
+	}
+	if !hasHealthIssueContaining(issues, "failed to read AGENTS.md") {
+		t.Fatalf("expected AGENTS.md read failure issue, got %+v", issues)
+	}
+}
+
 func TestCheckCodex_Healthy(t *testing.T) {
 	tmpHome := t.TempDir()
 
@@ -443,6 +460,37 @@ func TestCheckCodex_Healthy(t *testing.T) {
 	}
 	if len(issues) != 0 {
 		t.Errorf("expected 0 issues, got %d: %+v", len(issues), issues)
+	}
+}
+
+func TestCheckCodex_BrokenSymlinkedAgentsFile(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	if err := installCodex(tmpHome); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+	agentsPath := filepath.Join(tmpHome, ".codex", "AGENTS.md")
+	targetPath := filepath.Join(tmpHome, "target-AGENTS.md")
+	data, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	if err := os.WriteFile(targetPath, data, 0644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.Remove(agentsPath); err != nil {
+		t.Fatalf("remove AGENTS.md: %v", err)
+	}
+	if err := os.Symlink(targetPath, agentsPath); err != nil {
+		t.Fatalf("symlink AGENTS.md: %v", err)
+	}
+
+	issues, state := CheckCodex(tmpHome)
+	if state != StateBroken {
+		t.Fatalf("expected StateBroken for symlinked AGENTS.md, got %q", state)
+	}
+	if !hasHealthIssueContaining(issues, "symlink") {
+		t.Fatalf("expected symlink issue, got %+v", issues)
 	}
 }
 

--- a/internal/install/health_test.go
+++ b/internal/install/health_test.go
@@ -166,6 +166,38 @@ func TestCheckClaudeCode_BrokenStaleCanonicalContent(t *testing.T) {
 	}
 }
 
+func TestCheckClaudeCode_BrokenSymlinkedHook(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	if err := installClaudeCode(tmpHome); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	hookPath := filepath.Join(tmpHome, ".claude", "hooks", "waggle-connect.sh")
+	canonical, err := claudeCodeFiles.ReadFile("claude-code/hook.sh")
+	if err != nil {
+		t.Fatalf("read canonical hook: %v", err)
+	}
+	targetPath := filepath.Join(tmpHome, "hook-target.sh")
+	if err := os.WriteFile(targetPath, canonical, 0o755); err != nil {
+		t.Fatalf("write hook target: %v", err)
+	}
+	if err := os.Remove(hookPath); err != nil {
+		t.Fatalf("remove installed hook: %v", err)
+	}
+	if err := os.Symlink(targetPath, hookPath); err != nil {
+		t.Fatalf("symlink hook: %v", err)
+	}
+
+	issues, state := CheckClaudeCode(tmpHome)
+	if state != StateBroken {
+		t.Fatalf("expected StateBroken for symlinked Claude Code hook, got %q", state)
+	}
+	if !hasHealthIssueContaining(issues, "symlink") {
+		t.Fatalf("expected symlink issue, got %+v", issues)
+	}
+}
+
 func TestCheckClaudeCode_BrokenInvalidSettingsJSON(t *testing.T) {
 	tmpHome := t.TempDir()
 

--- a/internal/install/health_test.go
+++ b/internal/install/health_test.go
@@ -257,6 +257,43 @@ func TestCheckClaudeCode_DanglingSymlinkedHookWithoutFingerprintIsBroken(t *test
 	}
 }
 
+func TestCheckClaudeCode_DanglingSymlinkedManagedFilesReportOnlySymlink(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		file string
+	}{
+		{name: "hook", file: filepath.Join(".claude", "hooks", "waggle-connect.sh")},
+		{name: "heartbeat", file: filepath.Join(".claude", "hooks", "waggle-heartbeat.sh")},
+		{name: "push", file: filepath.Join(".claude", "hooks", "waggle-push.js")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpHome := t.TempDir()
+			if err := installClaudeCode(tmpHome); err != nil {
+				t.Fatalf("install failed: %v", err)
+			}
+
+			path := filepath.Join(tmpHome, tt.file)
+			if err := os.Remove(path); err != nil {
+				t.Fatalf("remove installed file: %v", err)
+			}
+			if err := os.Symlink(filepath.Join(tmpHome, "missing-"+tt.name), path); err != nil {
+				t.Fatalf("symlink file: %v", err)
+			}
+
+			issues, state := CheckClaudeCode(tmpHome)
+			if state != StateBroken {
+				t.Fatalf("expected StateBroken for dangling %s symlink, got %q", tt.name, state)
+			}
+			if !hasHealthIssueForAssetContaining(issues, path, "symlink") {
+				t.Fatalf("expected symlink issue for %s, got %+v", path, issues)
+			}
+			if hasHealthIssueForAssetContaining(issues, path, "missing") {
+				t.Fatalf("did not expect redundant missing issue for dangling symlink, got %+v", issues)
+			}
+		})
+	}
+}
+
 func TestCheckClaudeCode_BrokenInvalidSettingsJSON(t *testing.T) {
 	tmpHome := t.TempDir()
 

--- a/internal/install/health_test.go
+++ b/internal/install/health_test.go
@@ -234,6 +234,29 @@ func TestCheckClaudeCode_DanglingSymlinkedSkillReportsOnlySymlink(t *testing.T) 
 	}
 }
 
+func TestCheckClaudeCode_DanglingSymlinkedHookWithoutFingerprintIsBroken(t *testing.T) {
+	tmpHome := t.TempDir()
+	hooksDir := filepath.Join(tmpHome, ".claude", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hookPath := filepath.Join(hooksDir, "waggle-connect.sh")
+	if err := os.Symlink(filepath.Join(tmpHome, "missing-hook.sh"), hookPath); err != nil {
+		t.Fatalf("symlink hook: %v", err)
+	}
+
+	issues, state := CheckClaudeCode(tmpHome)
+	if state != StateBroken {
+		t.Fatalf("expected StateBroken for dangling hook symlink, got %q", state)
+	}
+	if !hasHealthIssueForAssetContaining(issues, hookPath, "symlink") {
+		t.Fatalf("expected symlink issue for %s, got %+v", hookPath, issues)
+	}
+	if hasHealthIssueForAssetContaining(issues, hookPath, "missing") {
+		t.Fatalf("did not expect redundant missing issue for dangling symlink, got %+v", issues)
+	}
+}
+
 func TestCheckClaudeCode_BrokenInvalidSettingsJSON(t *testing.T) {
 	tmpHome := t.TempDir()
 

--- a/internal/install/health_test.go
+++ b/internal/install/health_test.go
@@ -219,6 +219,46 @@ func TestCheckClaudeCode_BrokenInvalidSettingsJSON(t *testing.T) {
 	}
 }
 
+func TestCheckClaudeCode_BrokenInvalidSettingsJSONPreservesPathIssues(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	if err := installClaudeCode(tmpHome); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	settingsPath := filepath.Join(tmpHome, ".claude", "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(`{"hooks":`), 0644); err != nil {
+		t.Fatalf("write invalid settings.json: %v", err)
+	}
+
+	hookPath := filepath.Join(tmpHome, ".claude", "hooks", "waggle-connect.sh")
+	canonical, err := claudeCodeFiles.ReadFile("claude-code/hook.sh")
+	if err != nil {
+		t.Fatalf("read canonical hook: %v", err)
+	}
+	targetPath := filepath.Join(tmpHome, "hook-target.sh")
+	if err := os.WriteFile(targetPath, canonical, 0o755); err != nil {
+		t.Fatalf("write hook target: %v", err)
+	}
+	if err := os.Remove(hookPath); err != nil {
+		t.Fatalf("remove installed hook: %v", err)
+	}
+	if err := os.Symlink(targetPath, hookPath); err != nil {
+		t.Fatalf("symlink hook: %v", err)
+	}
+
+	issues, state := CheckClaudeCode(tmpHome)
+	if state != StateBroken {
+		t.Fatalf("expected StateBroken for invalid settings.json and symlinked hook, got %q", state)
+	}
+	if !hasHealthIssueContaining(issues, "cannot parse settings.json") {
+		t.Fatalf("expected invalid settings.json issue, got %+v", issues)
+	}
+	if !hasHealthIssueContaining(issues, "symlink") {
+		t.Fatalf("expected symlink issue, got %+v", issues)
+	}
+}
+
 func TestCheckClaudeCode_BrokenMissingHook(t *testing.T) {
 	tmpHome := t.TempDir()
 

--- a/internal/install/health_test.go
+++ b/internal/install/health_test.go
@@ -124,6 +124,15 @@ func hasHealthIssueContaining(issues []HealthIssue, problem string) bool {
 	return false
 }
 
+func hasHealthIssueForAssetContaining(issues []HealthIssue, asset, problem string) bool {
+	for _, issue := range issues {
+		if issue.Asset == asset && strings.Contains(issue.Problem, problem) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestCheckClaudeCode_Healthy(t *testing.T) {
 	tmpHome := t.TempDir()
 
@@ -195,6 +204,33 @@ func TestCheckClaudeCode_BrokenSymlinkedHook(t *testing.T) {
 	}
 	if !hasHealthIssueContaining(issues, "symlink") {
 		t.Fatalf("expected symlink issue, got %+v", issues)
+	}
+}
+
+func TestCheckClaudeCode_DanglingSymlinkedSkillReportsOnlySymlink(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	if err := installClaudeCode(tmpHome); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	skillPath := filepath.Join(tmpHome, ".claude", "skills", "waggle", "send.md")
+	if err := os.Remove(skillPath); err != nil {
+		t.Fatalf("remove installed skill: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(tmpHome, "missing-target.md"), skillPath); err != nil {
+		t.Fatalf("symlink skill: %v", err)
+	}
+
+	issues, state := CheckClaudeCode(tmpHome)
+	if state != StateBroken {
+		t.Fatalf("expected StateBroken for dangling skill symlink, got %q", state)
+	}
+	if !hasHealthIssueForAssetContaining(issues, skillPath, "symlink") {
+		t.Fatalf("expected symlink issue for %s, got %+v", skillPath, issues)
+	}
+	if hasHealthIssueForAssetContaining(issues, skillPath, "missing") {
+		t.Fatalf("did not expect redundant missing issue for dangling symlink, got %+v", issues)
 	}
 }
 
@@ -563,6 +599,33 @@ func TestCheckCodex_BrokenSymlinkedAgentsFile(t *testing.T) {
 	}
 	if !hasHealthIssueContaining(issues, "symlink") {
 		t.Fatalf("expected symlink issue, got %+v", issues)
+	}
+}
+
+func TestCheckCodex_DanglingSymlinkedSkillReportsOnlySymlink(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	if err := installCodex(tmpHome); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	skillPath := filepath.Join(tmpHome, ".codex", "skills", "waggle-runtime", "SKILL.md")
+	if err := os.Remove(skillPath); err != nil {
+		t.Fatalf("remove installed skill: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(tmpHome, "missing-target.md"), skillPath); err != nil {
+		t.Fatalf("symlink skill: %v", err)
+	}
+
+	issues, state := CheckCodex(tmpHome)
+	if state != StateBroken {
+		t.Fatalf("expected StateBroken for dangling skill symlink, got %q", state)
+	}
+	if !hasHealthIssueForAssetContaining(issues, skillPath, "symlink") {
+		t.Fatalf("expected symlink issue for %s, got %+v", skillPath, issues)
+	}
+	if hasHealthIssueForAssetContaining(issues, skillPath, "missing") {
+		t.Fatalf("did not expect redundant missing issue for dangling symlink, got %+v", issues)
 	}
 }
 


### PR DESCRIPTION
## Summary

Install/startup health work for issues #99/#100/#105:

- `CheckCodex`, `CheckGemini`, `CheckAugment`, and `CheckClaudeCode` now reject unreadable or unsafe integration files instead of reporting misleading healthy/not-installed state.
- Claude Code hook and skill health now rejects symlink/ancestor-symlink topologies, matching the safety model used by the other protected adapter paths.
- `waggle install` with no platform now installs only integrations detected from the current home/PATH.
- `waggle start` auto-installs detected integrations before daemon startup, reports `auto_installed_adapters`, and fails open with `auto_install_error` if auto-install fails so startup is not blocked by repair work.
- Adds focused tests for detection, no-arg install behavior, start-before-daemon ordering, fail-open startup, and Claude Code symlink health.

## Verification

- `go test ./internal/install -count=1`
- `go test ./cmd -run 'TestStartReportsAutoInstallFailureButStillStartsDaemon|TestStartAutoInstallsDetectedIntegrationsBeforeDaemonStart' -count=1`
- `go test ./... -count=1 -p=1`
- `go vet ./...`
- `git diff --check`

## Safety

All new tests run against temporary homes. This branch does not install Waggle into the real user home during verification.