### PR TITLE
test: tighten broker error handling cleanup

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,9 +47,9 @@ var (
 			if broker.IsRunning(paths.PID) {
 				if !broker.IsResponding(paths.Socket, config.Defaults.HealthCheckTimeout) {
 					if pid, err := broker.ReadPID(paths.PID); err == nil {
-						fmt.Fprintf(os.Stderr, "waggle: unresponsive broker (PID %d) detected, starting fresh instance\n", pid)
+						_, _ = fmt.Fprintf(os.Stderr, "waggle: unresponsive broker (PID %d) detected, starting fresh instance\n", pid) // best-effort: warning emission must not block recovery.
 					} else {
-						fmt.Fprintf(os.Stderr, "waggle: unresponsive broker detected, starting fresh instance\n")
+						_, _ = fmt.Fprintf(os.Stderr, "waggle: unresponsive broker detected, starting fresh instance\n") // best-effort: warning emission must not block recovery.
 					}
 					if err := os.Remove(paths.Socket); err != nil && !os.IsNotExist(err) {
 						return fmt.Errorf("removing stale socket: %w", err)
@@ -161,10 +161,10 @@ func isTimeoutError(err error) bool {
 
 func cleanupStaleFiles() {
 	if err := os.Remove(paths.Socket); err != nil && !os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "waggle: warning: failed to remove stale socket: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "waggle: warning: failed to remove stale socket: %v\n", err) // best-effort: timeout recovery can continue.
 	}
 	if err := os.Remove(paths.PID); err != nil && !os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "waggle: warning: failed to remove stale PID file: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "waggle: warning: failed to remove stale PID file: %v\n", err) // best-effort: timeout recovery can continue.
 	}
 }
 

--- a/e2e_zombie_test.go
+++ b/e2e_zombie_test.go
@@ -20,6 +20,16 @@ func computeHash(projectID string) string {
 	return fmt.Sprintf("%012x", h.Sum64()&0xffffffffffff)
 }
 
+func shortTempDir(t *testing.T, pattern string) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", pattern) // Use /tmp to keep derived Unix socket paths below the macOS 104-byte limit.
+	if err != nil {
+		t.Fatalf("mkdirtemp %s: %v", pattern, err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return dir
+}
+
 // setupZombie creates a zombie broker: a process (the test itself) that
 // listens on the correct socket path but never accepts connections.
 // It writes the current PID to the PID file.
@@ -57,8 +67,8 @@ func setupZombie(t *testing.T, tmpHome, projectID string) (net.Listener, func())
 
 	cleanup := func() {
 		ln.Close()
-		os.Remove(sockPath)
-		os.Remove(pidPath)
+		_ = os.Remove(sockPath) // best-effort: listener close normally removes the socket.
+		_ = os.Remove(pidPath)  // best-effort: temp HOME cleanup removes leftovers.
 	}
 	return ln, cleanup
 }
@@ -66,12 +76,7 @@ func setupZombie(t *testing.T, tmpHome, projectID string) (net.Listener, func())
 // buildBinary compiles the waggle binary into a temp dir and returns its path.
 func buildBinary(t *testing.T) string {
 	t.Helper()
-	// Place binary in /tmp to avoid long path issues
-	tmpBin, err := os.MkdirTemp("/tmp", "waggle-bin-*")
-	if err != nil {
-		t.Fatalf("mkdirtemp for bin: %v", err)
-	}
-	t.Cleanup(func() { os.RemoveAll(tmpBin) })
+	tmpBin := shortTempDir(t, "waggle-bin-*")
 
 	binPath := filepath.Join(tmpBin, "waggle")
 	build := exec.Command("go", "build", "-o", binPath, ".")
@@ -91,11 +96,7 @@ func TestE2E_ZombieAutoRecovery(t *testing.T) {
 
 	tmpBin := buildBinary(t)
 
-	tmpHome, err := os.MkdirTemp("/tmp", "waggle-zombie-*")
-	if err != nil {
-		t.Fatalf("mkdirtemp home: %v", err)
-	}
-	defer os.RemoveAll(tmpHome)
+	tmpHome := shortTempDir(t, "waggle-zombie-*")
 
 	const projectID = "zombie-recovery-test"
 
@@ -153,11 +154,7 @@ func TestE2E_ZombieFailFast_NoAutoStart(t *testing.T) {
 
 	tmpBin := buildBinary(t)
 
-	tmpHome, err := os.MkdirTemp("/tmp", "waggle-zombie-noauto-*")
-	if err != nil {
-		t.Fatalf("mkdirtemp home: %v", err)
-	}
-	defer os.RemoveAll(tmpHome)
+	tmpHome := shortTempDir(t, "waggle-zombie-noauto-*")
 
 	const projectID = "zombie-noauto-test"
 
@@ -218,11 +215,7 @@ func TestE2E_HealthyBrokerUnaffected(t *testing.T) {
 
 	tmpBin := buildBinary(t)
 
-	tmpHome, err := os.MkdirTemp("/tmp", "waggle-healthy-*")
-	if err != nil {
-		t.Fatalf("mkdirtemp home: %v", err)
-	}
-	defer os.RemoveAll(tmpHome)
+	tmpHome := shortTempDir(t, "waggle-healthy-*")
 
 	const projectID = "healthy-broker-test"
 
@@ -288,17 +281,8 @@ func TestE2E_HelpFromNonGitDir(t *testing.T) {
 
 	tmpBin := buildBinary(t)
 
-	nonGitDir, err := os.MkdirTemp("/tmp", "waggle-nongit-*")
-	if err != nil {
-		t.Fatalf("mkdirtemp nongit: %v", err)
-	}
-	defer os.RemoveAll(nonGitDir)
-
-	fakeHome, err := os.MkdirTemp("/tmp", "waggle-fakehome-*")
-	if err != nil {
-		t.Fatalf("mkdirtemp fakehome: %v", err)
-	}
-	defer os.RemoveAll(fakeHome)
+	nonGitDir := shortTempDir(t, "waggle-nongit-*")
+	fakeHome := shortTempDir(t, "waggle-fakehome-*")
 
 	subcommands := [][]string{
 		{"listen", "--help"},

--- a/e2e_zombie_test.go
+++ b/e2e_zombie_test.go
@@ -26,7 +26,11 @@ func shortTempDir(t *testing.T, pattern string) string {
 	if err != nil {
 		t.Fatalf("mkdirtemp %s: %v", pattern, err)
 	}
-	t.Cleanup(func() { os.RemoveAll(dir) })
+	t.Cleanup(func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Logf("cleanup temp dir %s: %v", dir, err)
+		}
+	})
 	return dir
 }
 

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -48,7 +48,6 @@ func startTestBroker(t *testing.T) (string, *Broker, func()) {
 	time.Sleep(100 * time.Millisecond)
 	return sockPath, b, func() {
 		b.Shutdown()
-		os.Remove(sockPath)
 	}
 }
 
@@ -73,7 +72,6 @@ func startTestBrokerWithTTL(t *testing.T, ttlCheckPeriod time.Duration) (string,
 	time.Sleep(100 * time.Millisecond)
 	return sockPath, b, func() {
 		b.Shutdown()
-		os.Remove(sockPath)
 	}
 }
 
@@ -1220,7 +1218,6 @@ func TestBroker_MessagesSurviveRestart(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	defer func() {
 		b2.Shutdown()
-		os.Remove(sockPath)
 	}()
 
 	// Check inbox
@@ -2692,7 +2689,6 @@ func TestBroker_TaskTTLCheckerRuns(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	defer func() {
 		b.Shutdown()
-		os.Remove(sockPath)
 	}()
 
 	c := connectClient(t, sockPath)
@@ -2806,7 +2802,6 @@ func TestBroker_TaskStaleEvent(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	defer func() {
 		b.Shutdown()
-		os.Remove(sockPath)
 	}()
 
 	// Subscriber client

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -173,7 +173,7 @@ func unmarshalResponse(t *testing.T, resp any, v any) {
 		t.Fatalf("unsupported response type %T", resp)
 	}
 	if data == nil {
-		t.Fatal("expected non-nil response")
+		t.Fatal("expected non-nil response data")
 	}
 	unmarshalJSON(t, data, v)
 }
@@ -967,17 +967,22 @@ func TestBroker_SendPushDelivery(t *testing.T) {
 
 	// Alice sends to Bob (who is online)
 	// This happens in a goroutine to allow Bob to receive the push concurrently
-	sendDone := make(chan bool)
+	sendDone := make(chan error, 1)
 	go func() {
-		resp := sendRequest(t, c1, protocol.Request{
+		resp, err := c1.Send(protocol.Request{
 			Cmd:     protocol.CmdSend,
 			Name:    "bob",
 			Message: "hello",
 		})
-		if !resp.OK {
-			t.Errorf("send failed: %s", resp.Error)
+		if err != nil {
+			sendDone <- fmt.Errorf("send: %w", err)
+			return
 		}
-		sendDone <- true
+		if !resp.OK {
+			sendDone <- fmt.Errorf("send failed: %s", resp.Error)
+			return
+		}
+		sendDone <- nil
 	}()
 
 	// Bob should receive the pushed message
@@ -1004,23 +1009,38 @@ func TestBroker_SendPushDelivery(t *testing.T) {
 	}
 
 	// Wait for send to complete
-	<-sendDone
+	if err := <-sendDone; err != nil {
+		t.Fatal(err)
+	}
 
 	// Exercise writeMu with concurrent operations:
 	// Bob sends an inbox command while Alice sends another message
 	// This creates concurrent writes to Bob's connection (push + response)
+	concurrentSendDone := make(chan error, 1)
 	go func() {
-		sendRequest(t, c1, protocol.Request{
+		resp, err := c1.Send(protocol.Request{
 			Cmd:     protocol.CmdSend,
 			Name:    "bob",
 			Message: "second message",
 		})
+		if err != nil {
+			concurrentSendDone <- fmt.Errorf("concurrent send: %w", err)
+			return
+		}
+		if !resp.OK {
+			concurrentSendDone <- fmt.Errorf("concurrent send failed: %s", resp.Error)
+			return
+		}
+		concurrentSendDone <- nil
 	}()
 
 	// Bob checks inbox concurrently
 	resp := sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdInbox})
 	if !resp.OK {
 		t.Fatalf("inbox failed: %s", resp.Error)
+	}
+	if err := <-concurrentSendDone; err != nil {
+		t.Fatal(err)
 	}
 
 	// Read the second push
@@ -1869,8 +1889,9 @@ func TestBroker_AwaitAck(t *testing.T) {
 	// Alice sends with await-ack (blocks)
 	sendDone := make(chan bool)
 	var sendResp *protocol.Response
+	var sendErr error
 	go func() {
-		sendResp = sendRequest(t, c1, protocol.Request{
+		sendResp, sendErr = c1.Send(protocol.Request{
 			Cmd:      protocol.CmdSend,
 			Name:     "bob",
 			Message:  "await test",
@@ -1896,6 +1917,9 @@ func TestBroker_AwaitAck(t *testing.T) {
 	// Alice's send should unblock
 	select {
 	case <-sendDone:
+		if sendErr != nil {
+			t.Fatalf("send: %v", sendErr)
+		}
 		if !sendResp.OK {
 			t.Errorf("send should succeed after ack: %s", sendResp.Error)
 		}
@@ -2255,9 +2279,8 @@ func TestBroker_SpawnUpdatePID(t *testing.T) {
 
 // TestBroker_SpawnStatusAfterStop — spawned list is empty after shutdown
 func TestBroker_SpawnStatusAfterStop(t *testing.T) {
-	sockPath, b, cleanup := startTestBroker(t)
+	_, b, cleanup := startTestBroker(t)
 	_ = cleanup // This test calls b.Shutdown directly to assert post-stop state.
-	defer os.Remove(sockPath)
 
 	// Add agent directly
 	b.spawnMgr.Add("worker-1", "claude", 99999)
@@ -2515,16 +2538,22 @@ func TestBroker_AwaitAckRaceEarlyAck(t *testing.T) {
 	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// Alice sends with await-ack
-	sendDone := make(chan *protocol.Response)
+	sendDone := make(chan struct {
+		resp *protocol.Response
+		err  error
+	}, 1)
 	go func() {
-		resp := sendRequest(t, c1, protocol.Request{
+		resp, err := c1.Send(protocol.Request{
 			Cmd:      protocol.CmdSend,
 			Name:     "bob",
 			Message:  "race test",
 			AwaitAck: true,
 			Timeout:  5,
 		})
-		sendDone <- resp
+		sendDone <- struct {
+			resp *protocol.Response
+			err  error
+		}{resp: resp, err: err}
 	}()
 
 	// Bob receives push and acks immediately
@@ -2543,9 +2572,12 @@ func TestBroker_AwaitAckRaceEarlyAck(t *testing.T) {
 
 	// Alice's send should unblock (not timeout)
 	select {
-	case resp := <-sendDone:
-		if !resp.OK {
-			t.Errorf("send should succeed after ack: %s (code=%s)", resp.Error, resp.Code)
+	case result := <-sendDone:
+		if result.err != nil {
+			t.Fatalf("send: %v", result.err)
+		}
+		if !result.resp.OK {
+			t.Errorf("send should succeed after ack: %s (code=%s)", result.resp.Error, result.resp.Code)
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("send timed out despite ack (race condition not fixed)")

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -131,13 +131,13 @@ func sendRequest(t *testing.T, c *client.Client, req protocol.Request) *protocol
 	return resp
 }
 
-func receiveResponse(t *testing.T, c *client.Client) protocol.Response {
+func receiveResponse(t *testing.T, c *client.Client) *protocol.Response {
 	t.Helper()
 	resp, err := c.Receive()
 	if err != nil {
 		t.Fatalf("Receive: %v", err)
 	}
-	return resp
+	return &resp
 }
 
 func marshalJSON(t *testing.T, v any) []byte {

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -78,9 +78,7 @@ func pushTokenFromResponse(t *testing.T, resp *protocol.Response) string {
 	var payload struct {
 		PushToken string `json:"push_token"`
 	}
-	if err := json.Unmarshal(resp.Data, &payload); err != nil {
-		t.Fatalf("parse connect response: %v", err)
-	}
+	unmarshalResponse(t, resp, &payload)
 	if payload.PushToken == "" {
 		t.Fatal("expected connect response to include push token")
 	}
@@ -111,6 +109,61 @@ func readStream(t *testing.T, c *client.Client) <-chan protocol.Event {
 	return ch
 }
 
+// sendRequest sends a broker request and fatals on transport errors.
+func sendRequest(t *testing.T, c *client.Client, req protocol.Request) *protocol.Response {
+	t.Helper()
+	resp, err := c.Send(req)
+	if err != nil {
+		t.Fatalf("Send(%s): %v", req.Cmd, err)
+	}
+	return resp
+}
+
+func receiveResponse(t *testing.T, c *client.Client) protocol.Response {
+	t.Helper()
+	resp, err := c.Receive()
+	if err != nil {
+		t.Fatalf("Receive: %v", err)
+	}
+	return resp
+}
+
+func marshalJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	return data
+}
+
+func unmarshalJSON(t *testing.T, data json.RawMessage, v any) {
+	t.Helper()
+	if err := json.Unmarshal(data, v); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+}
+
+func unmarshalResponse(t *testing.T, resp any, v any) {
+	t.Helper()
+	var data json.RawMessage
+	switch r := resp.(type) {
+	case *protocol.Response:
+		if r == nil {
+			t.Fatal("expected non-nil response")
+		}
+		data = r.Data
+	case protocol.Response:
+		data = r.Data
+	default:
+		t.Fatalf("unsupported response type %T", resp)
+	}
+	if data == nil {
+		t.Fatal("expected non-nil response")
+	}
+	unmarshalJSON(t, data, v)
+}
+
 // TestBroker_SessionsCommand — D1: connect "alice" and "bob", send CmdPresence, response contains both
 func TestBroker_SessionsCommand(t *testing.T) {
 	sockPath, _, cleanup := startTestBroker(t)
@@ -118,24 +171,24 @@ func TestBroker_SessionsCommand(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// Use a third client for discovery
 	c3 := connectClient(t, sockPath)
 	defer c3.Close()
-	c3.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "_discovery-test"})
+	sendRequest(t, c3, protocol.Request{Cmd: protocol.CmdConnect, Name: "_discovery-test"})
 
-	resp, _ := c3.Send(protocol.Request{Cmd: protocol.CmdPresence})
+	resp := sendRequest(t, c3, protocol.Request{Cmd: protocol.CmdPresence})
 	if !resp.OK {
 		t.Fatalf("presence: %s", resp.Error)
 	}
 
 	var agents []map[string]string
-	json.Unmarshal(resp.Data, &agents)
+	unmarshalResponse(t, resp, &agents)
 
 	names := make(map[string]bool)
 	for _, a := range agents {
@@ -155,21 +208,21 @@ func TestBroker_SessionsAfterDisconnect(t *testing.T) {
 	defer cleanup()
 
 	c1 := connectClient(t, sockPath)
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// Disconnect alice
-	c1.Send(protocol.Request{Cmd: protocol.CmdDisconnect})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdDisconnect})
 	c1.Close()
 	time.Sleep(100 * time.Millisecond)
 
 	// Check from bob
-	resp, _ := c2.Send(protocol.Request{Cmd: protocol.CmdPresence})
+	resp := sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdPresence})
 	var agents []map[string]string
-	json.Unmarshal(resp.Data, &agents)
+	unmarshalResponse(t, resp, &agents)
 
 	for _, a := range agents {
 		if a["name"] == "alice" {
@@ -186,15 +239,15 @@ func TestBroker_SessionsSorted(t *testing.T) {
 	// Connect bob first, then alice
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
-	resp, _ := c1.Send(protocol.Request{Cmd: protocol.CmdPresence})
+	resp := sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdPresence})
 	var agents []map[string]string
-	json.Unmarshal(resp.Data, &agents)
+	unmarshalResponse(t, resp, &agents)
 
 	if len(agents) < 2 {
 		t.Fatalf("expected at least 2 agents, got %d", len(agents))
@@ -224,11 +277,11 @@ func TestBroker_SessionsEmpty(t *testing.T) {
 
 	c := connectClient(t, sockPath)
 	defer c.Close()
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "_discovery-empty"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "_discovery-empty"})
 
-	resp, _ := c.Send(protocol.Request{Cmd: protocol.CmdPresence})
+	resp := sendRequest(t, c, protocol.Request{Cmd: protocol.CmdPresence})
 	var agents []map[string]string
-	json.Unmarshal(resp.Data, &agents)
+	unmarshalResponse(t, resp, &agents)
 
 	// Should contain at least the discovery session itself
 	// but filter: only non-underscore names should be empty
@@ -253,21 +306,21 @@ func TestBroker_SessionsExcludesEphemeral(t *testing.T) {
 	// Connect a real agent
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	// Connect an ephemeral discovery session
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "_discovery-12345"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "_discovery-12345"})
 
 	// Query presence from the discovery session
-	resp, _ := c2.Send(protocol.Request{Cmd: protocol.CmdPresence})
+	resp := sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdPresence})
 	if !resp.OK {
 		t.Fatalf("presence: %s", resp.Error)
 	}
 
 	var agents []map[string]string
-	json.Unmarshal(resp.Data, &agents)
+	unmarshalResponse(t, resp, &agents)
 
 	// Broker SHOULD include both (it lists all sessions)
 	hasAlice := false
@@ -294,20 +347,17 @@ func TestBroker_FullRoundTrip_CreateClaimComplete(t *testing.T) {
 	sockPath, _, cleanup := startTestBroker(t)
 	defer cleanup()
 
-	c, err := client.Connect(sockPath, 5*time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
+	c := connectClient(t, sockPath)
 	defer c.Close()
 
 	// Connect
-	resp, _ := c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "worker-1"})
+	resp := sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "worker-1"})
 	if !resp.OK {
 		t.Fatalf("connect failed: %s", resp.Error)
 	}
 
 	// Create task
-	resp, _ = c.Send(protocol.Request{
+	resp = sendRequest(t, c, protocol.Request{
 		Cmd:     protocol.CmdTaskCreate,
 		Payload: json.RawMessage(`{"desc":"test task"}`),
 		Type:    "test",
@@ -317,7 +367,7 @@ func TestBroker_FullRoundTrip_CreateClaimComplete(t *testing.T) {
 	}
 
 	// Claim task
-	resp, _ = c.Send(protocol.Request{Cmd: protocol.CmdTaskClaim})
+	resp = sendRequest(t, c, protocol.Request{Cmd: protocol.CmdTaskClaim})
 	if !resp.OK {
 		t.Fatalf("claim: %s", resp.Error)
 	}
@@ -325,12 +375,12 @@ func TestBroker_FullRoundTrip_CreateClaimComplete(t *testing.T) {
 		ID         int64  `json:"ID"`
 		ClaimToken string `json:"ClaimToken"`
 	}
-	json.Unmarshal(resp.Data, &claimData)
+	unmarshalResponse(t, resp, &claimData)
 	t.Logf("Claimed task ID=%d, token=%s", claimData.ID, claimData.ClaimToken)
 
 	// Complete task
 	taskIDStr := fmt.Sprintf("%d", claimData.ID)
-	resp, _ = c.Send(protocol.Request{
+	resp = sendRequest(t, c, protocol.Request{
 		Cmd:        protocol.CmdTaskComplete,
 		TaskID:     taskIDStr,
 		ClaimToken: claimData.ClaimToken,
@@ -341,14 +391,14 @@ func TestBroker_FullRoundTrip_CreateClaimComplete(t *testing.T) {
 	}
 
 	// Verify state
-	resp, _ = c.Send(protocol.Request{
+	resp = sendRequest(t, c, protocol.Request{
 		Cmd:    protocol.CmdTaskGet,
 		TaskID: taskIDStr,
 	})
 	var task struct {
 		State string `json:"State"`
 	}
-	json.Unmarshal(resp.Data, &task)
+	unmarshalResponse(t, resp, &task)
 	if task.State != "completed" {
 		t.Errorf("state = %q, want completed", task.State)
 	}
@@ -360,10 +410,10 @@ func TestBroker_DisconnectCleansUpLocks(t *testing.T) {
 	defer cleanup()
 
 	c := connectClient(t, sockPath)
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "w-1"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "w-1"})
 
 	// Acquire lock
-	resp, _ := c.Send(protocol.Request{Cmd: protocol.CmdLock, Resource: "file:main.go"})
+	resp := sendRequest(t, c, protocol.Request{Cmd: protocol.CmdLock, Resource: "file:main.go"})
 	if !resp.OK {
 		t.Fatalf("lock: %s", resp.Error)
 	}
@@ -375,8 +425,8 @@ func TestBroker_DisconnectCleansUpLocks(t *testing.T) {
 	// Verify lock released
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "w-2"})
-	resp, _ = c2.Send(protocol.Request{Cmd: protocol.CmdLock, Resource: "file:main.go"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "w-2"})
+	resp = sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdLock, Resource: "file:main.go"})
 	if !resp.OK {
 		t.Errorf("lock should be available after disconnect: %s", resp.Error)
 	}
@@ -388,15 +438,15 @@ func TestBroker_DisconnectRequeuesClaimedTasks(t *testing.T) {
 	defer cleanup()
 
 	c := connectClient(t, sockPath)
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "w-1"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "w-1"})
 
 	// Create and claim task
-	c.Send(protocol.Request{
+	sendRequest(t, c, protocol.Request{
 		Cmd:     protocol.CmdTaskCreate,
 		Payload: json.RawMessage(`{"desc":"test"}`),
 		Type:    "test",
 	})
-	resp, _ := c.Send(protocol.Request{Cmd: protocol.CmdTaskClaim})
+	resp := sendRequest(t, c, protocol.Request{Cmd: protocol.CmdTaskClaim})
 	if !resp.OK {
 		t.Fatalf("claim: %s", resp.Error)
 	}
@@ -408,8 +458,8 @@ func TestBroker_DisconnectRequeuesClaimedTasks(t *testing.T) {
 	// Verify task re-queued
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "w-2"})
-	resp, _ = c2.Send(protocol.Request{Cmd: protocol.CmdTaskClaim})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "w-2"})
+	resp = sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdTaskClaim})
 	if !resp.OK {
 		t.Errorf("task should be re-queued after disconnect: %s", resp.Error)
 	}
@@ -421,29 +471,29 @@ func TestBroker_CleanDisconnectDoesNotRequeue(t *testing.T) {
 	defer cleanup()
 
 	c := connectClient(t, sockPath)
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "w-1"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "w-1"})
 
 	// Create and claim task
-	c.Send(protocol.Request{
+	sendRequest(t, c, protocol.Request{
 		Cmd:     protocol.CmdTaskCreate,
 		Payload: json.RawMessage(`{"desc":"test"}`),
 		Type:    "test",
 	})
-	resp, _ := c.Send(protocol.Request{Cmd: protocol.CmdTaskClaim})
+	resp := sendRequest(t, c, protocol.Request{Cmd: protocol.CmdTaskClaim})
 	if !resp.OK {
 		t.Fatalf("claim: %s", resp.Error)
 	}
 
 	// Clean disconnect (send disconnect command)
-	c.Send(protocol.Request{Cmd: protocol.CmdDisconnect})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdDisconnect})
 	c.Close()
 	time.Sleep(50 * time.Millisecond)
 
 	// Verify task NOT re-queued (should still be claimed)
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "w-2"})
-	resp, _ = c2.Send(protocol.Request{Cmd: protocol.CmdTaskClaim})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "w-2"})
+	resp = sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdTaskClaim})
 	if resp.OK {
 		t.Error("task should NOT be re-queued after clean disconnect")
 	}
@@ -455,25 +505,22 @@ func TestBroker_EventsSubscribeFormat(t *testing.T) {
 	defer cleanup()
 
 	c := connectClient(t, sockPath)
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "subscriber"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "subscriber"})
 
 	// Subscribe to task.events
-	resp, _ := c.Send(protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "task.events"})
+	resp := sendRequest(t, c, protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "task.events"})
 	if !resp.OK {
 		t.Fatalf("subscribe: %s", resp.Error)
 	}
 
 	// Start reading events
-	eventCh, err := c.ReadStream()
-	if err != nil {
-		t.Fatalf("read stream: %v", err)
-	}
+	eventCh := readStream(t, c)
 
 	// Create a task to trigger an event
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "creator"})
-	c2.Send(protocol.Request{
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "creator"})
+	sendRequest(t, c2, protocol.Request{
 		Cmd:     protocol.CmdTaskCreate,
 		Payload: json.RawMessage(`{"test":true}`),
 		Type:    "test",
@@ -502,28 +549,28 @@ func TestBroker_StatusIncludesTaskCounts(t *testing.T) {
 	defer cleanup()
 
 	c := connectClient(t, sockPath)
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "w-1"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "w-1"})
 
 	// Create tasks in different states
-	c.Send(protocol.Request{
+	sendRequest(t, c, protocol.Request{
 		Cmd:     protocol.CmdTaskCreate,
 		Payload: json.RawMessage(`{"a":1}`),
 	})
-	c.Send(protocol.Request{
+	sendRequest(t, c, protocol.Request{
 		Cmd:     protocol.CmdTaskCreate,
 		Payload: json.RawMessage(`{"b":2}`),
 	})
 	// Claim one task
-	c.Send(protocol.Request{Cmd: protocol.CmdTaskClaim})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdTaskClaim})
 
 	// Get status
-	resp, _ := c.Send(protocol.Request{Cmd: protocol.CmdStatus})
+	resp := sendRequest(t, c, protocol.Request{Cmd: protocol.CmdStatus})
 	if !resp.OK {
 		t.Fatalf("status: %s", resp.Error)
 	}
 
 	var status map[string]interface{}
-	json.Unmarshal(resp.Data, &status)
+	unmarshalResponse(t, resp, &status)
 
 	// Check for task counts
 	tasks, ok := status["tasks"].(map[string]interface{})
@@ -548,10 +595,10 @@ func TestBroker_DisconnectUnsubscribesEvents(t *testing.T) {
 	defer cleanup()
 
 	c := connectClient(t, sockPath)
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "w-1"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "w-1"})
 
 	// Subscribe to topic
-	resp, _ := c.Send(protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "test.topic"})
+	resp := sendRequest(t, c, protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "test.topic"})
 	if !resp.OK {
 		t.Fatalf("subscribe: %s", resp.Error)
 	}
@@ -563,8 +610,8 @@ func TestBroker_DisconnectUnsubscribesEvents(t *testing.T) {
 	// Verify subscription removed (check via status or another mechanism)
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "w-2"})
-	resp, _ = c2.Send(protocol.Request{Cmd: protocol.CmdStatus})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "w-2"})
+	resp = sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdStatus})
 	if !resp.OK {
 		t.Fatalf("status: %s", resp.Error)
 	}
@@ -572,7 +619,7 @@ func TestBroker_DisconnectUnsubscribesEvents(t *testing.T) {
 	var status struct {
 		Subscribers int `json:"subscribers"`
 	}
-	json.Unmarshal(resp.Data, &status)
+	unmarshalResponse(t, resp, &status)
 	if status.Subscribers != 0 {
 		t.Errorf("subscribers = %d, want 0 after disconnect", status.Subscribers)
 	}
@@ -584,10 +631,10 @@ func TestBroker_PublishesTaskEventsOnStateTransitions(t *testing.T) {
 	defer cleanup()
 
 	c := connectClient(t, sockPath)
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "w-1"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "w-1"})
 
 	// Subscribe to task.events
-	resp, _ := c.Send(protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "task.events"})
+	resp := sendRequest(t, c, protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "task.events"})
 	if !resp.OK {
 		t.Fatalf("subscribe: %s", resp.Error)
 	}
@@ -595,18 +642,15 @@ func TestBroker_PublishesTaskEventsOnStateTransitions(t *testing.T) {
 	// Create task (should publish event)
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "w-2"})
-	c2.Send(protocol.Request{
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "w-2"})
+	sendRequest(t, c2, protocol.Request{
 		Cmd:     protocol.CmdTaskCreate,
 		Payload: json.RawMessage(`{"desc":"test"}`),
 		Type:    "test",
 	})
 
 	// Read event stream (should receive task.created event)
-	eventChan, err := c.ReadStream()
-	if err != nil {
-		t.Fatalf("ReadStream: %v", err)
-	}
+	eventChan := readStream(t, c)
 
 	select {
 	case evt := <-eventChan:
@@ -625,7 +669,7 @@ func TestBroker_InvalidJSONReturnsError(t *testing.T) {
 
 	c := connectClient(t, sockPath)
 	defer c.Close()
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "w-1"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "w-1"})
 
 	// Send request with missing required field (name for connect)
 	c2 := connectClient(t, sockPath)
@@ -649,34 +693,34 @@ func TestBroker_DisconnectOnlyRequeuesOwnTasks(t *testing.T) {
 
 	// Worker A connects and claims task 1
 	c1 := connectClient(t, sockPath)
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "worker-a"})
-	c1.Send(protocol.Request{Cmd: protocol.CmdTaskCreate, Payload: json.RawMessage(`{"desc":"task1"}`), Type: "test"})
-	resp1, _ := c1.Send(protocol.Request{Cmd: protocol.CmdTaskClaim})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "worker-a"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdTaskCreate, Payload: json.RawMessage(`{"desc":"task1"}`), Type: "test"})
+	resp1 := sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdTaskClaim})
 	var claim1 struct {
 		ID int64 `json:"ID"`
 	}
-	json.Unmarshal(resp1.Data, &claim1)
+	unmarshalResponse(t, resp1, &claim1)
 
 	// Worker B connects and claims task 2
 	c2 := connectClient(t, sockPath)
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "worker-b"})
-	c2.Send(protocol.Request{Cmd: protocol.CmdTaskCreate, Payload: json.RawMessage(`{"desc":"task2"}`), Type: "test"})
-	resp2, _ := c2.Send(protocol.Request{Cmd: protocol.CmdTaskClaim})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "worker-b"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdTaskCreate, Payload: json.RawMessage(`{"desc":"task2"}`), Type: "test"})
+	resp2 := sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdTaskClaim})
 	var claim2 struct {
 		ID int64 `json:"ID"`
 	}
-	json.Unmarshal(resp2.Data, &claim2)
+	unmarshalResponse(t, resp2, &claim2)
 
 	// Worker A disconnects
 	c1.Close()
 	time.Sleep(50 * time.Millisecond)
 
 	// Verify Worker B's task is still claimed
-	resp, _ := c2.Send(protocol.Request{Cmd: protocol.CmdTaskGet, TaskID: fmt.Sprintf("%d", claim2.ID)})
+	resp := sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdTaskGet, TaskID: fmt.Sprintf("%d", claim2.ID)})
 	var task struct {
 		State string `json:"State"`
 	}
-	json.Unmarshal(resp.Data, &task)
+	unmarshalResponse(t, resp, &task)
 	if task.State != "claimed" {
 		t.Errorf("Worker B's task state = %q, want claimed (should NOT be re-queued when Worker A disconnects)", task.State)
 	}
@@ -690,10 +734,10 @@ func TestBroker_InputValidation(t *testing.T) {
 	defer cleanup()
 
 	c := connectClient(t, sockPath)
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "w-1"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "w-1"})
 
 	// Test negative priority
-	resp, _ := c.Send(protocol.Request{
+	resp := sendRequest(t, c, protocol.Request{
 		Cmd:      protocol.CmdTaskCreate,
 		Payload:  json.RawMessage(`{"test":true}`),
 		Priority: -1,
@@ -706,7 +750,7 @@ func TestBroker_InputValidation(t *testing.T) {
 	}
 
 	// Test priority > 100
-	resp, _ = c.Send(protocol.Request{
+	resp = sendRequest(t, c, protocol.Request{
 		Cmd:      protocol.CmdTaskCreate,
 		Payload:  json.RawMessage(`{"test":true}`),
 		Priority: 101,
@@ -720,7 +764,7 @@ func TestBroker_InputValidation(t *testing.T) {
 	for i := range longName {
 		longName = longName[:i] + "a"
 	}
-	resp, _ = c.Send(protocol.Request{
+	resp = sendRequest(t, c, protocol.Request{
 		Cmd:  protocol.CmdConnect,
 		Name: longName,
 	})
@@ -740,7 +784,7 @@ func TestBroker_LargePayloadRoundTrip(t *testing.T) {
 
 	c := connectClient(t, sockPath)
 	defer c.Close()
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "w-large"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "w-large"})
 
 	payloadSize := 100 * 1024 // 100KB — above 64KB default, below 1MB config max
 	bigPayload := strings.Repeat("x", payloadSize)
@@ -772,16 +816,16 @@ func TestBroker_CleanDisconnectCleansUpOnce(t *testing.T) {
 	defer cleanup()
 
 	c := connectClient(t, sockPath)
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "w-once"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "w-once"})
 
 	// Acquire a lock, create+claim a task
-	c.Send(protocol.Request{Cmd: protocol.CmdLock, Resource: "file:once.go"})
-	c.Send(protocol.Request{
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdLock, Resource: "file:once.go"})
+	sendRequest(t, c, protocol.Request{
 		Cmd:     protocol.CmdTaskCreate,
 		Payload: json.RawMessage(`{"desc":"once-test"}`),
 		Type:    "test",
 	})
-	c.Send(protocol.Request{Cmd: protocol.CmdTaskClaim})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdTaskClaim})
 
 	// Clean disconnect — triggers cleanup from deferred readLoop.
 	// Both should complete without panic or double-close errors.
@@ -798,8 +842,8 @@ func TestBroker_CleanDisconnectCleansUpOnce(t *testing.T) {
 	// Verify lock was released (cleanup ran at least once)
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "w-verify"})
-	resp, _ = c2.Send(protocol.Request{Cmd: protocol.CmdLock, Resource: "file:once.go"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "w-verify"})
+	resp = sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdLock, Resource: "file:once.go"})
 	if !resp.OK {
 		t.Errorf("lock should be available after clean disconnect: %s", resp.Error)
 	}
@@ -850,14 +894,14 @@ func TestBroker_SendMessage(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// Alice sends to Bob
-	resp, _ := c1.Send(protocol.Request{
+	resp := sendRequest(t, c1, protocol.Request{
 		Cmd:     protocol.CmdSend,
 		Name:    "bob",
 		Message: "hello from alice",
@@ -876,13 +920,13 @@ func TestBroker_SendMessage(t *testing.T) {
 	}
 
 	// Bob checks inbox
-	resp, _ = c2.Send(protocol.Request{Cmd: protocol.CmdInbox})
+	resp = sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdInbox})
 	if !resp.OK {
 		t.Fatalf("inbox failed: %s", resp.Error)
 	}
 
 	var messages []map[string]interface{}
-	json.Unmarshal(resp.Data, &messages)
+	unmarshalResponse(t, resp, &messages)
 	if len(messages) != 1 {
 		t.Fatalf("inbox len = %d, want 1", len(messages))
 	}
@@ -901,17 +945,17 @@ func TestBroker_SendPushDelivery(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// Alice sends to Bob (who is online)
 	// This happens in a goroutine to allow Bob to receive the push concurrently
 	sendDone := make(chan bool)
 	go func() {
-		resp, _ := c1.Send(protocol.Request{
+		resp := sendRequest(t, c1, protocol.Request{
 			Cmd:     protocol.CmdSend,
 			Name:    "bob",
 			Message: "hello",
@@ -934,7 +978,7 @@ func TestBroker_SendPushDelivery(t *testing.T) {
 
 	// Verify the pushed message has the right structure
 	var pushData map[string]interface{}
-	json.Unmarshal(pushResp.Data, &pushData)
+	unmarshalResponse(t, pushResp, &pushData)
 	if pushData["type"] != "message" {
 		t.Errorf("push type = %q, want 'message'", pushData["type"])
 	}
@@ -952,7 +996,7 @@ func TestBroker_SendPushDelivery(t *testing.T) {
 	// Bob sends an inbox command while Alice sends another message
 	// This creates concurrent writes to Bob's connection (push + response)
 	go func() {
-		c1.Send(protocol.Request{
+		sendRequest(t, c1, protocol.Request{
 			Cmd:     protocol.CmdSend,
 			Name:    "bob",
 			Message: "second message",
@@ -960,7 +1004,7 @@ func TestBroker_SendPushDelivery(t *testing.T) {
 	}()
 
 	// Bob checks inbox concurrently
-	resp, _ := c2.Send(protocol.Request{Cmd: protocol.CmdInbox})
+	resp := sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdInbox})
 	if !resp.OK {
 		t.Fatalf("inbox failed: %s", resp.Error)
 	}
@@ -975,13 +1019,13 @@ func TestBroker_SendPushDelivery(t *testing.T) {
 	}
 
 	// Verify via inbox that messages have state 'seen' (Task 48: inbox marks messages as seen)
-	resp, _ = c2.Send(protocol.Request{Cmd: protocol.CmdInbox})
+	resp = sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdInbox})
 	if !resp.OK {
 		t.Fatalf("inbox failed: %s", resp.Error)
 	}
 
 	var messages []map[string]interface{}
-	json.Unmarshal(resp.Data, &messages)
+	unmarshalResponse(t, resp, &messages)
 	if len(messages) != 2 {
 		t.Fatalf("inbox len = %d, want 2", len(messages))
 	}
@@ -1000,10 +1044,10 @@ func TestBroker_SendOfflineDelivery(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	// Alice sends to Bob (who is offline)
-	resp, _ := c1.Send(protocol.Request{
+	resp := sendRequest(t, c1, protocol.Request{
 		Cmd:     protocol.CmdSend,
 		Name:    "bob",
 		Message: "hello offline",
@@ -1015,16 +1059,16 @@ func TestBroker_SendOfflineDelivery(t *testing.T) {
 	// Bob connects later
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// Bob checks inbox
-	resp, _ = c2.Send(protocol.Request{Cmd: protocol.CmdInbox})
+	resp = sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdInbox})
 	if !resp.OK {
 		t.Fatalf("inbox failed: %s", resp.Error)
 	}
 
 	var messages []map[string]interface{}
-	json.Unmarshal(resp.Data, &messages)
+	unmarshalResponse(t, resp, &messages)
 	if len(messages) != 1 {
 		t.Fatalf("inbox len = %d, want 1", len(messages))
 	}
@@ -1044,9 +1088,9 @@ func TestBroker_SendRequiresName(t *testing.T) {
 
 	c := connectClient(t, sockPath)
 	defer c.Close()
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
-	resp, _ := c.Send(protocol.Request{
+	resp := sendRequest(t, c, protocol.Request{
 		Cmd:     protocol.CmdSend,
 		Name:    "",
 		Message: "hello",
@@ -1066,9 +1110,9 @@ func TestBroker_SendRequiresMessage(t *testing.T) {
 
 	c := connectClient(t, sockPath)
 	defer c.Close()
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
-	resp, _ := c.Send(protocol.Request{
+	resp := sendRequest(t, c, protocol.Request{
 		Cmd:     protocol.CmdSend,
 		Name:    "bob",
 		Message: "",
@@ -1090,7 +1134,7 @@ func TestBroker_SendRequiresSession(t *testing.T) {
 	defer c.Close()
 
 	// Try to send without connecting
-	resp, _ := c.Send(protocol.Request{
+	resp := sendRequest(t, c, protocol.Request{
 		Cmd:     protocol.CmdSend,
 		Name:    "bob",
 		Message: "hello",
@@ -1121,8 +1165,8 @@ func TestBroker_MessagesSurviveRestart(t *testing.T) {
 
 	// Send message
 	c1 := connectClient(t, sockPath)
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
-	c1.Send(protocol.Request{
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c1, protocol.Request{
 		Cmd:     protocol.CmdSend,
 		Name:    "bob",
 		Message: "persistent message",
@@ -1148,14 +1192,14 @@ func TestBroker_MessagesSurviveRestart(t *testing.T) {
 	// Check inbox
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
-	resp, _ := c2.Send(protocol.Request{Cmd: protocol.CmdInbox})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	resp := sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdInbox})
 	if !resp.OK {
 		t.Fatalf("inbox failed: %s", resp.Error)
 	}
 
 	var messages []map[string]interface{}
-	json.Unmarshal(resp.Data, &messages)
+	unmarshalResponse(t, resp, &messages)
 	if len(messages) != 1 {
 		t.Fatalf("inbox len = %d, want 1", len(messages))
 	}
@@ -1171,13 +1215,13 @@ func TestBroker_InboxPersistsAcrossReconnect(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	c2 := connectClient(t, sockPath)
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// Alice sends to Bob
-	c1.Send(protocol.Request{
+	sendRequest(t, c1, protocol.Request{
 		Cmd:     protocol.CmdSend,
 		Name:    "bob",
 		Message: "reconnect test",
@@ -1190,16 +1234,16 @@ func TestBroker_InboxPersistsAcrossReconnect(t *testing.T) {
 	// Bob reconnects
 	c3 := connectClient(t, sockPath)
 	defer c3.Close()
-	c3.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c3, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// Check inbox
-	resp, _ := c3.Send(protocol.Request{Cmd: protocol.CmdInbox})
+	resp := sendRequest(t, c3, protocol.Request{Cmd: protocol.CmdInbox})
 	if !resp.OK {
 		t.Fatalf("inbox failed: %s", resp.Error)
 	}
 
 	var messages []map[string]interface{}
-	json.Unmarshal(resp.Data, &messages)
+	unmarshalResponse(t, resp, &messages)
 	if len(messages) != 1 {
 		t.Fatalf("inbox len = %d, want 1", len(messages))
 	}
@@ -1215,18 +1259,18 @@ func TestBroker_MultipleSendersOrdering(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	c3 := connectClient(t, sockPath)
 	defer c3.Close()
-	c3.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "charlie"})
+	sendRequest(t, c3, protocol.Request{Cmd: protocol.CmdConnect, Name: "charlie"})
 
 	// Alice sends to Charlie
-	c1.Send(protocol.Request{
+	sendRequest(t, c1, protocol.Request{
 		Cmd:     protocol.CmdSend,
 		Name:    "charlie",
 		Message: "from alice",
@@ -1244,7 +1288,7 @@ func TestBroker_MultipleSendersOrdering(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// Bob sends to Charlie
-	c2.Send(protocol.Request{
+	sendRequest(t, c2, protocol.Request{
 		Cmd:     protocol.CmdSend,
 		Name:    "charlie",
 		Message: "from bob",
@@ -1260,13 +1304,13 @@ func TestBroker_MultipleSendersOrdering(t *testing.T) {
 	}
 
 	// Charlie checks inbox
-	resp, _ := c3.Send(protocol.Request{Cmd: protocol.CmdInbox})
+	resp := sendRequest(t, c3, protocol.Request{Cmd: protocol.CmdInbox})
 	if !resp.OK {
 		t.Fatalf("inbox failed: %s", resp.Error)
 	}
 
 	var messages []map[string]interface{}
-	json.Unmarshal(resp.Data, &messages)
+	unmarshalResponse(t, resp, &messages)
 	if len(messages) != 2 {
 		t.Fatalf("inbox len = %d, want 2", len(messages))
 	}
@@ -1287,10 +1331,10 @@ func TestBroker_SendToSelf(t *testing.T) {
 
 	c := connectClient(t, sockPath)
 	defer c.Close()
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	// Alice sends to herself
-	resp, _ := c.Send(protocol.Request{
+	resp := sendRequest(t, c, protocol.Request{
 		Cmd:     protocol.CmdSend,
 		Name:    "alice",
 		Message: "note to self",
@@ -1301,19 +1345,19 @@ func TestBroker_SendToSelf(t *testing.T) {
 
 	// Verify the send response is correct (not corrupted by push)
 	var sendData map[string]interface{}
-	json.Unmarshal(resp.Data, &sendData)
+	unmarshalResponse(t, resp, &sendData)
 	if sendData["body"] != "note to self" {
 		t.Errorf("send response body = %q, want 'note to self'", sendData["body"])
 	}
 
 	// Check inbox — message should be there
-	resp, _ = c.Send(protocol.Request{Cmd: protocol.CmdInbox})
+	resp = sendRequest(t, c, protocol.Request{Cmd: protocol.CmdInbox})
 	if !resp.OK {
 		t.Fatalf("inbox failed: %s", resp.Error)
 	}
 
 	var messages []map[string]interface{}
-	json.Unmarshal(resp.Data, &messages)
+	unmarshalResponse(t, resp, &messages)
 	if len(messages) != 1 {
 		t.Fatalf("inbox len = %d, want 1", len(messages))
 	}
@@ -1334,7 +1378,7 @@ func TestBroker_SessionNameCollision(t *testing.T) {
 	// Alice connects on first connection
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	resp1, _ := c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	resp1 := sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 	if !resp1.OK {
 		t.Fatalf("first connect failed: %s", resp1.Error)
 	}
@@ -1342,7 +1386,7 @@ func TestBroker_SessionNameCollision(t *testing.T) {
 	// Second connection tries same name — must be rejected
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	resp2, _ := c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	resp2 := sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 	if resp2.OK {
 		t.Fatal("expected second connect to fail, but got OK")
 	}
@@ -1353,8 +1397,8 @@ func TestBroker_SessionNameCollision(t *testing.T) {
 	// Original alice still works — bob can send to her and she receives push
 	c3 := connectClient(t, sockPath)
 	defer c3.Close()
-	c3.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
-	sendResp, _ := c3.Send(protocol.Request{
+	sendRequest(t, c3, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendResp := sendRequest(t, c3, protocol.Request{
 		Cmd:     protocol.CmdSend,
 		Name:    "alice",
 		Message: "test collision",
@@ -1372,7 +1416,7 @@ func TestBroker_SessionNameCollision(t *testing.T) {
 	}
 
 	var pushData map[string]interface{}
-	json.Unmarshal(pushResp.Data, &pushData)
+	unmarshalResponse(t, pushResp, &pushData)
 	if pushData["body"] != "test collision" {
 		t.Errorf("push body = %q, want 'test collision'", pushData["body"])
 	}
@@ -1386,7 +1430,7 @@ func TestBroker_DuplicateNameRejected(t *testing.T) {
 	// Client A connects as "agent-dup"
 	cA := connectClient(t, sockPath)
 	defer cA.Close()
-	respA, _ := cA.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "agent-dup"})
+	respA := sendRequest(t, cA, protocol.Request{Cmd: protocol.CmdConnect, Name: "agent-dup"})
 	if !respA.OK {
 		t.Fatalf("client A connect failed: %s", respA.Error)
 	}
@@ -1394,7 +1438,7 @@ func TestBroker_DuplicateNameRejected(t *testing.T) {
 	// Client B tries to connect as "agent-dup" — must be rejected
 	cB := connectClient(t, sockPath)
 	defer cB.Close()
-	respB, _ := cB.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "agent-dup"})
+	respB := sendRequest(t, cB, protocol.Request{Cmd: protocol.CmdConnect, Name: "agent-dup"})
 	if respB.OK {
 		t.Fatal("expected client B connect to fail, but got OK")
 	}
@@ -1405,8 +1449,8 @@ func TestBroker_DuplicateNameRejected(t *testing.T) {
 	// Client A is still functional — verify by sending a message to it
 	cC := connectClient(t, sockPath)
 	defer cC.Close()
-	cC.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "verifier"})
-	sendResp, _ := cC.Send(protocol.Request{
+	sendRequest(t, cC, protocol.Request{Cmd: protocol.CmdConnect, Name: "verifier"})
+	sendResp := sendRequest(t, cC, protocol.Request{
 		Cmd:     protocol.CmdSend,
 		Name:    "agent-dup",
 		Message: "still alive",
@@ -1423,7 +1467,7 @@ func TestBroker_DuplicateNameRejected(t *testing.T) {
 		t.Fatalf("push response not OK: %s", pushResp.Error)
 	}
 	var pushData map[string]interface{}
-	json.Unmarshal(pushResp.Data, &pushData)
+	unmarshalResponse(t, pushResp, &pushData)
 	if pushData["body"] != "still alive" {
 		t.Errorf("push body = %q, want 'still alive'", pushData["body"])
 	}
@@ -1437,14 +1481,14 @@ func TestBroker_ConcurrentSendToSameRecipient(t *testing.T) {
 	// Bob connects and will receive all messages
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// 10 senders connect
 	senders := make([]*client.Client, 10)
 	for i := 0; i < 10; i++ {
 		c := connectClient(t, sockPath)
 		defer c.Close()
-		c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: fmt.Sprintf("sender-%d", i)})
+		sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: fmt.Sprintf("sender-%d", i)})
 		senders[i] = c
 	}
 
@@ -1452,11 +1496,16 @@ func TestBroker_ConcurrentSendToSameRecipient(t *testing.T) {
 	done := make(chan bool, 10)
 	for i := 0; i < 10; i++ {
 		go func(idx int) {
-			resp, _ := senders[idx].Send(protocol.Request{
+			resp, err := senders[idx].Send(protocol.Request{
 				Cmd:     protocol.CmdSend,
 				Name:    "bob",
 				Message: fmt.Sprintf("msg-%d", idx),
 			})
+			if err != nil {
+				t.Errorf("sender-%d send error: %v", idx, err)
+				done <- true
+				return
+			}
 			if !resp.OK {
 				t.Errorf("sender-%d send failed: %s", idx, resp.Error)
 			}
@@ -1478,13 +1527,13 @@ func TestBroker_ConcurrentSendToSameRecipient(t *testing.T) {
 	}
 
 	// Verify inbox has all 10 messages
-	resp, _ := c1.Send(protocol.Request{Cmd: protocol.CmdInbox})
+	resp := sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdInbox})
 	if !resp.OK {
 		t.Fatalf("inbox failed: %s", resp.Error)
 	}
 
 	var messages []map[string]interface{}
-	json.Unmarshal(resp.Data, &messages)
+	unmarshalResponse(t, resp, &messages)
 	if len(messages) != 10 {
 		t.Fatalf("inbox len = %d, want 10", len(messages))
 	}
@@ -1498,8 +1547,8 @@ func TestBroker_SubscribeAndPushRace(t *testing.T) {
 	// Alice subscribes to task.events
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
-	resp, _ := c1.Send(protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "task.events"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	resp := sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "task.events"})
 	if !resp.OK {
 		t.Fatalf("subscribe failed: %s", resp.Error)
 	}
@@ -1507,18 +1556,18 @@ func TestBroker_SubscribeAndPushRace(t *testing.T) {
 	// Bob connects
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// Bob creates tasks and sends messages sequentially (not concurrently)
 	// The race we're testing is on the SERVER side (writeMu protecting concurrent writes to alice's connection)
 	// NOT on the client side (c2 is used from one goroutine only)
 	for i := 0; i < 5; i++ {
-		c2.Send(protocol.Request{
+		sendRequest(t, c2, protocol.Request{
 			Cmd:     protocol.CmdTaskCreate,
 			Payload: json.RawMessage(fmt.Sprintf(`{"task":%d}`, i)),
 			Type:    "test",
 		})
-		c2.Send(protocol.Request{
+		sendRequest(t, c2, protocol.Request{
 			Cmd:     protocol.CmdSend,
 			Name:    "alice",
 			Message: fmt.Sprintf("msg-%d", i),
@@ -1550,11 +1599,11 @@ func TestBroker_SendRecipientNameTooLong(t *testing.T) {
 
 	c := connectClient(t, sockPath)
 	defer c.Close()
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	// Create a name longer than MaxFieldLength (256)
 	longName := strings.Repeat("a", 257)
-	resp, _ := c.Send(protocol.Request{
+	resp := sendRequest(t, c, protocol.Request{
 		Cmd:     protocol.CmdSend,
 		Name:    longName,
 		Message: "test",
@@ -1574,7 +1623,7 @@ func TestBroker_SendMessageBodyTooLarge(t *testing.T) {
 
 	c := connectClient(t, sockPath)
 	defer c.Close()
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	// Create a message just under MaxMessageSize but large enough to test validation
 	// We can't test > MaxMessageSize because the client scanner will fail first
@@ -1593,14 +1642,14 @@ func TestBroker_Ack(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// Alice sends to Bob
-	resp, _ := c1.Send(protocol.Request{
+	resp := sendRequest(t, c1, protocol.Request{
 		Cmd:     protocol.CmdSend,
 		Name:    "bob",
 		Message: "hello",
@@ -1613,13 +1662,13 @@ func TestBroker_Ack(t *testing.T) {
 	var msgData struct {
 		ID int64 `json:"id"`
 	}
-	json.Unmarshal(resp.Data, &msgData)
+	unmarshalResponse(t, resp, &msgData)
 
 	// Bob receives push
 	c2.Receive()
 
 	// Bob acks the message
-	resp, _ = c2.Send(protocol.Request{
+	resp = sendRequest(t, c2, protocol.Request{
 		Cmd:       protocol.CmdAck,
 		MessageID: msgData.ID,
 	})
@@ -1628,13 +1677,13 @@ func TestBroker_Ack(t *testing.T) {
 	}
 
 	// Verify message no longer in inbox
-	resp, _ = c2.Send(protocol.Request{Cmd: protocol.CmdInbox})
+	resp = sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdInbox})
 	if !resp.OK {
 		t.Fatalf("inbox failed: %s", resp.Error)
 	}
 
 	var messages []map[string]interface{}
-	json.Unmarshal(resp.Data, &messages)
+	unmarshalResponse(t, resp, &messages)
 	for _, msg := range messages {
 		if int64(msg["id"].(float64)) == msgData.ID {
 			t.Error("acked message should not be in inbox")
@@ -1649,9 +1698,9 @@ func TestBroker_AckNonexistent(t *testing.T) {
 
 	c := connectClient(t, sockPath)
 	defer c.Close()
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
-	resp, _ := c.Send(protocol.Request{
+	resp := sendRequest(t, c, protocol.Request{
 		Cmd:       protocol.CmdAck,
 		MessageID: 99999,
 	})
@@ -1670,14 +1719,14 @@ func TestBroker_AckForbidden(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// Alice sends to Bob
-	resp, _ := c1.Send(protocol.Request{
+	resp := sendRequest(t, c1, protocol.Request{
 		Cmd:     protocol.CmdSend,
 		Name:    "bob",
 		Message: "hello",
@@ -1689,10 +1738,10 @@ func TestBroker_AckForbidden(t *testing.T) {
 	var msgData struct {
 		ID int64 `json:"id"`
 	}
-	json.Unmarshal(resp.Data, &msgData)
+	unmarshalResponse(t, resp, &msgData)
 
 	// Alice tries to ack Bob's message
-	resp, _ = c1.Send(protocol.Request{
+	resp = sendRequest(t, c1, protocol.Request{
 		Cmd:       protocol.CmdAck,
 		MessageID: msgData.ID,
 	})
@@ -1711,14 +1760,14 @@ func TestBroker_FullAckLifecycle(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// Alice sends to Bob (state: queued → pushed)
-	resp, _ := c1.Send(protocol.Request{
+	resp := sendRequest(t, c1, protocol.Request{
 		Cmd:     protocol.CmdSend,
 		Name:    "bob",
 		Message: "lifecycle test",
@@ -1730,7 +1779,7 @@ func TestBroker_FullAckLifecycle(t *testing.T) {
 	var msgData struct {
 		ID int64 `json:"id"`
 	}
-	json.Unmarshal(resp.Data, &msgData)
+	unmarshalResponse(t, resp, &msgData)
 
 	// After send, state could be "queued" or "pushed" (push happens synchronously for connected recipients)
 	state, err := b.msgStore.GetState(msgData.ID)
@@ -1745,7 +1794,7 @@ func TestBroker_FullAckLifecycle(t *testing.T) {
 	c2.Receive()
 
 	// Bob checks inbox (state: pushed → seen)
-	resp, _ = c2.Send(protocol.Request{Cmd: protocol.CmdInbox})
+	resp = sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdInbox})
 	if !resp.OK {
 		t.Fatalf("inbox failed: %s", resp.Error)
 	}
@@ -1760,7 +1809,7 @@ func TestBroker_FullAckLifecycle(t *testing.T) {
 	}
 
 	// Bob acks (state: seen → acked)
-	resp, _ = c2.Send(protocol.Request{
+	resp = sendRequest(t, c2, protocol.Request{
 		Cmd:       protocol.CmdAck,
 		MessageID: msgData.ID,
 	})
@@ -1778,13 +1827,13 @@ func TestBroker_FullAckLifecycle(t *testing.T) {
 	}
 
 	// Verify message no longer in inbox
-	resp, _ = c2.Send(protocol.Request{Cmd: protocol.CmdInbox})
+	resp = sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdInbox})
 	if !resp.OK {
 		t.Fatalf("inbox failed: %s", resp.Error)
 	}
 
 	var messages []map[string]interface{}
-	json.Unmarshal(resp.Data, &messages)
+	unmarshalResponse(t, resp, &messages)
 	if len(messages) != 0 {
 		t.Errorf("inbox len = %d, want 0 (acked message excluded)", len(messages))
 	}
@@ -1797,17 +1846,17 @@ func TestBroker_AwaitAck(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// Alice sends with await-ack (blocks)
 	sendDone := make(chan bool)
 	var sendResp *protocol.Response
 	go func() {
-		sendResp, _ = c1.Send(protocol.Request{
+		sendResp = sendRequest(t, c1, protocol.Request{
 			Cmd:      protocol.CmdSend,
 			Name:     "bob",
 			Message:  "await test",
@@ -1818,14 +1867,14 @@ func TestBroker_AwaitAck(t *testing.T) {
 	}()
 
 	// Bob receives push
-	pushResp, _ := c2.Receive()
+	pushResp := receiveResponse(t, c2)
 	var pushData struct {
 		ID int64 `json:"id"`
 	}
-	json.Unmarshal(pushResp.Data, &pushData)
+	unmarshalResponse(t, pushResp, &pushData)
 
 	// Bob acks
-	c2.Send(protocol.Request{
+	sendRequest(t, c2, protocol.Request{
 		Cmd:       protocol.CmdAck,
 		MessageID: pushData.ID,
 	})
@@ -1848,14 +1897,14 @@ func TestBroker_AwaitAckTimeout(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// Alice sends with await-ack and short timeout
-	resp, _ := c1.Send(protocol.Request{
+	resp := sendRequest(t, c1, protocol.Request{
 		Cmd:      protocol.CmdSend,
 		Name:     "bob",
 		Message:  "timeout test",
@@ -1879,14 +1928,14 @@ func TestBroker_AwaitAckNoLeak(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// Alice sends with await-ack and short timeout
-	c1.Send(protocol.Request{
+	sendRequest(t, c1, protocol.Request{
 		Cmd:      protocol.CmdSend,
 		Name:     "bob",
 		Message:  "leak test",
@@ -1906,14 +1955,14 @@ func TestBroker_AwaitAckNoLeak(t *testing.T) {
 	}
 
 	// Also verify by trying to ack the message and ensuring it doesn't crash
-	pushResp, _ := c2.Receive()
+	pushResp := receiveResponse(t, c2)
 	var pushData struct {
 		ID int64 `json:"id"`
 	}
-	json.Unmarshal(pushResp.Data, &pushData)
+	unmarshalResponse(t, pushResp, &pushData)
 
 	// Ack should succeed but not crash (waiter already removed)
-	resp, _ := c2.Send(protocol.Request{
+	resp := sendRequest(t, c2, protocol.Request{
 		Cmd:       protocol.CmdAck,
 		MessageID: pushData.ID,
 	})
@@ -1941,11 +1990,11 @@ func TestBroker_AwaitAckBrokerShutdown(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// Alice sends with await-ack (long timeout)
 	sendDone := make(chan *protocol.Response)
@@ -1988,20 +2037,20 @@ func TestBroker_PresenceShowsConnected(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// Check presence
-	resp, _ := c1.Send(protocol.Request{Cmd: protocol.CmdPresence})
+	resp := sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdPresence})
 	if !resp.OK {
 		t.Fatalf("presence failed: %s", resp.Error)
 	}
 
 	var agents []map[string]string
-	json.Unmarshal(resp.Data, &agents)
+	unmarshalResponse(t, resp, &agents)
 	if len(agents) != 2 {
 		t.Fatalf("presence len = %d, want 2", len(agents))
 	}
@@ -2028,7 +2077,7 @@ func TestBroker_SpawnStatus(t *testing.T) {
 
 	c := connectClient(t, sockPath)
 	defer c.Close()
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "cli"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "cli"})
 
 	// Add an agent to spawn manager
 	err := b.spawnMgr.Add("worker-1", "claude", 12345)
@@ -2037,13 +2086,13 @@ func TestBroker_SpawnStatus(t *testing.T) {
 	}
 
 	// Get status
-	resp, _ := c.Send(protocol.Request{Cmd: protocol.CmdStatus})
+	resp := sendRequest(t, c, protocol.Request{Cmd: protocol.CmdStatus})
 	if !resp.OK {
 		t.Fatalf("status failed: %s", resp.Error)
 	}
 
 	var status map[string]interface{}
-	json.Unmarshal(resp.Data, &status)
+	unmarshalResponse(t, resp, &status)
 
 	// Verify spawned key exists
 	spawned, ok := status["spawned"]
@@ -2070,14 +2119,14 @@ func TestBroker_SpawnRegister(t *testing.T) {
 
 	c := connectClient(t, sockPath)
 	defer c.Close()
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "cli"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "cli"})
 
 	// Register a spawn
-	spawnData, _ := json.Marshal(map[string]any{
+	spawnData := marshalJSON(t, map[string]any{
 		"pid":  12345,
 		"type": "claude",
 	})
-	resp, _ := c.Send(protocol.Request{
+	resp := sendRequest(t, c, protocol.Request{
 		Cmd:     protocol.CmdSpawnRegister,
 		Name:    "worker-1",
 		Payload: spawnData,
@@ -2087,13 +2136,13 @@ func TestBroker_SpawnRegister(t *testing.T) {
 	}
 
 	// Verify status includes spawn
-	resp, _ = c.Send(protocol.Request{Cmd: protocol.CmdStatus})
+	resp = sendRequest(t, c, protocol.Request{Cmd: protocol.CmdStatus})
 	if !resp.OK {
 		t.Fatalf("status failed: %s", resp.Error)
 	}
 
 	var status map[string]interface{}
-	json.Unmarshal(resp.Data, &status)
+	unmarshalResponse(t, resp, &status)
 
 	spawned, ok := status["spawned"]
 	if !ok {
@@ -2117,15 +2166,15 @@ func TestBroker_SpawnRegisterDuplicate(t *testing.T) {
 
 	c := connectClient(t, sockPath)
 	defer c.Close()
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "cli"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "cli"})
 
-	spawnData, _ := json.Marshal(map[string]any{
+	spawnData := marshalJSON(t, map[string]any{
 		"pid":  12345,
 		"type": "claude",
 	})
 
 	// First register
-	resp, _ := c.Send(protocol.Request{
+	resp := sendRequest(t, c, protocol.Request{
 		Cmd:     protocol.CmdSpawnRegister,
 		Name:    "worker-1",
 		Payload: spawnData,
@@ -2135,7 +2184,7 @@ func TestBroker_SpawnRegisterDuplicate(t *testing.T) {
 	}
 
 	// Second register same name
-	resp, _ = c.Send(protocol.Request{
+	resp = sendRequest(t, c, protocol.Request{
 		Cmd:     protocol.CmdSpawnRegister,
 		Name:    "worker-1",
 		Payload: spawnData,
@@ -2153,11 +2202,11 @@ func TestBroker_SpawnUpdatePID(t *testing.T) {
 	c := connectClient(t, sockPath)
 	defer c.Close()
 
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "spawner"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "spawner"})
 
 	// Register with PID=0
-	regData, _ := json.Marshal(map[string]any{"pid": 0, "type": "claude"})
-	resp, _ := c.Send(protocol.Request{
+	regData := marshalJSON(t, map[string]any{"pid": 0, "type": "claude"})
+	resp := sendRequest(t, c, protocol.Request{
 		Cmd:     protocol.CmdSpawnRegister,
 		Name:    "worker-1",
 		Payload: regData,
@@ -2167,8 +2216,8 @@ func TestBroker_SpawnUpdatePID(t *testing.T) {
 	}
 
 	// Update PID
-	pidData, _ := json.Marshal(map[string]any{"pid": 12345})
-	resp, _ = c.Send(protocol.Request{
+	pidData := marshalJSON(t, map[string]any{"pid": 12345})
+	resp = sendRequest(t, c, protocol.Request{
 		Cmd:     protocol.CmdSpawnUpdatePID,
 		Name:    "worker-1",
 		Payload: pidData,
@@ -2178,9 +2227,9 @@ func TestBroker_SpawnUpdatePID(t *testing.T) {
 	}
 
 	// Verify via status
-	resp, _ = c.Send(protocol.Request{Cmd: protocol.CmdStatus})
+	resp = sendRequest(t, c, protocol.Request{Cmd: protocol.CmdStatus})
 	var status map[string]interface{}
-	json.Unmarshal(resp.Data, &status)
+	unmarshalResponse(t, resp, &status)
 	spawned := status["spawned"].([]interface{})
 	if len(spawned) != 1 {
 		t.Fatalf("spawned len = %d, want 1", len(spawned))
@@ -2193,7 +2242,9 @@ func TestBroker_SpawnUpdatePID(t *testing.T) {
 
 // TestBroker_SpawnStatusAfterStop — spawned list is empty after shutdown
 func TestBroker_SpawnStatusAfterStop(t *testing.T) {
-	_, b, _ := startTestBroker(t)
+	sockPath, b, cleanup := startTestBroker(t)
+	_ = cleanup // This test calls b.Shutdown directly to assert post-stop state.
+	defer os.Remove(sockPath)
 
 	// Add agent directly
 	b.spawnMgr.Add("worker-1", "claude", 99999)
@@ -2221,15 +2272,15 @@ func TestBroker_PresenceConnectDisconnect(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	c2 := connectClient(t, sockPath)
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// Check presence — both present
-	resp, _ := c1.Send(protocol.Request{Cmd: protocol.CmdPresence})
+	resp := sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdPresence})
 	var agents []map[string]string
-	json.Unmarshal(resp.Data, &agents)
+	unmarshalResponse(t, resp, &agents)
 	if len(agents) != 2 {
 		t.Fatalf("presence len = %d, want 2", len(agents))
 	}
@@ -2239,8 +2290,8 @@ func TestBroker_PresenceConnectDisconnect(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// Check presence — only alice
-	resp, _ = c1.Send(protocol.Request{Cmd: protocol.CmdPresence})
-	json.Unmarshal(resp.Data, &agents)
+	resp = sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdPresence})
+	unmarshalResponse(t, resp, &agents)
 	if len(agents) != 1 {
 		t.Fatalf("presence len = %d, want 1 after disconnect", len(agents))
 	}
@@ -2256,10 +2307,10 @@ func TestBroker_PresenceEvents(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	// Subscribe to presence.events
-	resp, _ := c1.Send(protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "presence.events"})
+	resp := sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "presence.events"})
 	if !resp.OK {
 		t.Fatalf("subscribe failed: %s", resp.Error)
 	}
@@ -2269,7 +2320,7 @@ func TestBroker_PresenceEvents(t *testing.T) {
 	// Bob connects
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// Alice should receive presence.online event
 	select {
@@ -2292,14 +2343,14 @@ func TestBroker_SendWithPriority(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// Alice sends with priority
-	resp, _ := c1.Send(protocol.Request{
+	resp := sendRequest(t, c1, protocol.Request{
 		Cmd:         protocol.CmdSend,
 		Name:        "bob",
 		Message:     "urgent",
@@ -2313,13 +2364,13 @@ func TestBroker_SendWithPriority(t *testing.T) {
 	c2.Receive()
 
 	// Bob checks inbox
-	resp, _ = c2.Send(protocol.Request{Cmd: protocol.CmdInbox})
+	resp = sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdInbox})
 	if !resp.OK {
 		t.Fatalf("inbox failed: %s", resp.Error)
 	}
 
 	var messages []map[string]interface{}
-	json.Unmarshal(resp.Data, &messages)
+	unmarshalResponse(t, resp, &messages)
 	if len(messages) != 1 {
 		t.Fatalf("inbox len = %d, want 1", len(messages))
 	}
@@ -2335,14 +2386,14 @@ func TestBroker_SendWithTTL(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// Alice sends with TTL
-	resp, _ := c1.Send(protocol.Request{
+	resp := sendRequest(t, c1, protocol.Request{
 		Cmd:     protocol.CmdSend,
 		Name:    "bob",
 		Message: "expires soon",
@@ -2359,13 +2410,13 @@ func TestBroker_SendWithTTL(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// Bob checks inbox — should be empty (belt-and-suspenders filter)
-	resp, _ = c2.Send(protocol.Request{Cmd: protocol.CmdInbox})
+	resp = sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdInbox})
 	if !resp.OK {
 		t.Fatalf("inbox failed: %s", resp.Error)
 	}
 
 	var messages []map[string]interface{}
-	json.Unmarshal(resp.Data, &messages)
+	unmarshalResponse(t, resp, &messages)
 	if len(messages) != 0 {
 		t.Errorf("inbox len = %d, want 0 (expired)", len(messages))
 	}
@@ -2379,14 +2430,14 @@ func TestBroker_TTLCheckerRuns(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// Alice sends with TTL
-	resp, _ := c1.Send(protocol.Request{
+	resp := sendRequest(t, c1, protocol.Request{
 		Cmd:     protocol.CmdSend,
 		Name:    "bob",
 		Message: "expires",
@@ -2399,7 +2450,7 @@ func TestBroker_TTLCheckerRuns(t *testing.T) {
 	var msgData struct {
 		ID int64 `json:"id"`
 	}
-	json.Unmarshal(resp.Data, &msgData)
+	unmarshalResponse(t, resp, &msgData)
 
 	// Bob receives push
 	c2.Receive()
@@ -2417,13 +2468,13 @@ func TestBroker_TTLCheckerRuns(t *testing.T) {
 	}
 
 	// Bob checks inbox
-	resp, _ = c2.Send(protocol.Request{Cmd: protocol.CmdInbox})
+	resp = sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdInbox})
 	if !resp.OK {
 		t.Fatalf("inbox failed: %s", resp.Error)
 	}
 
 	var messages []map[string]interface{}
-	json.Unmarshal(resp.Data, &messages)
+	unmarshalResponse(t, resp, &messages)
 	if len(messages) != 0 {
 		t.Errorf("inbox len = %d, want 0 (expired)", len(messages))
 	}
@@ -2444,16 +2495,16 @@ func TestBroker_AwaitAckRaceEarlyAck(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "alice"})
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	// Alice sends with await-ack
 	sendDone := make(chan *protocol.Response)
 	go func() {
-		resp, _ := c1.Send(protocol.Request{
+		resp := sendRequest(t, c1, protocol.Request{
 			Cmd:      protocol.CmdSend,
 			Name:     "bob",
 			Message:  "race test",
@@ -2465,14 +2516,14 @@ func TestBroker_AwaitAckRaceEarlyAck(t *testing.T) {
 
 	// Bob receives push and acks immediately
 	// This creates the race: ack might arrive before sender enters select
-	pushResp, _ := c2.Receive()
+	pushResp := receiveResponse(t, c2)
 	var pushData struct {
 		ID int64 `json:"id"`
 	}
-	json.Unmarshal(pushResp.Data, &pushData)
+	unmarshalResponse(t, pushResp, &pushData)
 
 	// Ack immediately (no delay)
-	c2.Send(protocol.Request{
+	sendRequest(t, c2, protocol.Request{
 		Cmd:       protocol.CmdAck,
 		MessageID: pushData.ID,
 	})
@@ -2496,8 +2547,8 @@ func TestBroker_PresenceEventOnDisconnect(t *testing.T) {
 	// Observer subscribes to presence events
 	observer := connectClient(t, sockPath)
 	defer observer.Close()
-	observer.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "observer"})
-	resp, _ := observer.Send(protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "presence.events"})
+	sendRequest(t, observer, protocol.Request{Cmd: protocol.CmdConnect, Name: "observer"})
+	resp := sendRequest(t, observer, protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "presence.events"})
 	if !resp.OK {
 		t.Fatalf("subscribe failed: %s", resp.Error)
 	}
@@ -2506,7 +2557,7 @@ func TestBroker_PresenceEventOnDisconnect(t *testing.T) {
 
 	// Worker connects
 	worker := connectClient(t, sockPath)
-	worker.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "worker-1"})
+	sendRequest(t, worker, protocol.Request{Cmd: protocol.CmdConnect, Name: "worker-1"})
 
 	// Drain the connect event
 	select {
@@ -2516,7 +2567,7 @@ func TestBroker_PresenceEventOnDisconnect(t *testing.T) {
 	}
 
 	// Worker disconnects
-	worker.Send(protocol.Request{Cmd: protocol.CmdDisconnect})
+	sendRequest(t, worker, protocol.Request{Cmd: protocol.CmdDisconnect})
 	worker.Close()
 
 	// Observer should receive presence.offline event
@@ -2526,7 +2577,7 @@ func TestBroker_PresenceEventOnDisconnect(t *testing.T) {
 			t.Errorf("event = %q, want presence.offline", evt.Event)
 		}
 		var data map[string]string
-		json.Unmarshal(evt.Data, &data)
+		unmarshalJSON(t, evt.Data, &data)
 		if data["name"] != "worker-1" {
 			t.Errorf("name = %q, want worker-1", data["name"])
 		}
@@ -2540,20 +2591,17 @@ func TestBroker_CreateTaskWithTTL(t *testing.T) {
 	sockPath, b, cleanup := startTestBroker(t)
 	defer cleanup()
 
-	c, err := client.Connect(sockPath, 5*time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
+	c := connectClient(t, sockPath)
 	defer c.Close()
 
 	// Connect
-	resp, _ := c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "cli"})
+	resp := sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "cli"})
 	if !resp.OK {
 		t.Fatalf("connect failed: %s", resp.Error)
 	}
 
 	// Create task with TTL=60
-	resp, _ = c.Send(protocol.Request{
+	resp = sendRequest(t, c, protocol.Request{
 		Cmd:     protocol.CmdTaskCreate,
 		Payload: json.RawMessage(`{"desc":"ttl test"}`),
 		Type:    "test",
@@ -2567,7 +2615,7 @@ func TestBroker_CreateTaskWithTTL(t *testing.T) {
 	var taskData struct {
 		ID int64 `json:"id"`
 	}
-	json.Unmarshal(resp.Data, &taskData)
+	unmarshalResponse(t, resp, &taskData)
 	task, err := b.store.Get(taskData.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -2602,20 +2650,17 @@ func TestBroker_TaskTTLCheckerRuns(t *testing.T) {
 		os.Remove(sockPath)
 	}()
 
-	c, err := client.Connect(sockPath, 5*time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
+	c := connectClient(t, sockPath)
 	defer c.Close()
 
 	// Connect
-	resp, _ := c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "cli"})
+	resp := sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "cli"})
 	if !resp.OK {
 		t.Fatalf("connect failed: %s", resp.Error)
 	}
 
 	// Create task with TTL=1 second
-	resp, _ = c.Send(protocol.Request{
+	resp = sendRequest(t, c, protocol.Request{
 		Cmd:     protocol.CmdTaskCreate,
 		Payload: json.RawMessage(`{"desc":"expires soon"}`),
 		Type:    "test",
@@ -2628,7 +2673,7 @@ func TestBroker_TaskTTLCheckerRuns(t *testing.T) {
 	var taskData struct {
 		ID int64 `json:"id"`
 	}
-	json.Unmarshal(resp.Data, &taskData)
+	unmarshalResponse(t, resp, &taskData)
 	taskID := taskData.ID
 
 	// Wait for TTL to expire + checker to run
@@ -2652,21 +2697,18 @@ func TestBroker_StatusQueueHealth(t *testing.T) {
 	sockPath, _, cleanup := startTestBroker(t)
 	defer cleanup()
 
-	c, err := client.Connect(sockPath, 5*time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
+	c := connectClient(t, sockPath)
 	defer c.Close()
 
 	// Connect
-	resp, _ := c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "cli"})
+	resp := sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "cli"})
 	if !resp.OK {
 		t.Fatalf("connect failed: %s", resp.Error)
 	}
 
 	// Create 2 tasks
 	for i := 0; i < 2; i++ {
-		resp, _ = c.Send(protocol.Request{
+		resp = sendRequest(t, c, protocol.Request{
 			Cmd:     protocol.CmdTaskCreate,
 			Payload: json.RawMessage(fmt.Sprintf(`{"desc":"task %d"}`, i)),
 			Type:    "test",
@@ -2677,14 +2719,14 @@ func TestBroker_StatusQueueHealth(t *testing.T) {
 	}
 
 	// Get status
-	resp, _ = c.Send(protocol.Request{Cmd: protocol.CmdStatus})
+	resp = sendRequest(t, c, protocol.Request{Cmd: protocol.CmdStatus})
 	if !resp.OK {
 		t.Fatalf("status failed: %s", resp.Error)
 	}
 
 	// Verify queue_health is present
 	var statusData map[string]interface{}
-	json.Unmarshal(resp.Data, &statusData)
+	unmarshalResponse(t, resp, &statusData)
 	queueHealth, ok := statusData["queue_health"]
 	if !ok {
 		t.Fatal("expected queue_health in status")
@@ -2723,20 +2765,17 @@ func TestBroker_TaskStaleEvent(t *testing.T) {
 	}()
 
 	// Subscriber client
-	c1, err := client.Connect(sockPath, 5*time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
+	c1 := connectClient(t, sockPath)
 	defer c1.Close()
 
 	// Connect subscriber
-	resp, _ := c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "subscriber"})
+	resp := sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "subscriber"})
 	if !resp.OK {
 		t.Fatalf("connect failed: %s", resp.Error)
 	}
 
 	// Subscribe to task.events
-	resp, _ = c1.Send(protocol.Request{
+	resp = sendRequest(t, c1, protocol.Request{
 		Cmd:   protocol.CmdSubscribe,
 		Topic: "task.events",
 	})
@@ -2745,22 +2784,16 @@ func TestBroker_TaskStaleEvent(t *testing.T) {
 	}
 
 	// Start reading events
-	eventCh, err := c1.ReadStream()
-	if err != nil {
-		t.Fatalf("read stream: %v", err)
-	}
+	eventCh := readStream(t, c1)
 
 	// Creator client (separate connection to avoid protocol race)
-	c2, err := client.Connect(sockPath, 5*time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
+	c2 := connectClient(t, sockPath)
 	defer c2.Close()
 
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "creator"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "creator"})
 
 	// Create task (will become stale after 1 second)
-	resp, _ = c2.Send(protocol.Request{
+	resp = sendRequest(t, c2, protocol.Request{
 		Cmd:     protocol.CmdTaskCreate,
 		Payload: json.RawMessage(`{"desc":"stale task"}`),
 		Type:    "test",
@@ -2793,9 +2826,7 @@ func TestBroker_TaskStaleEvent(t *testing.T) {
 
 	// Parse the event data
 	var data map[string]interface{}
-	if err := json.Unmarshal(staleEvent.Data, &data); err != nil {
-		t.Fatalf("failed to parse event data: %v", err)
-	}
+	unmarshalJSON(t, staleEvent.Data, &data)
 
 	// Verify stale_count > 0
 	staleCount, ok := data["stale_count"].(float64)
@@ -2816,10 +2847,10 @@ func TestBroker_CreateTaskWithInvalidTTL(t *testing.T) {
 
 	c := connectClient(t, sockPath)
 	defer c.Close()
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "cli"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "cli"})
 
 	// Negative TTL
-	resp, _ := c.Send(protocol.Request{
+	resp := sendRequest(t, c, protocol.Request{
 		Cmd:     protocol.CmdTaskCreate,
 		Payload: json.RawMessage(`{"desc":"neg ttl"}`),
 		Type:    "test",
@@ -2833,7 +2864,7 @@ func TestBroker_CreateTaskWithInvalidTTL(t *testing.T) {
 	}
 
 	// Exceeds max TTL
-	resp, _ = c.Send(protocol.Request{
+	resp = sendRequest(t, c, protocol.Request{
 		Cmd:     protocol.CmdTaskCreate,
 		Payload: json.RawMessage(`{"desc":"big ttl"}`),
 		Type:    "test",
@@ -2856,20 +2887,17 @@ func TestBroker_CustomEventHasTopic(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "subscriber"})
-	resp, _ := c1.Send(protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "chat.demo"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "subscriber"})
+	resp := sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "chat.demo"})
 	if !resp.OK {
 		t.Fatalf("subscribe: %s", resp.Error)
 	}
-	eventCh, err := c1.ReadStream()
-	if err != nil {
-		t.Fatalf("ReadStream: %v", err)
-	}
+	eventCh := readStream(t, c1)
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "publisher"})
-	c2.Send(protocol.Request{Cmd: protocol.CmdPublish, Topic: "chat.demo", Message: `{"msg":"hi"}`})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "publisher"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdPublish, Topic: "chat.demo", Message: `{"msg":"hi"}`})
 
 	select {
 	case evt := <-eventCh:
@@ -2888,14 +2916,14 @@ func TestBroker_CustomEventHasTimestamp(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "subscriber"})
-	c1.Send(protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "chat.demo"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "subscriber"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "chat.demo"})
 	eventCh := readStream(t, c1)
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "publisher"})
-	c2.Send(protocol.Request{Cmd: protocol.CmdPublish, Topic: "chat.demo", Message: `{"msg":"hi"}`})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "publisher"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdPublish, Topic: "chat.demo", Message: `{"msg":"hi"}`})
 
 	select {
 	case evt := <-eventCh:
@@ -2917,14 +2945,14 @@ func TestBroker_CustomEventHasData(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "subscriber"})
-	c1.Send(protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "chat.demo"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "subscriber"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "chat.demo"})
 	eventCh := readStream(t, c1)
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "publisher"})
-	c2.Send(protocol.Request{Cmd: protocol.CmdPublish, Topic: "chat.demo", Message: `{"key":"value"}`})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "publisher"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdPublish, Topic: "chat.demo", Message: `{"key":"value"}`})
 
 	select {
 	case evt := <-eventCh:
@@ -2932,9 +2960,7 @@ func TestBroker_CustomEventHasData(t *testing.T) {
 			t.Error("event.Data should be non-empty")
 		}
 		var data map[string]string
-		if err := json.Unmarshal(evt.Data, &data); err != nil {
-			t.Fatalf("failed to parse event.Data: %v", err)
-		}
+		unmarshalJSON(t, evt.Data, &data)
 		if data["key"] != "value" {
 			t.Errorf("event.Data[key] = %q, want %q", data["key"], "value")
 		}
@@ -2950,14 +2976,14 @@ func TestBroker_CustomEventName(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "subscriber"})
-	c1.Send(protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "chat.demo"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "subscriber"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "chat.demo"})
 	eventCh := readStream(t, c1)
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "publisher"})
-	c2.Send(protocol.Request{Cmd: protocol.CmdPublish, Topic: "chat.demo", Message: `{"msg":"hi"}`})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "publisher"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdPublish, Topic: "chat.demo", Message: `{"msg":"hi"}`})
 
 	select {
 	case evt := <-eventCh:
@@ -2976,8 +3002,8 @@ func TestBroker_TaskEventsRegression(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "subscriber"})
-	resp, _ := c1.Send(protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "task.events"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "subscriber"})
+	resp := sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "task.events"})
 	if !resp.OK {
 		t.Fatalf("subscribe: %s", resp.Error)
 	}
@@ -2985,8 +3011,8 @@ func TestBroker_TaskEventsRegression(t *testing.T) {
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "creator"})
-	c2.Send(protocol.Request{
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "creator"})
+	sendRequest(t, c2, protocol.Request{
 		Cmd:     protocol.CmdTaskCreate,
 		Payload: json.RawMessage(`{"desc":"regression"}`),
 		Type:    "test",
@@ -3018,8 +3044,8 @@ func TestBroker_PresenceEventsRegression(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "subscriber"})
-	resp, _ := c1.Send(protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "presence.events"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "subscriber"})
+	resp := sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "presence.events"})
 	if !resp.OK {
 		t.Fatalf("subscribe: %s", resp.Error)
 	}
@@ -3027,7 +3053,7 @@ func TestBroker_PresenceEventsRegression(t *testing.T) {
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "new-agent"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "new-agent"})
 
 	select {
 	case evt := <-eventCh:
@@ -3052,9 +3078,9 @@ func TestBroker_CustomEventInvalidJSON(t *testing.T) {
 
 	c := connectClient(t, sockPath)
 	defer c.Close()
-	c.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "publisher"})
+	sendRequest(t, c, protocol.Request{Cmd: protocol.CmdConnect, Name: "publisher"})
 
-	resp, _ := c.Send(protocol.Request{
+	resp := sendRequest(t, c, protocol.Request{
 		Cmd:     protocol.CmdPublish,
 		Topic:   "chat.demo",
 		Message: "not json",
@@ -3074,14 +3100,14 @@ func TestBroker_CustomEventEmptyMessage(t *testing.T) {
 
 	c1 := connectClient(t, sockPath)
 	defer c1.Close()
-	c1.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "subscriber"})
-	c1.Send(protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "chat.demo"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdConnect, Name: "subscriber"})
+	sendRequest(t, c1, protocol.Request{Cmd: protocol.CmdSubscribe, Topic: "chat.demo"})
 	eventCh := readStream(t, c1)
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "publisher"})
-	resp, _ := c2.Send(protocol.Request{Cmd: protocol.CmdPublish, Topic: "chat.demo", Message: ""})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "publisher"})
+	resp := sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdPublish, Topic: "chat.demo", Message: ""})
 	if !resp.OK {
 		t.Fatalf("publish with empty message should succeed: %s", resp.Error)
 	}
@@ -4061,9 +4087,7 @@ func TestBroker_ListenerDoesNotBlockAgentCLI(t *testing.T) {
 	}
 
 	var inbox []map[string]any
-	if err := json.Unmarshal(inboxResp.Data, &inbox); err != nil {
-		t.Fatal(err)
-	}
+	unmarshalResponse(t, inboxResp, &inbox)
 	if len(inbox) != 1 {
 		t.Fatalf("inbox length = %d, want 1", len(inbox))
 	}
@@ -4137,10 +4161,7 @@ func TestBroker_PushToListenerSession(t *testing.T) {
 	sockPath, _, cleanup := startTestBroker(t)
 	defer cleanup()
 
-	baseConn, err := client.Connect(sockPath, 5*time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
+	baseConn := connectClient(t, sockPath)
 	defer baseConn.Close()
 
 	baseResp, err := baseConn.Send(protocol.Request{
@@ -4156,10 +4177,7 @@ func TestBroker_PushToListenerSession(t *testing.T) {
 	pushToken := pushTokenFromResponse(t, baseResp)
 
 	// Connect as "alice-push" (the persistent listener)
-	listenerConn, err := client.Connect(sockPath, 5*time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
+	listenerConn := connectClient(t, sockPath)
 	defer listenerConn.Close()
 
 	connectReq := protocol.Request{
@@ -4177,10 +4195,7 @@ func TestBroker_PushToListenerSession(t *testing.T) {
 	}
 
 	// Connect as sender
-	senderConn, err := client.Connect(sockPath, 5*time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
+	senderConn := connectClient(t, sockPath)
 	defer senderConn.Close()
 
 	connectReq = protocol.Request{
@@ -4212,9 +4227,7 @@ func TestBroker_PushToListenerSession(t *testing.T) {
 	}
 
 	var data map[string]any
-	if err := json.Unmarshal(recvResp.Data, &data); err != nil {
-		t.Fatal(err)
-	}
+	unmarshalResponse(t, recvResp, &data)
 
 	if data["type"] != "message" {
 		t.Errorf("expected type=message, got %v", data["type"])
@@ -4231,10 +4244,7 @@ func TestBroker_SelfSendDoesNotPushToListener(t *testing.T) {
 	sockPath, _, cleanup := startTestBroker(t)
 	defer cleanup()
 
-	baseConn, err := client.Connect(sockPath, 5*time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
+	baseConn := connectClient(t, sockPath)
 	defer baseConn.Close()
 
 	baseResp, err := baseConn.Send(protocol.Request{
@@ -4249,10 +4259,7 @@ func TestBroker_SelfSendDoesNotPushToListener(t *testing.T) {
 	}
 	pushToken := pushTokenFromResponse(t, baseResp)
 
-	listenerConn, err := client.Connect(sockPath, 5*time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
+	listenerConn := connectClient(t, sockPath)
 	defer listenerConn.Close()
 
 	pushResp, err := listenerConn.Send(protocol.Request{
@@ -4297,10 +4304,7 @@ func TestBroker_ListenReceivesPush(t *testing.T) {
 	sockPath, _, cleanup := startTestBroker(t)
 	defer cleanup()
 
-	baseConn, err := client.Connect(sockPath, 5*time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
+	baseConn := connectClient(t, sockPath)
 	defer baseConn.Close()
 
 	baseResp, err := baseConn.Send(protocol.Request{
@@ -4316,10 +4320,7 @@ func TestBroker_ListenReceivesPush(t *testing.T) {
 	pushToken := pushTokenFromResponse(t, baseResp)
 
 	// Connect listener using ReadMessages
-	listenerConn, err := client.Connect(sockPath, 5*time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
+	listenerConn := connectClient(t, sockPath)
 	defer listenerConn.Close()
 
 	connectReq := protocol.Request{
@@ -4343,10 +4344,7 @@ func TestBroker_ListenReceivesPush(t *testing.T) {
 	}
 
 	// Connect sender
-	senderConn, err := client.Connect(sockPath, 5*time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
+	senderConn := connectClient(t, sockPath)
 	defer senderConn.Close()
 
 	connectReq = protocol.Request{
@@ -4423,7 +4421,7 @@ func TestClient_ReadMessagesFilters(t *testing.T) {
 	// This will push to "filter-test-push" via the broker's -push logic
 	sender := connectClient(t, sockPath)
 	defer sender.Close()
-	sender.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "sender-filter"})
+	sendRequest(t, sender, protocol.Request{Cmd: protocol.CmdConnect, Name: "sender-filter"})
 	sendResp, err := sender.Send(protocol.Request{
 		Cmd:     protocol.CmdSend,
 		Name:    "filter-test",
@@ -4485,15 +4483,15 @@ func TestPresence_StripsPushAndDeduplicates(t *testing.T) {
 
 	c2 := connectClient(t, sockPath)
 	defer c2.Close()
-	c2.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
+	sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdConnect, Name: "bob"})
 
 	c3 := connectClient(t, sockPath)
 	defer c3.Close()
-	c3.Send(protocol.Request{Cmd: protocol.CmdConnect, Name: "probe"})
+	sendRequest(t, c3, protocol.Request{Cmd: protocol.CmdConnect, Name: "probe"})
 
-	resp, _ := c3.Send(protocol.Request{Cmd: protocol.CmdPresence})
+	resp := sendRequest(t, c3, protocol.Request{Cmd: protocol.CmdPresence})
 	var agents []map[string]string
-	json.Unmarshal(resp.Data, &agents)
+	unmarshalResponse(t, resp, &agents)
 
 	names := make(map[string]bool)
 	for _, a := range agents {

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
@@ -16,13 +17,26 @@ import (
 	"github.com/seungpyoson/waggle/internal/protocol"
 )
 
+func shortBrokerSocketPath(t *testing.T, pattern string) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", pattern) // Use /tmp to keep Unix socket paths below the macOS 104-byte limit.
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Logf("cleanup temp socket dir: %v", err)
+		}
+	})
+	return filepath.Join(dir, "broker.sock")
+}
+
 func startTestBroker(t *testing.T) (string, *Broker, func()) {
 	t.Helper()
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	// Use /tmp for socket to avoid path length issues
-	sockPath := fmt.Sprintf("/tmp/waggle-test-%d.sock", time.Now().UnixNano())
+	sockPath := shortBrokerSocketPath(t, "waggle-test-*")
 	dbPath := fmt.Sprintf("%s/db", tmpDir)
 
 	b, err := New(Config{SocketPath: sockPath, DBPath: dbPath})
@@ -43,7 +57,7 @@ func startTestBrokerWithTTL(t *testing.T, ttlCheckPeriod time.Duration) (string,
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	sockPath := fmt.Sprintf("/tmp/waggle-test-%d.sock", time.Now().UnixNano())
+	sockPath := shortBrokerSocketPath(t, "waggle-test-*")
 	dbPath := fmt.Sprintf("%s/db", tmpDir)
 
 	b, err := New(Config{
@@ -1152,7 +1166,7 @@ func TestBroker_MessagesSurviveRestart(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	sockPath := fmt.Sprintf("/tmp/waggle-test-%d.sock", time.Now().UnixNano())
+	sockPath := shortBrokerSocketPath(t, "waggle-test-*")
 	dbPath := fmt.Sprintf("%s/db", tmpDir)
 
 	// Start first broker
@@ -1976,8 +1990,7 @@ func TestBroker_AwaitAckBrokerShutdown(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	// Use /tmp for socket to avoid path length issues
-	sockPath := fmt.Sprintf("/tmp/waggle-test-%d.sock", time.Now().UnixNano())
+	sockPath := shortBrokerSocketPath(t, "waggle-test-*")
 	dbPath := fmt.Sprintf("%s/db", tmpDir)
 
 	b, err := New(Config{SocketPath: sockPath, DBPath: dbPath})
@@ -2630,7 +2643,7 @@ func TestBroker_TaskTTLCheckerRuns(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	sockPath := fmt.Sprintf("/tmp/waggle-test-%d.sock", time.Now().UnixNano())
+	sockPath := shortBrokerSocketPath(t, "waggle-test-*")
 	dbPath := fmt.Sprintf("%s/db", tmpDir)
 
 	// Create broker with short task TTL check period
@@ -2743,7 +2756,7 @@ func TestBroker_TaskStaleEvent(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	sockPath := fmt.Sprintf("/tmp/waggle-test-%d.sock", time.Now().UnixNano())
+	sockPath := shortBrokerSocketPath(t, "waggle-test-*")
 	dbPath := fmt.Sprintf("%s/db", tmpDir)
 
 	// Create broker with short task TTL check period and stale threshold

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -1696,7 +1696,7 @@ func TestBroker_Ack(t *testing.T) {
 	unmarshalResponse(t, resp, &msgData)
 
 	// Bob receives push
-	c2.Receive()
+	receiveResponse(t, c2)
 
 	// Bob acks the message
 	resp = sendRequest(t, c2, protocol.Request{
@@ -1822,7 +1822,7 @@ func TestBroker_FullAckLifecycle(t *testing.T) {
 	}
 
 	// Bob receives push
-	c2.Receive()
+	receiveResponse(t, c2)
 
 	// Bob checks inbox (state: pushed → seen)
 	resp = sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdInbox})
@@ -2394,7 +2394,7 @@ func TestBroker_SendWithPriority(t *testing.T) {
 	}
 
 	// Bob receives push
-	c2.Receive()
+	receiveResponse(t, c2)
 
 	// Bob checks inbox
 	resp = sendRequest(t, c2, protocol.Request{Cmd: protocol.CmdInbox})
@@ -2437,7 +2437,7 @@ func TestBroker_SendWithTTL(t *testing.T) {
 	}
 
 	// Bob receives push
-	c2.Receive()
+	receiveResponse(t, c2)
 
 	// Wait for TTL to expire
 	time.Sleep(2 * time.Second)
@@ -2486,7 +2486,7 @@ func TestBroker_TTLCheckerRuns(t *testing.T) {
 	unmarshalResponse(t, resp, &msgData)
 
 	// Bob receives push
-	c2.Receive()
+	receiveResponse(t, c2)
 
 	// Wait for TTL to expire (1s) and checker to fire (500ms period)
 	time.Sleep(2 * time.Second)

--- a/internal/broker/lifecycle.go
+++ b/internal/broker/lifecycle.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/seungpyoson/waggle/internal/config"
+	"github.com/seungpyoson/waggle/internal/protocol"
 )
 
 // WritePID writes the current process ID to the specified file.
@@ -26,13 +27,13 @@ func ReadPID(pidFile string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	
+
 	pidStr := strings.TrimSpace(string(data))
 	pid, err := strconv.Atoi(pidStr)
 	if err != nil {
 		return 0, fmt.Errorf("invalid PID in file: %w", err)
 	}
-	
+
 	return pid, nil
 }
 
@@ -43,20 +44,20 @@ func IsRunning(pidFile string) bool {
 	if err != nil {
 		return false
 	}
-	
+
 	// Send signal 0 to check if process exists
 	// This doesn't actually send a signal, just checks permissions
 	process, err := os.FindProcess(pid)
 	if err != nil {
 		return false
 	}
-	
+
 	// On Unix, FindProcess always succeeds, so we need to send signal 0
 	err = process.Signal(syscall.Signal(0))
 	if err != nil {
 		return false
 	}
-	
+
 	return true
 }
 
@@ -84,7 +85,7 @@ func IsResponding(socketPath string, timeout time.Duration) bool {
 	// Send a status request (no session required)
 	req := struct {
 		Cmd string `json:"cmd"`
-	}{Cmd: "status"}
+	}{Cmd: protocol.CmdStatus}
 	data, err := json.Marshal(req)
 	if err != nil {
 		return false
@@ -120,21 +121,21 @@ func CleanupStale(pidFile, socketPath string) error {
 	if IsRunning(pidFile) {
 		return fmt.Errorf("cannot cleanup: broker is running")
 	}
-	
+
 	// Remove stale PID file
 	if _, err := os.Stat(pidFile); err == nil {
 		if err := os.Remove(pidFile); err != nil {
 			return fmt.Errorf("removing stale PID file: %w", err)
 		}
 	}
-	
+
 	// Remove stale socket file
 	if _, err := os.Stat(socketPath); err == nil {
 		if err := os.Remove(socketPath); err != nil {
 			return fmt.Errorf("removing stale socket file: %w", err)
 		}
 	}
-	
+
 	return nil
 }
 

--- a/internal/broker/lifecycle_test.go
+++ b/internal/broker/lifecycle_test.go
@@ -10,16 +10,6 @@ import (
 	"time"
 )
 
-func shortSocketPath(t *testing.T, pattern string) string {
-	t.Helper()
-	dir, err := os.MkdirTemp("/tmp", pattern) // Use /tmp to keep Unix socket paths below the macOS 104-byte limit.
-	if err != nil {
-		t.Fatalf("MkdirTemp: %v", err)
-	}
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	return filepath.Join(dir, "broker.sock")
-}
-
 // TestLifecycle_StartFailsIfPIDIsLive verifies that starting a broker fails
 // if a PID file exists and the process is still running.
 func TestLifecycle_StartFailsIfPIDIsLive(t *testing.T) {
@@ -84,7 +74,7 @@ func TestLifecycle_StartCleansStalePIDAndSocket(t *testing.T) {
 func TestLifecycle_StopRemovesPIDAndSocket(t *testing.T) {
 	tmpDir := t.TempDir()
 	pidFile := filepath.Join(tmpDir, "broker.pid")
-	sockPath := shortSocketPath(t, "waggle-lifecycle-test-*")
+	sockPath := shortBrokerSocketPath(t, "waggle-lifecycle-test-*")
 	dbPath := filepath.Join(tmpDir, "state.db")
 
 	// Create broker
@@ -133,7 +123,7 @@ func TestLifecycle_StopRemovesPIDAndSocket(t *testing.T) {
 // with 0700 permissions (owner-only access).
 func TestLifecycle_SocketPermissions0700(t *testing.T) {
 	tmpDir := t.TempDir()
-	sockPath := shortSocketPath(t, "waggle-lifecycle-perm-test-*")
+	sockPath := shortBrokerSocketPath(t, "waggle-lifecycle-perm-test-*")
 	dbPath := filepath.Join(tmpDir, "state.db")
 
 	// Create broker (which creates socket with 0700 permissions)
@@ -269,7 +259,7 @@ func TestWaitForReady_RejectsNegativeInterval(t *testing.T) {
 // the idle timeout when there are no active sessions.
 func TestLifecycle_IdleTimeout(t *testing.T) {
 	tmpDir := t.TempDir()
-	sockPath := shortSocketPath(t, "waggle-idle-test-*")
+	sockPath := shortBrokerSocketPath(t, "waggle-idle-test-*")
 	dbPath := filepath.Join(tmpDir, "state.db")
 
 	// Create broker with short idle timeout
@@ -316,7 +306,7 @@ func TestLifecycle_IdleTimeout(t *testing.T) {
 }
 
 func TestIsResponding_ZombieSocket(t *testing.T) {
-	sockPath := shortSocketPath(t, "waggle-zombie-test-*")
+	sockPath := shortBrokerSocketPath(t, "waggle-zombie-test-*")
 	ln, err := net.Listen("unix", sockPath)
 	if err != nil {
 		t.Fatal(err)
@@ -337,7 +327,7 @@ func TestIsResponding_ZombieSocket(t *testing.T) {
 
 func TestIsResponding_HealthyBroker(t *testing.T) {
 	tmpDir := t.TempDir()
-	sockPath := shortSocketPath(t, "waggle-responding-test-*")
+	sockPath := shortBrokerSocketPath(t, "waggle-responding-test-*")
 	dbPath := filepath.Join(tmpDir, "state.db")
 
 	b, err := New(Config{SocketPath: sockPath, DBPath: dbPath})

--- a/internal/broker/lifecycle_test.go
+++ b/internal/broker/lifecycle_test.go
@@ -10,6 +10,16 @@ import (
 	"time"
 )
 
+func shortSocketPath(t *testing.T, pattern string) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", pattern) // Use /tmp to keep Unix socket paths below the macOS 104-byte limit.
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return filepath.Join(dir, "broker.sock")
+}
+
 // TestLifecycle_StartFailsIfPIDIsLive verifies that starting a broker fails
 // if a PID file exists and the process is still running.
 func TestLifecycle_StartFailsIfPIDIsLive(t *testing.T) {
@@ -74,10 +84,8 @@ func TestLifecycle_StartCleansStalePIDAndSocket(t *testing.T) {
 func TestLifecycle_StopRemovesPIDAndSocket(t *testing.T) {
 	tmpDir := t.TempDir()
 	pidFile := filepath.Join(tmpDir, "broker.pid")
-	// Use /tmp for socket to avoid path length issues
-	sockPath := fmt.Sprintf("/tmp/waggle-lifecycle-test-%d.sock", time.Now().UnixNano())
+	sockPath := shortSocketPath(t, "waggle-lifecycle-test-*")
 	dbPath := filepath.Join(tmpDir, "state.db")
-	defer os.Remove(sockPath)
 
 	// Create broker
 	b, err := New(Config{SocketPath: sockPath, DBPath: dbPath})
@@ -125,10 +133,8 @@ func TestLifecycle_StopRemovesPIDAndSocket(t *testing.T) {
 // with 0700 permissions (owner-only access).
 func TestLifecycle_SocketPermissions0700(t *testing.T) {
 	tmpDir := t.TempDir()
-	// Use /tmp for socket to avoid path length issues
-	sockPath := fmt.Sprintf("/tmp/waggle-lifecycle-perm-test-%d.sock", time.Now().UnixNano())
+	sockPath := shortSocketPath(t, "waggle-lifecycle-perm-test-*")
 	dbPath := filepath.Join(tmpDir, "state.db")
-	defer os.Remove(sockPath)
 
 	// Create broker (which creates socket with 0700 permissions)
 	b, err := New(Config{SocketPath: sockPath, DBPath: dbPath})
@@ -263,9 +269,8 @@ func TestWaitForReady_RejectsNegativeInterval(t *testing.T) {
 // the idle timeout when there are no active sessions.
 func TestLifecycle_IdleTimeout(t *testing.T) {
 	tmpDir := t.TempDir()
-	sockPath := fmt.Sprintf("/tmp/waggle-idle-test-%d.sock", time.Now().UnixNano())
+	sockPath := shortSocketPath(t, "waggle-idle-test-*")
 	dbPath := filepath.Join(tmpDir, "state.db")
-	defer os.Remove(sockPath)
 
 	// Create broker with short idle timeout
 	b, err := New(Config{
@@ -311,12 +316,11 @@ func TestLifecycle_IdleTimeout(t *testing.T) {
 }
 
 func TestIsResponding_ZombieSocket(t *testing.T) {
-	sockPath := fmt.Sprintf("/tmp/waggle-zombie-test-%d.sock", time.Now().UnixNano())
+	sockPath := shortSocketPath(t, "waggle-zombie-test-*")
 	ln, err := net.Listen("unix", sockPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(sockPath)
 	defer ln.Close()
 
 	start := time.Now()
@@ -333,9 +337,8 @@ func TestIsResponding_ZombieSocket(t *testing.T) {
 
 func TestIsResponding_HealthyBroker(t *testing.T) {
 	tmpDir := t.TempDir()
-	sockPath := fmt.Sprintf("/tmp/waggle-responding-test-%d.sock", time.Now().UnixNano())
+	sockPath := shortSocketPath(t, "waggle-responding-test-*")
 	dbPath := filepath.Join(tmpDir, "state.db")
-	defer os.Remove(sockPath)
 
 	b, err := New(Config{SocketPath: sockPath, DBPath: dbPath})
 	if err != nil {
@@ -351,7 +354,7 @@ func TestIsResponding_HealthyBroker(t *testing.T) {
 }
 
 func TestIsResponding_MissingSocket(t *testing.T) {
-	if IsResponding("/tmp/nonexistent-waggle.sock", 500*time.Millisecond) {
+	if IsResponding(filepath.Join(t.TempDir(), "nonexistent-waggle.sock"), 500*time.Millisecond) {
 		t.Error("expected false for missing socket")
 	}
 }

--- a/internal/broker/lifecycle_test.go
+++ b/internal/broker/lifecycle_test.go
@@ -344,7 +344,7 @@ func TestIsResponding_HealthyBroker(t *testing.T) {
 }
 
 func TestIsResponding_MissingSocket(t *testing.T) {
-	if IsResponding(filepath.Join(t.TempDir(), "nonexistent-waggle.sock"), 500*time.Millisecond) {
+	if IsResponding(shortBrokerSocketPath(t, "nonexistent-waggle-*"), 500*time.Millisecond) {
 		t.Error("expected false for missing socket")
 	}
 }


### PR DESCRIPTION
## Summary

Addresses #61 and #67.

- Adds fail-loud broker test helpers for `Send`, `Receive`, JSON marshal/unmarshal, and response decoding.
- Replaces unchecked broker test `Send`, `Receive`, `ReadStream`, `Connect`, and JSON decode/encode patterns with helpers or explicit checks.
- Uses `protocol.CmdStatus` in `IsResponding` instead of a raw `"status"` literal.
- Makes zombie cleanup stderr writes explicitly best-effort and centralizes intentional `/tmp` test directories behind short-path helpers with macOS socket-limit comments.
- Removes the remaining direct `/tmp/waggle-test-*.sock` literals from broker tests.

## Verification

- `go test ./internal/broker -run 'TestBroker_MessagesSurviveRestart|TestBroker_AwaitAckBrokerShutdown|TestBroker_TaskTTLCheckerRuns|TestBroker_TaskStaleEvent|TestBroker_SessionsCommand' -count=1`
- `go test ./... -count=1 -p=1`
- `go vet ./...`
- `git diff --check`
- #67 static grep checks: no direct `/tmp/waggle-test-*.sock` literals remain; intentional `/tmp` helper use is annotated
- #61 broker-test unchecked JSON grep: only helper implementation lines remain