### PR TITLE
fix: harden runtime delivery identity and replay

### DIFF
--- a/cmd/adapter_test.go
+++ b/cmd/adapter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	ia "github.com/seungpyoson/waggle/internal/adapter"
 	"github.com/seungpyoson/waggle/internal/config"
 	rt "github.com/seungpyoson/waggle/internal/runtime"
 )
@@ -248,6 +249,35 @@ func TestAdapterBootstrapJSONReportsSkippedWhenRuntimeStoreUnavailable(t *testin
 	}
 	if resp.Tool != "codex" {
 		t.Fatalf("tool = %q, want codex", resp.Tool)
+	}
+}
+
+func TestWhoamiReturnsMappedAgentIdentity(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("WAGGLE_AGENT_PPID", "12345")
+
+	runtimeDir := config.NewPaths("").RuntimeDir
+	nonce := "12345-1711843200000000002"
+	if err := ia.WriteSessionMapping(runtimeDir, 12345, nonce, "codex-ttys001", "proj-whoami"); err != nil {
+		t.Fatalf("write session mapping: %v", err)
+	}
+
+	stdout, stderr := executeRootCommandForTest(t, "whoami")
+	if stderr != "" {
+		t.Fatalf("whoami stderr = %q, want empty", stderr)
+	}
+
+	var resp struct {
+		OK         bool   `json:"ok"`
+		AgentName  string `json:"agent_name"`
+		ProjectKey string `json:"project_key"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &resp); err != nil {
+		t.Fatalf("unmarshal whoami response: %v", err)
+	}
+	if !resp.OK || resp.AgentName != "codex-ttys001" || resp.ProjectKey != rt.ProjectPathKey("proj-whoami") {
+		t.Fatalf("whoami response = %+v", resp)
 	}
 }
 

--- a/cmd/adapter_test.go
+++ b/cmd/adapter_test.go
@@ -281,18 +281,51 @@ func TestWhoamiReturnsMappedAgentIdentity(t *testing.T) {
 	}
 }
 
+func TestWhoamiParsesCRLFSessionMapping(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("WAGGLE_AGENT_PPID", "12345")
+
+	runtimeDir := config.NewPaths("").RuntimeDir
+	nonce := "12345-1711843200000000002"
+	if err := ia.WriteSessionMapping(runtimeDir, 12345, nonce, "codex-ttys001", "proj-whoami"); err != nil {
+		t.Fatalf("write session mapping: %v", err)
+	}
+	sessionPath := filepath.Join(runtimeDir, "agent-session-"+nonce)
+	if err := os.WriteFile(sessionPath, []byte("codex-ttys001\r\n"+rt.ProjectPathKey("proj-whoami")+"\r\n"), 0o600); err != nil {
+		t.Fatalf("rewrite CRLF session mapping: %v", err)
+	}
+
+	stdout, stderr := executeRootCommandForTest(t, "whoami")
+	if stderr != "" {
+		t.Fatalf("whoami stderr = %q, want empty", stderr)
+	}
+
+	var resp struct {
+		OK         bool   `json:"ok"`
+		AgentName  string `json:"agent_name"`
+		ProjectKey string `json:"project_key"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &resp); err != nil {
+		t.Fatalf("unmarshal whoami response: %v", err)
+	}
+	if !resp.OK || resp.AgentName != "codex-ttys001" || resp.ProjectKey != rt.ProjectPathKey("proj-whoami") {
+		t.Fatalf("whoami response = %+v", resp)
+	}
+}
+
 func TestWhoamiFallsBackToTTYMapping(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("WAGGLE_AGENT_PPID", "")
-	t.Setenv("TTY", "/dev/ttyS009")
+	t.Setenv("TTY", "/dev/tty_U0")
 
 	runtimeDir := config.NewPaths("").RuntimeDir
 	nonce := "12345-1711843200000003"
-	if err := ia.WriteSessionMapping(runtimeDir, 12345, nonce, "codex-ttys009", "proj-whoami"); err != nil {
+	if err := ia.WriteSessionMapping(runtimeDir, 12345, nonce, "codex-tty_u0", "proj-whoami"); err != nil {
 		t.Fatalf("write session mapping: %v", err)
 	}
-	if err := ia.WriteTTYMapping(runtimeDir, "ttyS009", nonce); err != nil {
+	if err := ia.WriteTTYMapping(runtimeDir, "tty_U0", nonce); err != nil {
 		t.Fatalf("write tty mapping: %v", err)
 	}
 
@@ -311,14 +344,14 @@ func TestWhoamiFallsBackToTTYMapping(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &resp); err != nil {
 		t.Fatalf("unmarshal whoami response: %v", err)
 	}
-	if !resp.OK || resp.AgentName != "codex-ttys009" || resp.Source != "tty" {
+	if !resp.OK || resp.AgentName != "codex-tty_u0" || resp.Source != "tty" {
 		t.Fatalf("whoami response = %+v", resp)
 	}
 	if resp.PPID != "" {
 		t.Fatalf("whoami ppid = %q, want empty for tty-sourced lookup", resp.PPID)
 	}
-	if resp.TTY != "ttys009" {
-		t.Fatalf("whoami tty = %q, want ttys009", resp.TTY)
+	if resp.TTY != "tty_u0" {
+		t.Fatalf("whoami tty = %q, want tty_u0", resp.TTY)
 	}
 }
 

--- a/cmd/adapter_test.go
+++ b/cmd/adapter_test.go
@@ -281,6 +281,39 @@ func TestWhoamiReturnsMappedAgentIdentity(t *testing.T) {
 	}
 }
 
+func TestWhoamiFallsBackToTTYMapping(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("WAGGLE_AGENT_PPID", "")
+	t.Setenv("TTY", "/dev/ttys009")
+
+	runtimeDir := config.NewPaths("").RuntimeDir
+	nonce := "12345-1711843200000003"
+	if err := ia.WriteSessionMapping(runtimeDir, 12345, nonce, "codex-ttys009", "proj-whoami"); err != nil {
+		t.Fatalf("write session mapping: %v", err)
+	}
+	if err := ia.WriteTTYMapping(runtimeDir, "ttys009", nonce); err != nil {
+		t.Fatalf("write tty mapping: %v", err)
+	}
+
+	stdout, stderr := executeRootCommandForTest(t, "whoami")
+	if stderr != "" {
+		t.Fatalf("whoami stderr = %q, want empty", stderr)
+	}
+
+	var resp struct {
+		OK        bool   `json:"ok"`
+		AgentName string `json:"agent_name"`
+		Source    string `json:"source"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &resp); err != nil {
+		t.Fatalf("unmarshal whoami response: %v", err)
+	}
+	if !resp.OK || resp.AgentName != "codex-ttys009" || resp.Source != "tty" {
+		t.Fatalf("whoami response = %+v", resp)
+	}
+}
+
 func blockRuntimeDirForTest(t *testing.T, home string) {
 	t.Helper()
 	waggleDir := filepath.Join(home, ".waggle")

--- a/cmd/adapter_test.go
+++ b/cmd/adapter_test.go
@@ -285,14 +285,14 @@ func TestWhoamiFallsBackToTTYMapping(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("WAGGLE_AGENT_PPID", "")
-	t.Setenv("TTY", "/dev/ttys009")
+	t.Setenv("TTY", "/dev/ttyS009")
 
 	runtimeDir := config.NewPaths("").RuntimeDir
 	nonce := "12345-1711843200000003"
 	if err := ia.WriteSessionMapping(runtimeDir, 12345, nonce, "codex-ttys009", "proj-whoami"); err != nil {
 		t.Fatalf("write session mapping: %v", err)
 	}
-	if err := ia.WriteTTYMapping(runtimeDir, "ttys009", nonce); err != nil {
+	if err := ia.WriteTTYMapping(runtimeDir, "ttyS009", nonce); err != nil {
 		t.Fatalf("write tty mapping: %v", err)
 	}
 
@@ -305,12 +305,30 @@ func TestWhoamiFallsBackToTTYMapping(t *testing.T) {
 		OK        bool   `json:"ok"`
 		AgentName string `json:"agent_name"`
 		Source    string `json:"source"`
+		PPID      string `json:"ppid"`
+		TTY       string `json:"tty"`
 	}
 	if err := json.Unmarshal([]byte(stdout), &resp); err != nil {
 		t.Fatalf("unmarshal whoami response: %v", err)
 	}
 	if !resp.OK || resp.AgentName != "codex-ttys009" || resp.Source != "tty" {
 		t.Fatalf("whoami response = %+v", resp)
+	}
+	if resp.PPID != "" {
+		t.Fatalf("whoami ppid = %q, want empty for tty-sourced lookup", resp.PPID)
+	}
+	if resp.TTY != "ttys009" {
+		t.Fatalf("whoami tty = %q, want ttys009", resp.TTY)
+	}
+}
+
+func TestWhoamiRejectsArgs(t *testing.T) {
+	err := whoamiCmd.Args(whoamiCmd, []string{"extra"})
+	if err == nil {
+		t.Fatal("whoami Args accepted unexpected positional argument")
+	}
+	if !strings.Contains(err.Error(), "unknown command") {
+		t.Fatalf("whoami Args error = %v, want no-args error", err)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -107,7 +107,7 @@ func printErr(code, message string) {
 func isBrokerIndependentCommand(cmd *cobra.Command) bool {
 	for current := cmd; current != nil; current = current.Parent() {
 		switch current.Name() {
-		case "start", "install", "help", "version", "runtime", "adapter", "status":
+		case "start", "install", "help", "version", "runtime", "adapter", "status", "whoami":
 			return true
 		}
 	}

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -18,6 +18,7 @@ func init() {
 var whoamiCmd = &cobra.Command{
 	Use:   "whoami",
 	Short: "Show this shell's Waggle runtime identity",
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		runtimePaths := config.NewPaths("")
 		if runtimePaths.RuntimeDir == "" {
@@ -52,14 +53,20 @@ var whoamiCmd = &cobra.Command{
 			return nil
 		}
 
-		printJSON(map[string]any{
+		out := map[string]any{
 			"ok":          true,
 			"found":       true,
 			"agent_name":  lines[0],
 			"project_key": lines[1],
-			"ppid":        ppid,
 			"source":      source,
-		})
+		}
+		if source == "ppid" {
+			out["ppid"] = ppid
+		}
+		if source == "tty" {
+			out["tty"] = safeTTYToken(os.Getenv("TTY"))
+		}
+		printJSON(out)
 		return nil
 	},
 }
@@ -95,7 +102,7 @@ func safeTTYToken(tty string) string {
 	if !isSafeRuntimeToken(base) {
 		return ""
 	}
-	return base
+	return strings.ToLower(base)
 }
 
 func isSafeRuntimeToken(s string) bool {

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/seungpyoson/waggle/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(whoamiCmd)
+}
+
+var whoamiCmd = &cobra.Command{
+	Use:   "whoami",
+	Short: "Show this shell's Waggle runtime identity",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		runtimePaths := config.NewPaths("")
+		if runtimePaths.RuntimeDir == "" {
+			printJSON(map[string]any{"ok": false, "found": false, "reason": "HOME not set"})
+			return nil
+		}
+
+		ppid := os.Getenv("WAGGLE_AGENT_PPID")
+		if ppid == "" {
+			ppid = strconv.Itoa(os.Getppid())
+		}
+		if !isSafeRuntimeToken(ppid) {
+			printJSON(map[string]any{"ok": false, "found": false, "reason": "invalid WAGGLE_AGENT_PPID"})
+			return nil
+		}
+
+		nonceData, err := os.ReadFile(filepath.Join(runtimePaths.RuntimeDir, "agent-ppid-"+ppid))
+		if err != nil {
+			printJSON(map[string]any{"ok": false, "found": false, "reason": "no session mapping for parent process"})
+			return nil
+		}
+		nonce := strings.TrimSpace(string(nonceData))
+		if !isSafeRuntimeToken(nonce) {
+			printJSON(map[string]any{"ok": false, "found": false, "reason": "invalid session mapping"})
+			return nil
+		}
+
+		sessionData, err := os.ReadFile(filepath.Join(runtimePaths.RuntimeDir, "agent-session-"+nonce))
+		if err != nil {
+			printJSON(map[string]any{"ok": false, "found": false, "reason": "session mapping is stale"})
+			return nil
+		}
+		lines := strings.Split(strings.TrimRight(string(sessionData), "\n"), "\n")
+		if len(lines) < 2 || !isSafeRuntimeToken(lines[0]) || !isSafeRuntimeToken(lines[1]) {
+			printJSON(map[string]any{"ok": false, "found": false, "reason": "session mapping is malformed"})
+			return nil
+		}
+
+		printJSON(map[string]any{
+			"ok":          true,
+			"found":       true,
+			"agent_name":  lines[0],
+			"project_key": lines[1],
+			"ppid":        ppid,
+		})
+		return nil
+	},
+}
+
+func isSafeRuntimeToken(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '_' || r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -47,8 +47,14 @@ var whoamiCmd = &cobra.Command{
 			printJSON(map[string]any{"ok": false, "found": false, "reason": "session mapping is stale"})
 			return nil
 		}
-		lines := strings.Split(strings.TrimRight(string(sessionData), "\n"), "\n")
-		if len(lines) < 2 || !isSafeRuntimeToken(lines[0]) || !isSafeRuntimeToken(lines[1]) {
+		lines := strings.Split(strings.TrimSpace(string(sessionData)), "\n")
+		if len(lines) < 2 {
+			printJSON(map[string]any{"ok": false, "found": false, "reason": "session mapping is malformed"})
+			return nil
+		}
+		agentName := strings.TrimSpace(lines[0])
+		projectKey := strings.TrimSpace(lines[1])
+		if !isSafeRuntimeToken(agentName) || !isSafeRuntimeToken(projectKey) {
 			printJSON(map[string]any{"ok": false, "found": false, "reason": "session mapping is malformed"})
 			return nil
 		}
@@ -56,8 +62,8 @@ var whoamiCmd = &cobra.Command{
 		out := map[string]any{
 			"ok":          true,
 			"found":       true,
-			"agent_name":  lines[0],
-			"project_key": lines[1],
+			"agent_name":  agentName,
+			"project_key": projectKey,
 			"source":      source,
 		}
 		if source == "ppid" {

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -24,21 +25,17 @@ var whoamiCmd = &cobra.Command{
 			return nil
 		}
 
-		ppid := os.Getenv("WAGGLE_AGENT_PPID")
-		if ppid == "" {
-			ppid = strconv.Itoa(os.Getppid())
-		}
-		if !isSafeRuntimeToken(ppid) {
+		ppid := currentAgentPPID()
+		if ppid != "" && !isSafeRuntimeToken(ppid) {
 			printJSON(map[string]any{"ok": false, "found": false, "reason": "invalid WAGGLE_AGENT_PPID"})
 			return nil
 		}
 
-		nonceData, err := os.ReadFile(filepath.Join(runtimePaths.RuntimeDir, "agent-ppid-"+ppid))
+		nonce, source, err := readCurrentSessionNonce(runtimePaths.RuntimeDir, ppid, os.Getenv("TTY"))
 		if err != nil {
-			printJSON(map[string]any{"ok": false, "found": false, "reason": "no session mapping for parent process"})
+			printJSON(map[string]any{"ok": false, "found": false, "reason": err.Error()})
 			return nil
 		}
-		nonce := strings.TrimSpace(string(nonceData))
 		if !isSafeRuntimeToken(nonce) {
 			printJSON(map[string]any{"ok": false, "found": false, "reason": "invalid session mapping"})
 			return nil
@@ -61,9 +58,44 @@ var whoamiCmd = &cobra.Command{
 			"agent_name":  lines[0],
 			"project_key": lines[1],
 			"ppid":        ppid,
+			"source":      source,
 		})
 		return nil
 	},
+}
+
+func currentAgentPPID() string {
+	ppid := os.Getenv("WAGGLE_AGENT_PPID")
+	if ppid == "" {
+		ppid = strconv.Itoa(os.Getppid())
+	}
+	return ppid
+}
+
+func readCurrentSessionNonce(runtimeDir, ppid, tty string) (string, string, error) {
+	if ppid != "" && isSafeRuntimeToken(ppid) {
+		if data, err := os.ReadFile(filepath.Join(runtimeDir, "agent-ppid-"+ppid)); err == nil {
+			return strings.TrimSpace(string(data)), "ppid", nil
+		}
+	}
+	if ttyName := safeTTYToken(tty); ttyName != "" {
+		if data, err := os.ReadFile(filepath.Join(runtimeDir, "agent-tty-"+ttyName)); err == nil {
+			return strings.TrimSpace(string(data)), "tty", nil
+		}
+	}
+	return "", "", fmt.Errorf("no session mapping for parent process or TTY")
+}
+
+func safeTTYToken(tty string) string {
+	tty = strings.TrimSpace(tty)
+	if tty == "" {
+		return ""
+	}
+	base := filepath.Base(tty)
+	if !isSafeRuntimeToken(base) {
+		return ""
+	}
+	return base
 }
 
 func isSafeRuntimeToken(s string) bool {

--- a/docs/durable-bootstrap-handoff.md
+++ b/docs/durable-bootstrap-handoff.md
@@ -34,7 +34,9 @@ which reads a named inbox without connecting as that name.
 
 This PR implements the safe broker-side foundation:
 
-- `CmdReplay` reads a named inbox without session registration.
+- `CmdReplay` reads a named inbox without session registration and without
+  marking messages seen; runtime catch-up ACKs each delivered message after the
+  handler accepts it.
 - runtime CatchUp ACKs each successfully handled replayed broker message, so
   broker inbox replay does not grow without bound for runtime-managed agents.
 - runtime CatchUp uses `CmdReplay`, so it no longer competes with an active

--- a/docs/durable-bootstrap-handoff.md
+++ b/docs/durable-bootstrap-handoff.md
@@ -1,0 +1,44 @@
+# Durable Bootstrap Handoff
+
+## Current Failure Modes
+
+Waggle now has two delivery paths:
+
+- broker inbox replay, used by runtime catch-up
+- runtime signal files, used by adapter shell hooks
+
+The remaining durability risks are:
+
+1. A consumer can read unread runtime delivery records and crash after the local
+   store transition but before the agent has actually consumed the context.
+2. Multiple bootstrap consumers for the same agent can race unless one store
+   transition claims ownership before surfacing records.
+3. Broker catch-up previously had to connect as `<agent>-push`, which could
+   collide with an active listener and left a disconnect/reconnect gap.
+
+## Chosen Direction
+
+Use a single lifecycle for future durable bootstrap handoff:
+
+1. Claim unread runtime records with an expiring lease.
+2. Surface only claimed records to the adapter.
+3. Dismiss records only after an explicit adapter ACK.
+4. Reclaim expired claims so crashed consumers do not strand records.
+
+This requires store changes for claim ownership and expiry. It does not require
+agents to hold broker session identity while replaying historical inbox state.
+Broker replay is now separated from session registration through `CmdReplay`,
+which reads a named inbox without connecting as that name.
+
+## Current Implementation Boundary
+
+This PR implements the safe broker-side foundation:
+
+- `CmdReplay` reads a named inbox without session registration.
+- runtime CatchUp uses `CmdReplay`, so it no longer competes with an active
+  `<agent>-push` listener.
+- adapter bootstrap writes both PPID and TTY mappings, so pushed signal files
+  are discoverable when later command shells have a different PPID.
+
+Claim/lease/ACK for local bootstrap records is intentionally not fused into this
+PR. It needs a runtime store migration and a new adapter ACK contract.

--- a/docs/durable-bootstrap-handoff.md
+++ b/docs/durable-bootstrap-handoff.md
@@ -35,10 +35,12 @@ which reads a named inbox without connecting as that name.
 This PR implements the safe broker-side foundation:
 
 - `CmdReplay` reads a named inbox without session registration.
+- runtime CatchUp ACKs each successfully handled replayed broker message, so
+  broker inbox replay does not grow without bound for runtime-managed agents.
 - runtime CatchUp uses `CmdReplay`, so it no longer competes with an active
   `<agent>-push` listener.
 - adapter bootstrap writes both PPID and TTY mappings, so pushed signal files
   are discoverable when later command shells have a different PPID.
 
-Claim/lease/ACK for local bootstrap records is intentionally not fused into this
-PR. It needs a runtime store migration and a new adapter ACK contract.
+Claim/lease/ACK for local runtime bootstrap records is intentionally not fused
+into this PR. It needs a runtime store migration and a new adapter ACK contract.

--- a/integrations/auggie/RULE-block.md
+++ b/integrations/auggie/RULE-block.md
@@ -4,4 +4,4 @@ At the start of every session, run:
 
   WAGGLE_AGENT_PPID=$PPID waggle adapter bootstrap auggie --format markdown
 
-If waggle is not installed or the command fails, continue normally. Use the agent name from the output for any subsequent waggle commands in this session.
+If waggle is not installed or the command fails, continue normally. Use the agent name from the output for any subsequent waggle commands in this session. If you need to rediscover your identity later, run `waggle whoami`.

--- a/integrations/augment/SKILL-block.md
+++ b/integrations/augment/SKILL-block.md
@@ -6,7 +6,7 @@ At the start of every session, run:
 
 What to do with the result:
 
-1. If the command succeeds, note the `Agent:` value from the output and use it for any subsequent waggle commands in this session.
+1. If the command succeeds, note the `Agent:` value from the output and use it for any subsequent waggle commands in this session. If you need to rediscover it later, run `waggle whoami`.
 2. If the command fails or waggle is not installed, continue normally — this is not an error.
 
 Do not start background listeners or invent a separate transport path. The bootstrap command is the single entry point for waggle coordination.

--- a/integrations/claude-code/skills/waggle.md
+++ b/integrations/claude-code/skills/waggle.md
@@ -8,9 +8,9 @@ Available commands:
 - `/waggle inbox` — check your messages
 - `/waggle ack <id>` — acknowledge a message
 - `/waggle status` — broker status and queue health
+- `waggle whoami` — show this session's Waggle runtime identity
 - `/waggle claim` — claim next available task
 - `/waggle done <task_id> <result>` — complete a claimed task
 - `/waggle presence` — who's connected
 
-Your agent name is `${WAGGLE_AGENT_NAME}` (set by waggle spawn or environment).
-
+Your agent name is `${WAGGLE_AGENT_NAME}` when set by waggle spawn or environment. If it is missing, run `waggle whoami` to read the runtime mapping used for pushed message delivery.

--- a/integrations/claude-code/waggle-push.js
+++ b/integrations/claude-code/waggle-push.js
@@ -16,7 +16,7 @@ if (!/^\d+$/.test(ppid)) process.exit(0);
 try {
     let pointerFile = path.join(rtDir, 'agent-ppid-' + ppid);
     if (!fs.existsSync(pointerFile)) {
-        const tty = path.basename(process.env.TTY || '');
+        const tty = path.basename(process.env.TTY || '').toLowerCase();
         if (!/^[a-zA-Z0-9_-]+$/.test(tty)) process.exit(0);
         pointerFile = path.join(rtDir, 'agent-tty-' + tty);
         if (!fs.existsSync(pointerFile)) process.exit(0);

--- a/integrations/claude-code/waggle-push.js
+++ b/integrations/claude-code/waggle-push.js
@@ -12,10 +12,15 @@ const rtDir = path.join(home, '.waggle', 'runtime');
 // Use WAGGLE_PPID (agent PID) not process.ppid (intermediate shell PID)
 const ppid = process.env.WAGGLE_PPID || String(process.ppid);
 if (!/^\d+$/.test(ppid)) process.exit(0);
-const pointerFile = path.join(rtDir, 'agent-ppid-' + ppid);
 
 try {
-    if (!fs.existsSync(pointerFile)) process.exit(0);
+    let pointerFile = path.join(rtDir, 'agent-ppid-' + ppid);
+    if (!fs.existsSync(pointerFile)) {
+        const tty = path.basename(process.env.TTY || '');
+        if (!/^[a-zA-Z0-9_-]+$/.test(tty)) process.exit(0);
+        pointerFile = path.join(rtDir, 'agent-tty-' + tty);
+        if (!fs.existsSync(pointerFile)) process.exit(0);
+    }
 
     const nonce = fs.readFileSync(pointerFile, 'utf8').trim();
     if (!nonce) process.exit(0);

--- a/integrations/codex/AGENTS-block.md
+++ b/integrations/codex/AGENTS-block.md
@@ -4,4 +4,4 @@ At the start of every session, run:
 
   WAGGLE_AGENT_PPID=$PPID waggle adapter bootstrap codex --format markdown
 
-Do not skip this step. If the command fails or waggle is not installed, continue normally. Use the agent name from the output for any subsequent waggle commands in this session.
+Do not skip this step. If the command fails or waggle is not installed, continue normally. Use the agent name from the output for any subsequent waggle commands in this session. If you need to rediscover your identity later, run `waggle whoami`; it reads the same runtime mapping used for pushed message delivery.

--- a/integrations/codex/skills/waggle-runtime/SKILL.md
+++ b/integrations/codex/skills/waggle-runtime/SKILL.md
@@ -16,7 +16,7 @@ waggle adapter bootstrap codex --format markdown
 What to do with the result:
 
 1. Read the returned unread records and incorporate them into the current context.
-2. Note the `Agent:` value from the output and reuse it for later Waggle commands in this session by prefixing them with `WAGGLE_AGENT_NAME="<agent>"` when needed.
+2. Note the `Agent:` value from the output and reuse it for later Waggle commands in this session by prefixing them with `WAGGLE_AGENT_NAME="<agent>"` when needed. If you lose it, run `waggle whoami`.
 3. If the command reports that Waggle is unavailable or the current directory is not a Waggle-capable project, continue normally without treating that as a failure.
 
 Do not start background listeners or invent a separate transport path. The bootstrap command is the authoritative runtime-backed participation entry point.

--- a/integrations/gemini/GEMINI-block.md
+++ b/integrations/gemini/GEMINI-block.md
@@ -4,4 +4,4 @@ At the start of every session, run:
 
     WAGGLE_AGENT_PPID=$PPID waggle adapter bootstrap gemini --format markdown
 
-Do not skip this step. If waggle is not installed, the command will fail silently — continue normally. Use the agent name from the output for any subsequent waggle commands in this session.
+Do not skip this step. If waggle is not installed, the command will fail silently — continue normally. Use the agent name from the output for any subsequent waggle commands in this session. If you need to rediscover your identity later, run `waggle whoami`.

--- a/internal/adapter/bootstrap.go
+++ b/internal/adapter/bootstrap.go
@@ -51,7 +51,8 @@ func Bootstrap(input BootstrapInput) (BootstrapResult, error) {
 		return BootstrapResult{Tool: tool, Skipped: true, SkipReason: err.Error()}, nil
 	}
 
-	agentName := ResolveAgentName(tool, input.AgentName, resolveTTY(), os.Getppid(), os.Getpid())
+	tty := resolveTTY()
+	agentName := ResolveAgentName(tool, input.AgentName, tty, os.Getppid(), os.Getpid())
 	source := input.Source
 	if source == "" {
 		source = tool + "-adapter"
@@ -97,6 +98,11 @@ func Bootstrap(input BootstrapInput) (BootstrapResult, error) {
 	if err := WriteSessionMapping(runtimePaths.RuntimeDir, ppid, nonce, agentName, projectID); err != nil {
 		log.Printf("warning: write session mapping failed: %v; push delivery degraded", err)
 	}
+	if ttyName := sanitizeTTY(tty); ttyName != "" {
+		if err := WriteTTYMapping(runtimePaths.RuntimeDir, ttyName, nonce); err != nil {
+			log.Printf("warning: write TTY session mapping failed: %v; push delivery degraded", err)
+		}
+	}
 
 	records, err := store.Unread(projectID, agentName)
 	if err != nil {
@@ -113,6 +119,18 @@ func Bootstrap(input BootstrapInput) (BootstrapResult, error) {
 
 	result.Records = records
 	return result, nil
+}
+
+func WriteTTYMapping(runtimeDir, ttyName, nonce string) error {
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		return err
+	}
+	ttyName = sanitizeToken(ttyName)
+	if ttyName == "" {
+		return fmt.Errorf("tty name required")
+	}
+	ttyPath := filepath.Join(runtimeDir, "agent-tty-"+ttyName)
+	return writeRuntimeFileAtomic(ttyPath, []byte(nonce+"\n"), 0o600)
 }
 
 func skipRuntimeStore(result BootstrapResult, err error) BootstrapResult {

--- a/internal/adapter/bootstrap.go
+++ b/internal/adapter/bootstrap.go
@@ -125,7 +125,7 @@ func WriteTTYMapping(runtimeDir, ttyName, nonce string) error {
 	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
 		return err
 	}
-	ttyName = sanitizeToken(ttyName)
+	ttyName = sanitizeRuntimeToken(ttyName)
 	if ttyName == "" {
 		return fmt.Errorf("tty name required")
 	}
@@ -240,7 +240,21 @@ func sanitizeTTY(tty string) string {
 	if base == "." || base == string(filepath.Separator) || base == "" {
 		return ""
 	}
-	return sanitizeToken(base)
+	return sanitizeRuntimeToken(base)
+}
+
+func sanitizeRuntimeToken(v string) string {
+	v = strings.ToLower(strings.TrimSpace(v))
+	if v == "" {
+		return ""
+	}
+	for _, r := range v {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '_' || r == '-' {
+			continue
+		}
+		return ""
+	}
+	return v
 }
 
 // WriteSessionMapping writes the PPID pointer and unique session mapping for hook discovery.

--- a/internal/adapter/bootstrap_test.go
+++ b/internal/adapter/bootstrap_test.go
@@ -60,6 +60,13 @@ func TestResolveAgentNameSanitizesTTY(t *testing.T) {
 	}
 }
 
+func TestSanitizeTTYPreservesUnderscore(t *testing.T) {
+	got := sanitizeTTY("/dev/tty_U0")
+	if got != "tty_u0" {
+		t.Fatalf("sanitizeTTY() = %q, want tty_u0", got)
+	}
+}
+
 func TestShouldSkipRuntimeStartForTestHonorsEnvUnderTestBinary(t *testing.T) {
 	t.Setenv("WAGGLE_ADAPTER_SKIP_RUNTIME_START", "1")
 
@@ -247,6 +254,21 @@ func TestWriteTTYMapping(t *testing.T) {
 		t.Fatal(err)
 	}
 	data, err := os.ReadFile(filepath.Join(dir, "agent-tty-ttys009"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != nonce+"\n" {
+		t.Fatalf("tty mapping = %q, want %q", string(data), nonce+"\\n")
+	}
+}
+
+func TestWriteTTYMappingPreservesUnderscore(t *testing.T) {
+	dir := t.TempDir()
+	nonce := "12345-1711843200000000003"
+	if err := WriteTTYMapping(dir, "tty_U0", nonce); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "agent-tty-tty_u0"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/adapter/bootstrap_test.go
+++ b/internal/adapter/bootstrap_test.go
@@ -240,6 +240,51 @@ func TestWriteSessionMapping(t *testing.T) {
 	}
 }
 
+func TestWriteTTYMapping(t *testing.T) {
+	dir := t.TempDir()
+	nonce := "12345-1711843200000000003"
+	if err := WriteTTYMapping(dir, "ttys009", nonce); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "agent-tty-ttys009"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != nonce+"\n" {
+		t.Fatalf("tty mapping = %q, want %q", string(data), nonce+"\\n")
+	}
+}
+
+func TestBootstrapWritesTTYMappingFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("TTY", "/dev/ttys009")
+	t.Setenv("WAGGLE_PROJECT_ID", "proj-tty")
+	t.Setenv("WAGGLE_ADAPTER_SKIP_RUNTIME_START", "1")
+
+	result, err := Bootstrap(BootstrapInput{Tool: "codex"})
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if result.AgentName != "codex-ttys009" {
+		t.Fatalf("AgentName = %q, want codex-ttys009", result.AgentName)
+	}
+
+	runtimeDir := config.NewPaths("").RuntimeDir
+	data, err := os.ReadFile(filepath.Join(runtimeDir, "agent-tty-ttys009"))
+	if err != nil {
+		t.Fatalf("read tty mapping: %v", err)
+	}
+	nonce := strings.TrimSpace(string(data))
+	sessionData, err := os.ReadFile(filepath.Join(runtimeDir, "agent-session-"+nonce))
+	if err != nil {
+		t.Fatalf("read session mapping: %v", err)
+	}
+	if !strings.Contains(string(sessionData), "codex-ttys009\n") {
+		t.Fatalf("session mapping = %q, want agent name", sessionData)
+	}
+}
+
 func TestWriteSessionMapping_NoncesAreDifferent(t *testing.T) {
 	dir := t.TempDir()
 	ppid := 12345

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -900,23 +900,32 @@ func TestBroker_ReplayReadsNamedInboxWithoutSessionRegistration(t *testing.T) {
 
 	sender := connectClient(t, sockPath)
 	defer sender.Close()
-	resp, _ := sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	resp, err := sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	if err != nil {
+		t.Fatalf("sender connect request: %v", err)
+	}
 	if !resp.OK {
 		t.Fatalf("sender connect failed: %s", resp.Error)
 	}
 
 	recipient := connectClient(t, sockPath)
 	defer recipient.Close()
-	resp, _ = recipient.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	resp, err = recipient.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	if err != nil {
+		t.Fatalf("recipient connect request: %v", err)
+	}
 	if !resp.OK {
 		t.Fatalf("recipient connect failed: %s", resp.Error)
 	}
 
-	resp, _ = sender.Send(protocol.Request{
+	resp, err = sender.Send(protocol.Request{
 		Cmd:     protocol.CmdSend,
 		Name:    "bob",
 		Message: "replay without session collision",
 	})
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
 	if !resp.OK {
 		t.Fatalf("send failed: %s", resp.Error)
 	}
@@ -926,7 +935,10 @@ func TestBroker_ReplayReadsNamedInboxWithoutSessionRegistration(t *testing.T) {
 
 	replay := connectClient(t, sockPath)
 	defer replay.Close()
-	resp, _ = replay.Send(protocol.Request{Cmd: protocol.CmdReplay, Name: "bob"})
+	resp, err = replay.Send(protocol.Request{Cmd: protocol.CmdReplay, Name: "bob"})
+	if err != nil {
+		t.Fatalf("replay request: %v", err)
+	}
 	if !resp.OK {
 		t.Fatalf("replay failed: %s: %s", resp.Code, resp.Error)
 	}
@@ -938,7 +950,10 @@ func TestBroker_ReplayReadsNamedInboxWithoutSessionRegistration(t *testing.T) {
 		t.Fatalf("replay messages = %+v", messages)
 	}
 
-	resp, _ = recipient.Send(protocol.Request{Cmd: protocol.CmdPresence})
+	resp, err = recipient.Send(protocol.Request{Cmd: protocol.CmdPresence})
+	if err != nil {
+		t.Fatalf("recipient presence request: %v", err)
+	}
 	if !resp.OK {
 		t.Fatalf("recipient session was disrupted by replay: %s", resp.Error)
 	}
@@ -950,12 +965,18 @@ func TestBroker_AckCanTargetNamedInboxWithoutSessionRegistration(t *testing.T) {
 
 	sender := connectClient(t, sockPath)
 	defer sender.Close()
-	resp, _ := sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	resp, err := sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	if err != nil {
+		t.Fatalf("sender connect request: %v", err)
+	}
 	if !resp.OK {
 		t.Fatalf("sender connect failed: %s", resp.Error)
 	}
 
-	resp, _ = sender.Send(protocol.Request{Cmd: protocol.CmdSend, Name: "bob", Message: "ack by name"})
+	resp, err = sender.Send(protocol.Request{Cmd: protocol.CmdSend, Name: "bob", Message: "ack by name"})
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
 	if !resp.OK {
 		t.Fatalf("send failed: %s", resp.Error)
 	}
@@ -968,12 +989,18 @@ func TestBroker_AckCanTargetNamedInboxWithoutSessionRegistration(t *testing.T) {
 
 	ack := connectClient(t, sockPath)
 	defer ack.Close()
-	resp, _ = ack.Send(protocol.Request{Cmd: protocol.CmdAck, Name: "bob", MessageID: msg.ID})
+	resp, err = ack.Send(protocol.Request{Cmd: protocol.CmdAck, Name: "bob", MessageID: msg.ID})
+	if err != nil {
+		t.Fatalf("ack request: %v", err)
+	}
 	if !resp.OK {
 		t.Fatalf("ack failed: %s: %s", resp.Code, resp.Error)
 	}
 
-	resp, _ = ack.Send(protocol.Request{Cmd: protocol.CmdReplay, Name: "bob"})
+	resp, err = ack.Send(protocol.Request{Cmd: protocol.CmdReplay, Name: "bob"})
+	if err != nil {
+		t.Fatalf("replay request: %v", err)
+	}
 	if !resp.OK {
 		t.Fatalf("replay failed: %s: %s", resp.Code, resp.Error)
 	}

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -894,6 +894,56 @@ func TestBroker_SendMessage(t *testing.T) {
 	}
 }
 
+func TestBroker_ReplayReadsNamedInboxWithoutSessionRegistration(t *testing.T) {
+	sockPath, _, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	sender := connectClient(t, sockPath)
+	defer sender.Close()
+	resp, _ := sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	if !resp.OK {
+		t.Fatalf("sender connect failed: %s", resp.Error)
+	}
+
+	recipient := connectClient(t, sockPath)
+	defer recipient.Close()
+	resp, _ = recipient.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	if !resp.OK {
+		t.Fatalf("recipient connect failed: %s", resp.Error)
+	}
+
+	resp, _ = sender.Send(protocol.Request{
+		Cmd:     protocol.CmdSend,
+		Name:    "bob",
+		Message: "replay without session collision",
+	})
+	if !resp.OK {
+		t.Fatalf("send failed: %s", resp.Error)
+	}
+	if _, err := recipient.Receive(); err != nil {
+		t.Fatalf("receive push: %v", err)
+	}
+
+	replay := connectClient(t, sockPath)
+	defer replay.Close()
+	resp, _ = replay.Send(protocol.Request{Cmd: protocol.CmdReplay, Name: "bob"})
+	if !resp.OK {
+		t.Fatalf("replay failed: %s: %s", resp.Code, resp.Error)
+	}
+	var messages []map[string]interface{}
+	if err := json.Unmarshal(resp.Data, &messages); err != nil {
+		t.Fatalf("unmarshal replay: %v", err)
+	}
+	if len(messages) != 1 || messages[0]["body"] != "replay without session collision" {
+		t.Fatalf("replay messages = %+v", messages)
+	}
+
+	resp, _ = recipient.Send(protocol.Request{Cmd: protocol.CmdPresence})
+	if !resp.OK {
+		t.Fatalf("recipient session was disrupted by replay: %s", resp.Error)
+	}
+}
+
 // TestBroker_SendPushDelivery — client2 connected, receives push immediately on send
 func TestBroker_SendPushDelivery(t *testing.T) {
 	sockPath, _, cleanup := startTestBroker(t)

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -944,6 +944,48 @@ func TestBroker_ReplayReadsNamedInboxWithoutSessionRegistration(t *testing.T) {
 	}
 }
 
+func TestBroker_AckCanTargetNamedInboxWithoutSessionRegistration(t *testing.T) {
+	sockPath, _, cleanup := startTestBroker(t)
+	defer cleanup()
+
+	sender := connectClient(t, sockPath)
+	defer sender.Close()
+	resp, _ := sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	if !resp.OK {
+		t.Fatalf("sender connect failed: %s", resp.Error)
+	}
+
+	resp, _ = sender.Send(protocol.Request{Cmd: protocol.CmdSend, Name: "bob", Message: "ack by name"})
+	if !resp.OK {
+		t.Fatalf("send failed: %s", resp.Error)
+	}
+	var msg struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(resp.Data, &msg); err != nil {
+		t.Fatalf("unmarshal send: %v", err)
+	}
+
+	ack := connectClient(t, sockPath)
+	defer ack.Close()
+	resp, _ = ack.Send(protocol.Request{Cmd: protocol.CmdAck, Name: "bob", MessageID: msg.ID})
+	if !resp.OK {
+		t.Fatalf("ack failed: %s: %s", resp.Code, resp.Error)
+	}
+
+	resp, _ = ack.Send(protocol.Request{Cmd: protocol.CmdReplay, Name: "bob"})
+	if !resp.OK {
+		t.Fatalf("replay failed: %s: %s", resp.Code, resp.Error)
+	}
+	var messages []map[string]interface{}
+	if err := json.Unmarshal(resp.Data, &messages); err != nil {
+		t.Fatalf("unmarshal replay: %v", err)
+	}
+	if len(messages) != 0 {
+		t.Fatalf("replay after ack returned %d messages, want 0", len(messages))
+	}
+}
+
 // TestBroker_SendPushDelivery — client2 connected, receives push immediately on send
 func TestBroker_SendPushDelivery(t *testing.T) {
 	sockPath, _, cleanup := startTestBroker(t)

--- a/internal/broker/router.go
+++ b/internal/broker/router.go
@@ -24,6 +24,7 @@ var noSessionRequired = map[string]bool{
 	protocol.CmdStatus:      true,
 	protocol.CmdStop:        true,
 	protocol.CmdReplay:      true,
+	protocol.CmdAck:         true,
 	protocol.CmdPushReserve: true,
 	protocol.CmdPushRelease: true,
 }
@@ -792,7 +793,13 @@ func handleAck(s *Session, req protocol.Request) protocol.Response {
 		return protocol.ErrResponse(protocol.ErrInvalidRequest, "message_id required")
 	}
 
-	caller := strings.TrimSuffix(s.name, "-push")
+	caller := req.Name
+	if caller == "" {
+		caller = strings.TrimSuffix(s.name, "-push")
+	}
+	if caller == "" {
+		return protocol.ErrResponse(protocol.ErrInvalidRequest, "name required")
+	}
 	err := s.broker.msgStore.Ack(req.MessageID, caller)
 	if err != nil {
 		if errors.Is(err, messages.ErrMessageNotFound) {

--- a/internal/broker/router.go
+++ b/internal/broker/router.go
@@ -23,6 +23,7 @@ var noSessionRequired = map[string]bool{
 	protocol.CmdConnect:     true,
 	protocol.CmdStatus:      true,
 	protocol.CmdStop:        true,
+	protocol.CmdReplay:      true,
 	protocol.CmdPushReserve: true,
 	protocol.CmdPushRelease: true,
 }
@@ -75,6 +76,8 @@ func route(s *Session, req protocol.Request) protocol.Response {
 		return handleSend(s, req)
 	case protocol.CmdInbox:
 		return handleInbox(s, req)
+	case protocol.CmdReplay:
+		return handleReplay(s, req)
 	case protocol.CmdAck:
 		return handleAck(s, req)
 	case protocol.CmdPresence:
@@ -767,6 +770,17 @@ func handleSend(s *Session, req protocol.Request) protocol.Response {
 func handleInbox(s *Session, req protocol.Request) protocol.Response {
 	caller := strings.TrimSuffix(s.name, "-push")
 	messages, err := s.broker.msgStore.Inbox(caller)
+	if err != nil {
+		return protocol.ErrResponse(protocol.ErrInternalError, err.Error())
+	}
+	return protocol.OKResponse(mustMarshal(messages))
+}
+
+func handleReplay(s *Session, req protocol.Request) protocol.Response {
+	if req.Name == "" {
+		return protocol.ErrResponse(protocol.ErrInvalidRequest, "name required")
+	}
+	messages, err := s.broker.msgStore.Inbox(req.Name)
 	if err != nil {
 		return protocol.ErrResponse(protocol.ErrInternalError, err.Error())
 	}

--- a/internal/broker/router.go
+++ b/internal/broker/router.go
@@ -20,9 +20,12 @@ import (
 // Commands that work without a session handshake.
 // Everything else requires connect first.
 var noSessionRequired = map[string]bool{
-	protocol.CmdConnect:     true,
-	protocol.CmdStatus:      true,
-	protocol.CmdStop:        true,
+	protocol.CmdConnect: true,
+	protocol.CmdStatus:  true,
+	protocol.CmdStop:    true,
+	// Replay and ack are local-runtime catch-up commands. They deliberately
+	// avoid session registration so catch-up cannot collide with a live agent
+	// session; the broker socket is the local same-user trust boundary.
 	protocol.CmdReplay:      true,
 	protocol.CmdAck:         true,
 	protocol.CmdPushReserve: true,
@@ -781,7 +784,7 @@ func handleReplay(s *Session, req protocol.Request) protocol.Response {
 	if req.Name == "" {
 		return protocol.ErrResponse(protocol.ErrInvalidRequest, "name required")
 	}
-	messages, err := s.broker.msgStore.Inbox(req.Name)
+	messages, err := s.broker.msgStore.Replay(req.Name)
 	if err != nil {
 		return protocol.ErrResponse(protocol.ErrInternalError, err.Error())
 	}

--- a/internal/install/auggie/RULE-block.md
+++ b/internal/install/auggie/RULE-block.md
@@ -4,4 +4,4 @@ At the start of every session, run:
 
   WAGGLE_AGENT_PPID=$PPID waggle adapter bootstrap auggie --format markdown
 
-If waggle is not installed or the command fails, continue normally. Use the agent name from the output for any subsequent waggle commands in this session.
+If waggle is not installed or the command fails, continue normally. Use the agent name from the output for any subsequent waggle commands in this session. If you need to rediscover your identity later, run `waggle whoami`.

--- a/internal/install/augment/SKILL-block.md
+++ b/internal/install/augment/SKILL-block.md
@@ -6,7 +6,7 @@ At the start of every session, run:
 
 What to do with the result:
 
-1. If the command succeeds, note the `Agent:` value from the output and use it for any subsequent waggle commands in this session.
+1. If the command succeeds, note the `Agent:` value from the output and use it for any subsequent waggle commands in this session. If you need to rediscover it later, run `waggle whoami`.
 2. If the command fails or waggle is not installed, continue normally — this is not an error.
 
 Do not start background listeners or invent a separate transport path. The bootstrap command is the single entry point for waggle coordination.

--- a/internal/install/claude-code/skills/waggle.md
+++ b/internal/install/claude-code/skills/waggle.md
@@ -8,9 +8,9 @@ Available commands:
 - `/waggle inbox` — check your messages
 - `/waggle ack <id>` — acknowledge a message
 - `/waggle status` — broker status and queue health
+- `waggle whoami` — show this session's Waggle runtime identity
 - `/waggle claim` — claim next available task
 - `/waggle done <task_id> <result>` — complete a claimed task
 - `/waggle presence` — who's connected
 
-Your agent name is `${WAGGLE_AGENT_NAME}` (set by waggle spawn or environment).
-
+Your agent name is `${WAGGLE_AGENT_NAME}` when set by waggle spawn or environment. If it is missing, run `waggle whoami` to read the runtime mapping used for pushed message delivery.

--- a/internal/install/claude-code/waggle-push.js
+++ b/internal/install/claude-code/waggle-push.js
@@ -16,7 +16,7 @@ if (!/^\d+$/.test(ppid)) process.exit(0);
 try {
     let pointerFile = path.join(rtDir, 'agent-ppid-' + ppid);
     if (!fs.existsSync(pointerFile)) {
-        const tty = path.basename(process.env.TTY || '');
+        const tty = path.basename(process.env.TTY || '').toLowerCase();
         if (!/^[a-zA-Z0-9_-]+$/.test(tty)) process.exit(0);
         pointerFile = path.join(rtDir, 'agent-tty-' + tty);
         if (!fs.existsSync(pointerFile)) process.exit(0);

--- a/internal/install/claude-code/waggle-push.js
+++ b/internal/install/claude-code/waggle-push.js
@@ -12,10 +12,15 @@ const rtDir = path.join(home, '.waggle', 'runtime');
 // Use WAGGLE_PPID (agent PID) not process.ppid (intermediate shell PID)
 const ppid = process.env.WAGGLE_PPID || String(process.ppid);
 if (!/^\d+$/.test(ppid)) process.exit(0);
-const pointerFile = path.join(rtDir, 'agent-ppid-' + ppid);
 
 try {
-    if (!fs.existsSync(pointerFile)) process.exit(0);
+    let pointerFile = path.join(rtDir, 'agent-ppid-' + ppid);
+    if (!fs.existsSync(pointerFile)) {
+        const tty = path.basename(process.env.TTY || '');
+        if (!/^[a-zA-Z0-9_-]+$/.test(tty)) process.exit(0);
+        pointerFile = path.join(rtDir, 'agent-tty-' + tty);
+        if (!fs.existsSync(pointerFile)) process.exit(0);
+    }
 
     const nonce = fs.readFileSync(pointerFile, 'utf8').trim();
     if (!nonce) process.exit(0);

--- a/internal/install/claude_code_test.go
+++ b/internal/install/claude_code_test.go
@@ -307,6 +307,9 @@ func TestInstall_PushHookCreated(t *testing.T) {
 	if !strings.Contains(content, "agent-ppid-") {
 		t.Error("push hook missing agent-ppid- map file reference")
 	}
+	if !strings.Contains(content, "toLowerCase()") {
+		t.Error("push hook missing lowercase TTY fallback normalization")
+	}
 	if !strings.Contains(content, "additionalContext") {
 		t.Error("push hook missing additionalContext output")
 	}

--- a/internal/install/codex/AGENTS-block.md
+++ b/internal/install/codex/AGENTS-block.md
@@ -4,4 +4,4 @@ At the start of every session, run:
 
   WAGGLE_AGENT_PPID=$PPID waggle adapter bootstrap codex --format markdown
 
-Do not skip this step. If the command fails or waggle is not installed, continue normally. Use the agent name from the output for any subsequent waggle commands in this session.
+Do not skip this step. If the command fails or waggle is not installed, continue normally. Use the agent name from the output for any subsequent waggle commands in this session. If you need to rediscover your identity later, run `waggle whoami`; it reads the same runtime mapping used for pushed message delivery.

--- a/internal/install/codex/skills/waggle-runtime/SKILL.md
+++ b/internal/install/codex/skills/waggle-runtime/SKILL.md
@@ -16,7 +16,7 @@ waggle adapter bootstrap codex --format markdown
 What to do with the result:
 
 1. Read the returned unread records and incorporate them into the current context.
-2. Note the `Agent:` value from the output and reuse it for later Waggle commands in this session by prefixing them with `WAGGLE_AGENT_NAME="<agent>"` when needed.
+2. Note the `Agent:` value from the output and reuse it for later Waggle commands in this session by prefixing them with `WAGGLE_AGENT_NAME="<agent>"` when needed. If you lose it, run `waggle whoami`.
 3. If the command reports that Waggle is unavailable or the current directory is not a Waggle-capable project, continue normally without treating that as a failure.
 
 Do not start background listeners or invent a separate transport path. The bootstrap command is the authoritative runtime-backed participation entry point.

--- a/internal/install/gemini/GEMINI-block.md
+++ b/internal/install/gemini/GEMINI-block.md
@@ -4,4 +4,4 @@ At the start of every session, run:
 
     WAGGLE_AGENT_PPID=$PPID waggle adapter bootstrap gemini --format markdown
 
-Do not skip this step. If waggle is not installed, the command will fail silently — continue normally. Use the agent name from the output for any subsequent waggle commands in this session.
+Do not skip this step. If waggle is not installed, the command will fail silently — continue normally. Use the agent name from the output for any subsequent waggle commands in this session. If you need to rediscover your identity later, run `waggle whoami`.

--- a/internal/install/shell-hook/shell-hook.sh
+++ b/internal/install/shell-hook/shell-hook.sh
@@ -7,9 +7,19 @@ __waggle_check() {
     local _apid="${WAGGLE_AGENT_PPID:-$PPID}"
     case "$_apid" in *[!0-9]*) return 0 ;; esac
     local _pm="$_wd/agent-ppid-$_apid"
-    [ -f "$_pm" ] || return 0
     local _nonce
-    read -r _nonce < "$_pm" 2>/dev/null || return 0
+    if [ -f "$_pm" ]; then
+        read -r _nonce < "$_pm" 2>/dev/null || return 0
+    elif [ -n "${TTY-}" ]; then
+        local _tty="${TTY##*/}"
+        case "$_tty" in ""|*[!A-Za-z0-9_-]*) return 0 ;; esac
+        local _tm="$_wd/agent-tty-$_tty"
+        [ -f "$_tm" ] || return 0
+        read -r _nonce < "$_tm" 2>/dev/null || return 0
+        _pm="$_tm"
+    else
+        return 0
+    fi
     [ -n "$_nonce" ] || return 0
     local _sm="$_wd/agent-session-$_nonce"
     [ -f "$_sm" ] || return 0

--- a/internal/install/shell-hook/shell-hook.sh
+++ b/internal/install/shell-hook/shell-hook.sh
@@ -13,6 +13,7 @@ __waggle_check() {
     elif [ -n "${TTY-}" ]; then
         local _tty="${TTY##*/}"
         case "$_tty" in ""|*[!A-Za-z0-9_-]*) return 0 ;; esac
+        _tty="$(printf '%s' "$_tty" | tr '[:upper:]' '[:lower:]')"
         local _tm="$_wd/agent-tty-$_tty"
         [ -f "$_tm" ] || return 0
         read -r _nonce < "$_tm" 2>/dev/null || return 0

--- a/internal/install/shell_hook_test.go
+++ b/internal/install/shell_hook_test.go
@@ -85,6 +85,9 @@ func TestInstallShellHook_ScriptRefreshesBothMappings(t *testing.T) {
 	if !strings.Contains(content, ".c-") {
 		t.Fatal("shell hook should handle consumed orphan files")
 	}
+	if !strings.Contains(content, `tr '[:upper:]' '[:lower:]'`) {
+		t.Fatal("shell hook should normalize TTY fallback token to lowercase")
+	}
 }
 
 func TestInstallShellHook_ValidatesSessionTokens(t *testing.T) {

--- a/internal/messages/store.go
+++ b/internal/messages/store.go
@@ -227,6 +227,17 @@ func (s *Store) MarkExpired() (int, error) {
 // Inbox returns all queued, pushed, and seen messages for a recipient
 // Excludes expired messages and marks queued/pushed messages as seen
 func (s *Store) Inbox(name string) ([]*Message, error) {
+	return s.inbox(name, true)
+}
+
+// Replay returns all queued, pushed, and seen messages for a recipient without
+// changing message state. Runtime catch-up uses this before explicitly acking
+// delivered messages.
+func (s *Store) Replay(name string) ([]*Message, error) {
+	return s.inbox(name, false)
+}
+
+func (s *Store) inbox(name string, markSeen bool) ([]*Message, error) {
 	rows, err := s.db.Query(
 		`SELECT id, from_name, to_name, body, priority, ttl, state, created_at, pushed_at, seen_at, acked_at
 		 FROM messages
@@ -265,7 +276,7 @@ func (s *Store) Inbox(name string) ([]*Message, error) {
 		}
 
 		// Track messages that need to be marked as seen
-		if m.State == "queued" || m.State == "pushed" {
+		if markSeen && (m.State == "queued" || m.State == "pushed") {
 			idsToMarkSeen = append(idsToMarkSeen, m.ID)
 		}
 
@@ -338,4 +349,3 @@ func (s *Store) GetState(id int64) (string, error) {
 	}
 	return state, nil
 }
-

--- a/internal/messages/store_test.go
+++ b/internal/messages/store_test.go
@@ -440,6 +440,36 @@ func TestStore_InboxMarksSeen(t *testing.T) {
 	}
 }
 
+func TestStore_ReplayDoesNotMarkSeen(t *testing.T) {
+	s := newTestStore(t)
+
+	msg, _ := s.Send("alice", "bob", "hello", "", nil)
+	if err := s.MarkPushed(msg.ID); err != nil {
+		t.Fatalf("MarkPushed failed: %v", err)
+	}
+
+	messages, err := s.Replay("bob")
+	if err != nil {
+		t.Fatalf("Replay failed: %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("replay len = %d, want 1", len(messages))
+	}
+
+	var state string
+	var seenAt sql.NullString
+	err = s.db.QueryRow("SELECT state, seen_at FROM messages WHERE id = ?", msg.ID).Scan(&state, &seenAt)
+	if err != nil {
+		t.Fatalf("query message: %v", err)
+	}
+	if state != "pushed" {
+		t.Errorf("state = %q, want pushed", state)
+	}
+	if seenAt.Valid {
+		t.Errorf("seen_at = %q, want unset", seenAt.String)
+	}
+}
+
 // TestStore_PriorityStored — Send with priority=critical; inbox shows priority=critical
 func TestStore_PriorityStored(t *testing.T) {
 	s := newTestStore(t)

--- a/internal/protocol/codes.go
+++ b/internal/protocol/codes.go
@@ -25,6 +25,7 @@ const (
 
 	CmdSend     = "send"
 	CmdInbox    = "inbox"
+	CmdReplay   = "replay"
 	CmdAck      = "ack"
 	CmdPresence = "presence"
 

--- a/internal/protocol/message_test.go
+++ b/internal/protocol/message_test.go
@@ -187,6 +187,7 @@ func TestCommandConstants_Unique(t *testing.T) {
 		CmdTaskCreate, CmdTaskList, CmdTaskClaim, CmdTaskComplete, CmdTaskFail,
 		CmdTaskHeartbeat, CmdTaskCancel, CmdTaskGet, CmdTaskUpdate,
 		CmdLock, CmdUnlock, CmdLocks, CmdStatus, CmdStop,
+		CmdReplay,
 		CmdPushReserve, CmdPushRelease,
 	}
 

--- a/internal/runtime/listener.go
+++ b/internal/runtime/listener.go
@@ -48,56 +48,26 @@ func (f *BrokerListenerFactory) CatchUp(w Watch, handler DeliveryHandler) error 
 		return fmt.Errorf("cannot determine broker socket path")
 	}
 
-	pushToken, err := pushTokenForAgent(paths.Socket, w.AgentName)
-	if err != nil {
-		return err
-	}
-
 	c, err := client.Connect(paths.Socket, config.Defaults.ConnectTimeout)
 	if err != nil {
-		releasePushTokenForAgent(paths.Socket, w.AgentName, pushToken)
 		return err
 	}
-	connected := false
-	releaseOnReturn := true
-	defer func() {
-		// Clean disconnect prevents task requeue and lock release.
-		if connected {
-			sendDisconnect(c, fmt.Sprintf("catch-up %q/%q", w.ProjectID, w.AgentName))
-		}
-		c.Close()
-		if releaseOnReturn {
-			releasePushTokenForAgent(paths.Socket, w.AgentName, pushToken)
-		}
-	}()
+	defer c.Close()
 
-	// Set deadline for the entire catch-up operation (handshake + inbox + disconnect).
+	// Replay is no-session-required: CatchUp reads the named inbox without
+	// registering a competing <agent>-push session.
 	if err := c.SetDeadline(config.Defaults.ConnectTimeout); err != nil {
 		return fmt.Errorf("set deadline: %w", err)
 	}
 	resp, err := c.Send(protocol.Request{
-		Cmd:          protocol.CmdConnect,
-		Name:         w.AgentName + "-push",
-		PushListener: true,
-		PushToken:    pushToken,
+		Cmd:  protocol.CmdReplay,
+		Name: w.AgentName,
 	})
 	if err != nil {
 		return err
 	}
 	if !resp.OK {
-		// protocol.ErrAlreadyConnected is transient during restarts or duplicate workers;
-		// Manager.runWatch treats the returned Listen error as retryable and reconnects.
-		releaseOnReturn = false
-		return fmt.Errorf("%s: %s", resp.Code, resp.Error)
-	}
-	connected = true
-
-	resp, err = c.Send(protocol.Request{Cmd: protocol.CmdInbox})
-	if err != nil {
-		return err
-	}
-	if !resp.OK {
-		return fmt.Errorf("inbox: %s: %s", resp.Code, resp.Error)
+		return fmt.Errorf("replay: %s: %s", resp.Code, resp.Error)
 	}
 
 	var msgs []struct {

--- a/internal/runtime/listener.go
+++ b/internal/runtime/listener.go
@@ -95,6 +95,7 @@ func (f *BrokerListenerFactory) CatchUp(w Watch, handler DeliveryHandler) error 
 			SentAt:     sentAt,
 			ReceivedAt: time.Now().UTC(),
 		}); err != nil {
+			// Leave the message unacked so the next catch-up attempt can replay it.
 			return err
 		}
 		if err := ackReplayedMessage(c, w.AgentName, msg.ID); err != nil {

--- a/internal/runtime/listener.go
+++ b/internal/runtime/listener.go
@@ -69,6 +69,9 @@ func (f *BrokerListenerFactory) CatchUp(w Watch, handler DeliveryHandler) error 
 	if !resp.OK {
 		return fmt.Errorf("replay: %s: %s", resp.Code, resp.Error)
 	}
+	if err := c.ClearDeadline(); err != nil {
+		return fmt.Errorf("clear replay deadline: %w", err)
+	}
 
 	var msgs []struct {
 		ID        int64  `json:"id"`

--- a/internal/runtime/listener.go
+++ b/internal/runtime/listener.go
@@ -94,8 +94,26 @@ func (f *BrokerListenerFactory) CatchUp(w Watch, handler DeliveryHandler) error 
 		}); err != nil {
 			return err
 		}
+		if err := ackReplayedMessage(c, w.AgentName, msg.ID); err != nil {
+			return err
+		}
 	}
 
+	return nil
+}
+
+func ackReplayedMessage(c *client.Client, agentName string, messageID int64) error {
+	resp, err := c.Send(protocol.Request{
+		Cmd:       protocol.CmdAck,
+		Name:      agentName,
+		MessageID: messageID,
+	})
+	if err != nil {
+		return fmt.Errorf("ack replayed message %d: %w", messageID, err)
+	}
+	if !resp.OK {
+		return fmt.Errorf("ack replayed message %d: %s: %s", messageID, resp.Code, resp.Error)
+	}
 	return nil
 }
 

--- a/internal/runtime/listener_test.go
+++ b/internal/runtime/listener_test.go
@@ -243,7 +243,7 @@ func TestBrokerListenerFailedHandshakeDoesNotReleaseActiveListenerToken(t *testi
 	assertPushTokenStillAccepted(t, socketPath, active, "alice-push", token, "failed Listen handshake")
 }
 
-func TestBrokerListenerCatchUpFailedHandshakeDoesNotReleaseActiveListenerToken(t *testing.T) {
+func TestBrokerListenerCatchUpReadsWhileActiveListenerConnected(t *testing.T) {
 	socketPath, cleanup := startRuntimeTestBroker(t, "proj-catchup-duplicate")
 	defer cleanup()
 
@@ -272,17 +272,14 @@ func TestBrokerListenerCatchUpFailedHandshakeDoesNotReleaseActiveListenerToken(t
 		AgentName: "alice",
 		Source:    "hook",
 	}, func(d Delivery) error {
-		t.Fatal("duplicate catch-up unexpectedly received delivery")
+		t.Fatal("empty catch-up unexpectedly received delivery")
 		return nil
 	})
-	if err == nil {
-		t.Fatal("expected duplicate catch-up handshake to fail")
-	}
-	if !strings.Contains(err.Error(), string(protocol.ErrAlreadyConnected)) {
-		t.Fatalf("CatchUp() error = %v, want %s", err, protocol.ErrAlreadyConnected)
+	if err != nil {
+		t.Fatalf("CatchUp() error = %v", err)
 	}
 
-	assertPushTokenStillAccepted(t, socketPath, active, "alice-push", token, "failed CatchUp handshake")
+	assertPushTokenStillAccepted(t, socketPath, active, "alice-push", token, "CatchUp replay")
 }
 
 func TestBrokerListenerCatchUpReadsInboxWithoutBaseConnection(t *testing.T) {
@@ -334,7 +331,7 @@ func TestBrokerListenerCatchUpReadsInboxWithoutBaseConnection(t *testing.T) {
 	}
 }
 
-func TestBrokerListenerCatchUpReleasesPushToken(t *testing.T) {
+func TestBrokerListenerCatchUpDoesNotReleaseReservedPushToken(t *testing.T) {
 	socketPath, cleanup := startRuntimeTestBroker(t, "proj-catchup-release")
 	defer cleanup()
 
@@ -380,7 +377,8 @@ func TestBrokerListenerCatchUpReleasesPushToken(t *testing.T) {
 		t.Fatalf("CatchUp() deliveries = %d, want 1", len(got))
 	}
 
-	waitForPushTokenRejected(t, socketPath, "alice-push", token)
+	active := connectRuntimeClient(t, socketPath)
+	assertPushTokenStillAccepted(t, socketPath, active, "alice-push", token, "CatchUp replay")
 }
 
 func TestReleasePushTokenForAgentSuppressesAlreadyRevokedTokenWarning(t *testing.T) {

--- a/internal/runtime/listener_test.go
+++ b/internal/runtime/listener_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -455,6 +456,80 @@ func TestBrokerListenerCatchUpAcksPriorMessagesBeforeHandlerError(t *testing.T) 
 	}
 	if strings.Join(secondAttempt, ",") != "second" {
 		t.Fatalf("second attempt deliveries = %v, want only second", secondAttempt)
+	}
+}
+
+func TestBrokerListenerCatchUpContinuesAfterConcurrentAck(t *testing.T) {
+	socketPath, cleanup := startRuntimeTestBroker(t, "proj-catchup-concurrent-ack")
+	defer cleanup()
+
+	sender := connectRuntimeClient(t, socketPath)
+	defer sender.Close()
+	resp, err := sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "sender"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("sender connect failed: %s", resp.Error)
+	}
+	for _, body := range []string{"first", "second"} {
+		sendResp, err := sender.Send(protocol.Request{
+			Cmd:     protocol.CmdSend,
+			Name:    "alice",
+			Message: body,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !sendResp.OK {
+			t.Fatalf("send %q failed: %s", body, sendResp.Error)
+		}
+	}
+
+	var got []string
+	err = NewBrokerListenerFactory().CatchUp(Watch{
+		ProjectID: "proj-catchup-concurrent-ack",
+		AgentName: "alice",
+		Source:    "hook",
+	}, func(d Delivery) error {
+		got = append(got, d.Body)
+		if d.Body == "first" {
+			ack := connectRuntimeClient(t, socketPath)
+			defer ack.Close()
+			resp, err := ack.Send(protocol.Request{
+				Cmd:       protocol.CmdAck,
+				Name:      "alice",
+				MessageID: d.MessageID,
+			})
+			if err != nil {
+				return err
+			}
+			if !resp.OK {
+				return fmt.Errorf("concurrent ack failed: %s: %s", resp.Code, resp.Error)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("CatchUp() error = %v", err)
+	}
+	if strings.Join(got, ",") != "first,second" {
+		t.Fatalf("CatchUp() deliveries = %v, want first, second", got)
+	}
+
+	got = nil
+	if err := NewBrokerListenerFactory().CatchUp(Watch{
+		ProjectID: "proj-catchup-concurrent-ack",
+		AgentName: "alice",
+		Source:    "hook",
+	}, func(d Delivery) error {
+		got = append(got, d.Body)
+		return nil
+	}); err != nil {
+		t.Fatalf("second CatchUp() error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("second CatchUp() deliveries = %d, want 0 after ack", len(got))
 	}
 }
 

--- a/internal/runtime/listener_test.go
+++ b/internal/runtime/listener_test.go
@@ -396,6 +396,68 @@ func TestBrokerListenerCatchUpClearsReplayDeadlineBeforeAck(t *testing.T) {
 	}
 }
 
+func TestBrokerListenerCatchUpAcksPriorMessagesBeforeHandlerError(t *testing.T) {
+	socketPath, cleanup := startRuntimeTestBroker(t, "proj-catchup-handler-error")
+	defer cleanup()
+
+	sender := connectRuntimeClient(t, socketPath)
+	defer sender.Close()
+	resp, err := sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "sender"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("sender connect failed: %s", resp.Error)
+	}
+	for _, body := range []string{"first", "second"} {
+		sendResp, err := sender.Send(protocol.Request{
+			Cmd:     protocol.CmdSend,
+			Name:    "alice",
+			Message: body,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !sendResp.OK {
+			t.Fatalf("send %q failed: %s", body, sendResp.Error)
+		}
+	}
+
+	var firstAttempt []string
+	err = NewBrokerListenerFactory().CatchUp(Watch{
+		ProjectID: "proj-catchup-handler-error",
+		AgentName: "alice",
+		Source:    "hook",
+	}, func(d Delivery) error {
+		firstAttempt = append(firstAttempt, d.Body)
+		if d.Body == "second" {
+			return context.Canceled
+		}
+		return nil
+	})
+	if err == nil {
+		t.Fatal("CatchUp() error = nil, want handler error")
+	}
+	if strings.Join(firstAttempt, ",") != "first,second" {
+		t.Fatalf("first attempt deliveries = %v, want first, second", firstAttempt)
+	}
+
+	var secondAttempt []string
+	if err := NewBrokerListenerFactory().CatchUp(Watch{
+		ProjectID: "proj-catchup-handler-error",
+		AgentName: "alice",
+		Source:    "hook",
+	}, func(d Delivery) error {
+		secondAttempt = append(secondAttempt, d.Body)
+		return nil
+	}); err != nil {
+		t.Fatalf("second CatchUp() error = %v", err)
+	}
+	if strings.Join(secondAttempt, ",") != "second" {
+		t.Fatalf("second attempt deliveries = %v, want only second", secondAttempt)
+	}
+}
+
 func TestBrokerListenerCatchUpDoesNotReleaseReservedPushToken(t *testing.T) {
 	socketPath, cleanup := startRuntimeTestBroker(t, "proj-catchup-release")
 	defer cleanup()

--- a/internal/runtime/listener_test.go
+++ b/internal/runtime/listener_test.go
@@ -329,6 +329,21 @@ func TestBrokerListenerCatchUpReadsInboxWithoutBaseConnection(t *testing.T) {
 	if got[0].Body != "catch-up delivery" {
 		t.Fatalf("delivery.Body = %q, want %q", got[0].Body, "catch-up delivery")
 	}
+
+	got = nil
+	if err := NewBrokerListenerFactory().CatchUp(Watch{
+		ProjectID: "proj-catchup",
+		AgentName: "alice",
+		Source:    "hook",
+	}, func(d Delivery) error {
+		got = append(got, d)
+		return nil
+	}); err != nil {
+		t.Fatalf("second CatchUp() error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("second CatchUp() deliveries = %d, want 0 after ack", len(got))
+	}
 }
 
 func TestBrokerListenerCatchUpDoesNotReleaseReservedPushToken(t *testing.T) {

--- a/internal/runtime/listener_test.go
+++ b/internal/runtime/listener_test.go
@@ -346,6 +346,56 @@ func TestBrokerListenerCatchUpReadsInboxWithoutBaseConnection(t *testing.T) {
 	}
 }
 
+func TestBrokerListenerCatchUpClearsReplayDeadlineBeforeAck(t *testing.T) {
+	originalTimeout := config.Defaults.ConnectTimeout
+	shortTimeout := 25 * time.Millisecond
+	config.Defaults.ConnectTimeout = shortTimeout
+	t.Cleanup(func() {
+		config.Defaults.ConnectTimeout = originalTimeout
+	})
+
+	socketPath, cleanup := startRuntimeTestBroker(t, "proj-catchup-deadline")
+	defer cleanup()
+
+	sender := connectRuntimeClient(t, socketPath)
+	defer sender.Close()
+	resp, err := sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "sender"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Fatalf("sender connect failed: %s", resp.Error)
+	}
+
+	sendResp, err := sender.Send(protocol.Request{
+		Cmd:     protocol.CmdSend,
+		Name:    "alice",
+		Message: "slow catch-up delivery",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sendResp.OK {
+		t.Fatalf("send failed: %s", sendResp.Error)
+	}
+
+	var got []Delivery
+	if err := NewBrokerListenerFactory().CatchUp(Watch{
+		ProjectID: "proj-catchup-deadline",
+		AgentName: "alice",
+		Source:    "hook",
+	}, func(d Delivery) error {
+		time.Sleep(2 * shortTimeout)
+		got = append(got, d)
+		return nil
+	}); err != nil {
+		t.Fatalf("CatchUp() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("CatchUp() deliveries = %d, want 1", len(got))
+	}
+}
+
 func TestBrokerListenerCatchUpDoesNotReleaseReservedPushToken(t *testing.T) {
 	socketPath, cleanup := startRuntimeTestBroker(t, "proj-catchup-release")
 	defer cleanup()


### PR DESCRIPTION
## Summary

Closes #126.

Phase-one delivery identity/replay foundation only:

- Adds TTY-scoped runtime session mappings (`agent-tty-<tty>`) alongside existing PPID mappings.
- Updates shell hook and Claude Code `waggle-push.js` to fall back from PPID lookup to TTY lookup, fixing the observed class where later tool-call shells have a different PPID than the bootstrap shell.
- Updates `waggle whoami` to use the same PPID-or-TTY mapping resolution, reject positional args, and parse CRLF/trailing-whitespace session mappings robustly.
- Adds broker `CmdReplay` so runtime CatchUp can read a named inbox without registering as that agent or competing with an active `<agent>-push` listener.
- `CmdReplay` is non-mutating: it does not mark messages seen. Runtime CatchUp ACKs each successfully handled replayed broker message, bounding replay history for runtime-managed agents.
- Documents the local same-user broker-socket trust boundary for no-session replay/ack commands.
- Adds `docs/durable-bootstrap-handoff.md` to document the remaining durable local bootstrap handoff design boundary.

## Related, Not Closed

Related to #97, #98, and #107, but does not close them. Those are broader follow-up umbrellas and should be decomposed into additional narrow issues/PRs.

## Verification

- `go test ./cmd ./internal/adapter ./internal/runtime -run 'TestWhoami|TestSanitizeTTY|TestWriteTTYMapping|TestBrokerListenerCatchUpAcksPriorMessagesBeforeHandlerError' -count=1`
- `go test ./cmd ./internal/adapter ./internal/runtime ./internal/broker ./internal/messages -count=1`
- `git diff --check`

## Explicit Non-Goals

This PR does not prove #107 end-to-end across real Claude Code/Codex/Gemini/Auggie/Augment sessions, does not implement atomic replay+stream or pagination for all #98 criteria, and does not implement local runtime-store claim/lease/adapter-ACK migration for crash-proof #97 handoff.