### PR TITLE
feat: add GitHub release binaries workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -51,10 +51,13 @@ jobs:
           name="waggle-${GOOS}-${GOARCH}"
           go build \
             -trimpath \
-            -ldflags="-s -w -X github.com/seungpyoson/waggle/cmd.Version=${version} -X github.com/seungpyoson/waggle/cmd.Commit=${commit} -X github.com/seungpyoson/waggle/cmd.BuildTime=${built}" \
+            -ldflags="-s -w -X 'github.com/seungpyoson/waggle/cmd.Version=${version}' -X 'github.com/seungpyoson/waggle/cmd.Commit=${commit}' -X 'github.com/seungpyoson/waggle/cmd.BuildTime=${built}'" \
             -o "dist/${name}" \
             .
-          sha256sum "dist/${name}" > "dist/${name}.sha256"
+          (
+            cd dist
+            sha256sum "${name}" > "${name}.sha256"
+          )
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -68,6 +71,8 @@ jobs:
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -82,5 +87,6 @@ jobs:
           set -euo pipefail
           gh release create "$TAG" dist/* \
             --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
             --title "$TAG" \
             --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+name: release
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/release.yml"
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: build ${{ matrix.goos }}/${{ matrix.goarch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build binary
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME:-dev}"
+          commit="${GITHUB_SHA:-unknown}"
+          built="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          name="waggle-${GOOS}-${GOARCH}"
+          go build \
+            -trimpath \
+            -ldflags="-s -w -X github.com/seungpyoson/waggle/cmd.Version=${version} -X github.com/seungpyoson/waggle/cmd.Commit=${commit} -X github.com/seungpyoson/waggle/cmd.BuildTime=${built}" \
+            -o "dist/${name}" \
+            .
+          sha256sum "dist/${name}" > "dist/${name}.sha256"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: waggle-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/*
+          if-no-files-found: error
+
+  release:
+    name: publish GitHub release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Publish release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          gh release create "$TAG" dist/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$TAG" \
+            --generate-notes

--- a/README.md
+++ b/README.md
@@ -38,7 +38,24 @@ An orchestrator agent sends instructions. Worker agents receive them. Any agent 
 
 ### Pre-built binaries (recommended)
 
-Download from [GitHub Releases](https://github.com/seungpyoson/waggle/releases) — no Go required.
+Download from [GitHub Releases](https://github.com/seungpyoson/waggle/releases) — no Go required. Pick the binary for your OS and CPU:
+
+```bash
+# Apple Silicon macOS
+curl -L https://github.com/seungpyoson/waggle/releases/latest/download/waggle-darwin-arm64 -o waggle
+
+# Intel macOS
+curl -L https://github.com/seungpyoson/waggle/releases/latest/download/waggle-darwin-amd64 -o waggle
+
+# Linux x86_64
+curl -L https://github.com/seungpyoson/waggle/releases/latest/download/waggle-linux-amd64 -o waggle
+
+# Linux arm64
+curl -L https://github.com/seungpyoson/waggle/releases/latest/download/waggle-linux-arm64 -o waggle
+
+chmod +x waggle
+./waggle --help
+```
 
 ### From source
 

--- a/README.md
+++ b/README.md
@@ -41,18 +41,11 @@ An orchestrator agent sends instructions. Worker agents receive them. Any agent 
 Download from [GitHub Releases](https://github.com/seungpyoson/waggle/releases) — no Go required. Pick the binary for your OS and CPU:
 
 ```bash
-# Apple Silicon macOS
-curl -L https://github.com/seungpyoson/waggle/releases/latest/download/waggle-darwin-arm64 -o waggle
+# Choose one: waggle-darwin-arm64, waggle-darwin-amd64,
+# waggle-linux-amd64, or waggle-linux-arm64.
+WAGGLE_ASSET=waggle-darwin-arm64
 
-# Intel macOS
-curl -L https://github.com/seungpyoson/waggle/releases/latest/download/waggle-darwin-amd64 -o waggle
-
-# Linux x86_64
-curl -L https://github.com/seungpyoson/waggle/releases/latest/download/waggle-linux-amd64 -o waggle
-
-# Linux arm64
-curl -L https://github.com/seungpyoson/waggle/releases/latest/download/waggle-linux-arm64 -o waggle
-
+curl -L "https://github.com/seungpyoson/waggle/releases/latest/download/${WAGGLE_ASSET}" -o waggle
 chmod +x waggle
 ./waggle --help
 ```

--- a/cmd/listen.go
+++ b/cmd/listen.go
@@ -31,14 +31,12 @@ var listenCmd = &cobra.Command{
 		// When --output is set, this command typically runs backgrounded (e.g., from
 		// hooks). Redirect stderr to a .err file so errors don't corrupt the host
 		// terminal (TUI). This must happen BEFORE any printErr/fmt.Fprintf calls.
-		// Redirect both os.Stderr (Go-level) and fd 2 (OS-level) to catch all output.
+		// Redirect fd 2 so os.Stderr, log.Printf, and any C-level writes go to file.
 		if listenOutput != "" {
 			errFile, err := os.OpenFile(listenOutput+".err", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 			if err == nil {
-				os.Stderr = errFile
-				// Also redirect OS fd 2 so log.Printf and any C-level writes go to file
 				_ = unix.Dup2(int(errFile.Fd()), 2)
-				defer errFile.Close()
+				_ = errFile.Close()
 			}
 			// If errFile fails to open, keep original stderr — better than crashing
 		}

--- a/cmd/listen.go
+++ b/cmd/listen.go
@@ -7,6 +7,8 @@ import (
 	"syscall"
 	"time"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/spf13/cobra"
 )
 
@@ -35,7 +37,7 @@ var listenCmd = &cobra.Command{
 			if err == nil {
 				os.Stderr = errFile
 				// Also redirect OS fd 2 so log.Printf and any C-level writes go to file
-				syscall.Dup2(int(errFile.Fd()), 2)
+				_ = unix.Dup2(int(errFile.Fd()), 2)
 				defer errFile.Close()
 			}
 			// If errFile fails to open, keep original stderr — better than crashing
@@ -105,4 +107,3 @@ var listenCmd = &cobra.Command{
 		}
 	},
 }
-

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/seungpyoson/waggle
 
 go 1.26.1
 
-require modernc.org/sqlite v1.47.0
+require (
+	golang.org/x/sys v0.42.0
+	modernc.org/sqlite v1.47.0
+)
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
@@ -13,7 +16,6 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	modernc.org/libc v1.70.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect


### PR DESCRIPTION
## Summary

- add a tag-triggered GitHub Actions release workflow that builds raw binaries for darwin/linux on amd64/arm64
- upload binaries with the asset names documented in #40, plus `.sha256` files
- document direct release downloads in the README without copy-paste commands that overwrite each other
- replace `syscall.Dup2` with `x/sys/unix.Dup2` so Linux arm64 cross-compilation works
- list `golang.org/x/sys` as a direct module dependency because `cmd/listen.go` imports it directly

## Scope

Addresses #40 release automation. This PR does not add a Homebrew tap; it starts with GitHub release binaries as requested in the issue.

## Verification

- `go build -o /tmp/waggle-pr122 .`
- `go test ./... -count=1 -p=1`
- `go test ./e2e -run TestRuntimeRealProcessesReceiveWatchedAgentMessage -count=1 -p=1` after one flaky first run of that real-process E2E
- `go vet ./...`
- `git diff --check`

## Note

The GitHub Actions release matrix is also running on this PR branch. It must pass before merge.