### PR TITLE
fix(#774): correct comment corruption and harden format gate

### DIFF
--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -15,7 +15,7 @@ commands:
   # exclude .worktrees/ — this repo keeps git worktrees of other branches
   # there and their files have their own (correct) formatting state for
   # those branches; not relevant to formatting this branch.
-  format: 'test -z "$(gofmt -l . | grep -v ^\.worktrees/)"'
+  format: 'files=$(gofmt -l . 2>&1); rc=$?; if [ "$rc" -ne 0 ]; then printf "%s\n" "$files" >&2; exit "$rc"; fi; files=$(printf "%s\n" "$files" | grep -v "^\.worktrees/" || true); test -z "$files"'
 
 # Paths excluded from agent-driven review/document steps.
 # .worktrees/ contains nested git worktree checkouts (not part of this branch's

--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -16,13 +16,17 @@ commands:
   # there and their files have their own (correct) formatting state for
   # those branches; not relevant to formatting this branch.
   #
-  # Filter at the file-enumeration level (find -not -path) rather than
+  # Filter at the file-enumeration level (find -prune) rather than
   # post-hoc on gofmt's stdout. Post-hoc filtering misses parse errors,
   # which gofmt emits to stderr with a non-zero exit code regardless of
   # which file caused them — including files under .worktrees/. Pruning
   # before gofmt runs ensures parse errors confined to .worktrees/ do not
   # fail this branch's gate.
-  format: 'out=$(find . -name "*.go" -not -path "./.worktrees/*" -exec gofmt -l {} + 2>&1); rc=$?; if [ "$rc" -ne 0 ] || [ -n "$out" ]; then printf "%s\n" "$out" >&2; exit 1; fi'
+  #
+  # -prune (not -not -path) so find never descends into .worktrees/ at all.
+  # -type f so a directory accidentally named *.go is not passed to gofmt
+  # (gofmt recurses into directory arguments, causing duplicate work).
+  format: 'out=$(find . -path "./.worktrees" -prune -o -type f -name "*.go" -exec gofmt -l {} + 2>&1); rc=$?; if [ "$rc" -ne 0 ] || [ -n "$out" ]; then printf "%s\n" "$out" >&2; exit 1; fi'
 
 # Paths excluded from agent-driven review/document steps.
 # .worktrees/ contains nested git worktree checkouts (not part of this branch's

--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -15,7 +15,14 @@ commands:
   # exclude .worktrees/ — this repo keeps git worktrees of other branches
   # there and their files have their own (correct) formatting state for
   # those branches; not relevant to formatting this branch.
-  format: 'files=$(gofmt -l . 2>&1); rc=$?; if [ "$rc" -ne 0 ]; then printf "%s\n" "$files" >&2; exit "$rc"; fi; files=$(printf "%s\n" "$files" | grep -v "^\.worktrees/" || true); test -z "$files"'
+  #
+  # Filter at the file-enumeration level (find -not -path) rather than
+  # post-hoc on gofmt's stdout. Post-hoc filtering misses parse errors,
+  # which gofmt emits to stderr with a non-zero exit code regardless of
+  # which file caused them — including files under .worktrees/. Pruning
+  # before gofmt runs ensures parse errors confined to .worktrees/ do not
+  # fail this branch's gate.
+  format: 'out=$(find . -name "*.go" -not -path "./.worktrees/*" -exec gofmt -l {} + 2>&1); rc=$?; if [ "$rc" -ne 0 ] || [ -n "$out" ]; then printf "%s\n" "$out" >&2; exit 1; fi'
 
 # Paths excluded from agent-driven review/document steps.
 # .worktrees/ contains nested git worktree checkouts (not part of this branch's

--- a/internal/spawn/command.go
+++ b/internal/spawn/command.go
@@ -61,7 +61,7 @@ func BuildPgrepPattern(name string) string {
 }
 
 // shellQuote wraps a value in single quotes with proper escaping.
-// Single-quote escape: replace ' with '\” (end quote, escaped quote, start quote)
+// Single-quote escape: replace ' with end-quote + escaped-quote + start-quote.
 func shellQuote(s string) string {
 	// Replace each single quote with '\''
 	escaped := strings.ReplaceAll(s, "'", `'\''`)

--- a/internal/spawn/format_gate_test.go
+++ b/internal/spawn/format_gate_test.go
@@ -1,0 +1,201 @@
+package spawn
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestFormatGate guards seungpyoson/claude-config#774 D3 and D5.
+//
+// The .no-mistakes.yaml `format:` command was previously
+//
+//	test -z "$(gofmt -l . | grep -v ^\.worktrees/)"
+//
+// which masked gofmt's non-zero exit on parse errors (the pipe replaces
+// gofmt's exit code with grep's, and `$(...)` swallows stderr). Broken Go
+// files passed the gate (D3). A subsequent fix that captured gofmt's exit
+// code explicitly exposed D5: parse errors confined to .worktrees/ also
+// failed the gate, because parse errors go to stderr with rc=2 regardless
+// of which file produced them, and post-hoc stdout filtering on gofmt -l's
+// file list cannot reach them. The current command filters at the file-
+// enumeration level (find -not -path) so .worktrees/ is pruned before gofmt
+// runs.
+//
+// This test reads the live `format:` command from .no-mistakes.yaml so it
+// guards the *current* gate, not a frozen historical snapshot. The four
+// sub-tests cover the cartesian product of {parse error, unformatted} ×
+// {main tree, .worktrees/}.
+func TestFormatGate(t *testing.T) {
+	cmd := readFormatCommand(t)
+
+	const brokenGo = "package main\nfunc broken( {\n"
+	const okGo = "package main\n"
+	// goimports/gofmt-correct would be: "package main\n\nfunc f() {}\n"
+	// An unformatted file: missing the blank line + extra spaces.
+	const unformattedGo = "package main\nfunc  f() {}\n"
+
+	cases := []struct {
+		name     string
+		setup    func(dir string) error
+		wantExit int
+		why      string
+	}{
+		{
+			name: "parse error in main tree fails the gate (D3)",
+			setup: func(dir string) error {
+				return writeFiles(dir, map[string]string{
+					"ok.go":     okGo,
+					"broken.go": brokenGo,
+				})
+			},
+			wantExit: 1,
+			why:      "main-tree parse errors must fail; this is the D3 fix",
+		},
+		{
+			name: "parse error confined to .worktrees/ does NOT fail the gate (D5)",
+			setup: func(dir string) error {
+				return writeFiles(dir, map[string]string{
+					"ok.go":                                okGo,
+					".worktrees/branch/internal/broken.go": brokenGo,
+				})
+			},
+			wantExit: 0,
+			why:      ".worktrees/ parse errors must be excluded; this is the D5 fix",
+		},
+		{
+			name: "unformatted file in main tree fails the gate",
+			setup: func(dir string) error {
+				return writeFiles(dir, map[string]string{
+					"ok.go":          okGo,
+					"unformatted.go": unformattedGo,
+				})
+			},
+			wantExit: 1,
+			why:      "main-tree unformatted files must fail (the gate's primary purpose)",
+		},
+		{
+			name: "unformatted file confined to .worktrees/ does NOT fail the gate",
+			setup: func(dir string) error {
+				return writeFiles(dir, map[string]string{
+					"ok.go": okGo,
+					".worktrees/branch/internal/unformatted.go": unformattedGo,
+				})
+			},
+			wantExit: 0,
+			why:      ".worktrees/ unformatted files must be excluded (the original .worktrees/ exclusion intent)",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := tc.setup(dir); err != nil {
+				t.Fatalf("setup: %v", err)
+			}
+			exitCode := runShell(t, dir, cmd)
+			if exitCode != tc.wantExit {
+				t.Fatalf("format gate exit = %d, want %d (%s)\nCommand: %s",
+					exitCode, tc.wantExit, tc.why, cmd)
+			}
+		})
+	}
+}
+
+// readFormatCommand finds .no-mistakes.yaml by walking up from the test's
+// working directory and extracts the `format:` command literal.
+func readFormatCommand(t *testing.T) string {
+	t.Helper()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	dir := cwd
+	for {
+		candidate := filepath.Join(dir, ".no-mistakes.yaml")
+		if _, err := os.Stat(candidate); err == nil {
+			return extractFormatCommand(t, candidate)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf(".no-mistakes.yaml not found walking up from %s", cwd)
+		}
+		dir = parent
+	}
+}
+
+// extractFormatCommand pulls the value of `format:` out of .no-mistakes.yaml
+// without pulling in a YAML dependency. The YAML uses single-quoted strings
+// for `format:` because the command itself contains double quotes.
+func extractFormatCommand(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	// Match a line of the form:
+	//   format: 'literal'
+	// or
+	//   format: "literal"
+	re := regexp.MustCompile(`(?m)^\s*format:\s*'([^']*)'\s*$|^\s*format:\s*"([^"]*)"\s*$`)
+	m := re.FindStringSubmatch(string(data))
+	if m == nil {
+		t.Fatalf("could not find `format:` command in %s", path)
+	}
+	for _, g := range m[1:] {
+		if g != "" {
+			return g
+		}
+	}
+	t.Fatalf("matched `format:` line but captured empty literal in %s", path)
+	return ""
+}
+
+// runShell executes the command via /bin/sh in dir and returns its exit code.
+func runShell(t *testing.T, dir, command string) int {
+	t.Helper()
+
+	c := exec.Command("/bin/sh", "-c", command)
+	c.Dir = dir
+	output, err := c.CombinedOutput()
+	if err != nil {
+		var ee *exec.ExitError
+		if asExitError(err, &ee) {
+			t.Logf("shell stderr/stdout: %s", strings.TrimSpace(string(output)))
+			return ee.ExitCode()
+		}
+		t.Fatalf("shell run error: %v (output: %s)", err, output)
+	}
+	return 0
+}
+
+// asExitError unwraps to *exec.ExitError without pulling in errors.As's
+// generic machinery (keeps the test minimal).
+func asExitError(err error, out **exec.ExitError) bool {
+	if ee, ok := err.(*exec.ExitError); ok {
+		*out = ee
+		return true
+	}
+	return false
+}
+
+// writeFiles writes a map of relative-path → contents under root.
+func writeFiles(root string, files map[string]string) error {
+	for rel, contents := range files {
+		full := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(full, []byte(contents), 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/spawn/format_gate_test.go
+++ b/internal/spawn/format_gate_test.go
@@ -1,6 +1,7 @@
 package spawn
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -132,6 +133,14 @@ func readFormatCommand(t *testing.T) string {
 // extractFormatCommand pulls the value of `format:` out of .no-mistakes.yaml
 // without pulling in a YAML dependency. The YAML uses single-quoted strings
 // for `format:` because the command itself contains double quotes.
+//
+// Constraint: the regex below only matches single-line YAML scalars (the
+// `[^']*` / `[^"]*` classes do not span newlines). If `format:` is ever
+// converted to a YAML block scalar (`|` or `>`), this function will fail
+// with the "unsupported YAML style" message below — it will NOT silently
+// pass an empty or partial command. The single-line form is sufficient
+// for the foreseeable use of .no-mistakes.yaml, so the dependency-free
+// regex is preferred over importing a YAML parser.
 func extractFormatCommand(t *testing.T, path string) string {
 	t.Helper()
 
@@ -147,7 +156,10 @@ func extractFormatCommand(t *testing.T, path string) string {
 	re := regexp.MustCompile(`(?m)^\s*format:\s*'([^']*)'\s*$|^\s*format:\s*"([^"]*)"\s*$`)
 	m := re.FindStringSubmatch(string(data))
 	if m == nil {
-		t.Fatalf("could not find `format:` command in %s", path)
+		t.Fatalf("could not find single-line quoted `format:` command in %s — "+
+			"this test does not support YAML block scalars (| or >); convert "+
+			"the value back to a single-line single- or double-quoted string, "+
+			"or extend this regex to handle the new style.", path)
 	}
 	for _, g := range m[1:] {
 		if g != "" {
@@ -166,24 +178,18 @@ func runShell(t *testing.T, dir, command string) int {
 	c.Dir = dir
 	output, err := c.CombinedOutput()
 	if err != nil {
+		// errors.As walks the wrapping chain, so this stays correct even
+		// if a future stdlib change wraps the *exec.ExitError. A direct
+		// type assertion would silently fall through to the t.Fatalf below
+		// in that case, hiding the real exit code.
 		var ee *exec.ExitError
-		if asExitError(err, &ee) {
+		if errors.As(err, &ee) {
 			t.Logf("shell stderr/stdout: %s", strings.TrimSpace(string(output)))
 			return ee.ExitCode()
 		}
 		t.Fatalf("shell run error: %v (output: %s)", err, output)
 	}
 	return 0
-}
-
-// asExitError unwraps to *exec.ExitError without pulling in errors.As's
-// generic machinery (keeps the test minimal).
-func asExitError(err error, out **exec.ExitError) bool {
-	if ee, ok := err.(*exec.ExitError); ok {
-		*out = ee
-		return true
-	}
-	return false
 }
 
 // writeFiles writes a map of relative-path → contents under root.

--- a/internal/spawn/format_gate_test.go
+++ b/internal/spawn/format_gate_test.go
@@ -22,9 +22,10 @@ import (
 // code explicitly exposed D5: parse errors confined to .worktrees/ also
 // failed the gate, because parse errors go to stderr with rc=2 regardless
 // of which file produced them, and post-hoc stdout filtering on gofmt -l's
-// file list cannot reach them. The current command filters at the file-
-// enumeration level (find -not -path) so .worktrees/ is pruned before gofmt
-// runs.
+// file list cannot reach them. The current command excludes .worktrees/ at
+// the file-enumeration level (find -prune) so find never descends into the
+// directory and gofmt is never invoked on its contents — neither parse
+// errors nor unformatted files inside .worktrees/ can reach the gate.
 //
 // This test reads the live `format:` command from .no-mistakes.yaml so it
 // guards the *current* gate, not a frozen historical snapshot. The four


### PR DESCRIPTION
## Summary

- **D2** (`a048d71`): Replace U+201D typographic quote in `internal/spawn/command.go:64` with an ASCII rephrasing of the comment. The original fix using ASCII apostrophes was rewritten back by gofmt due to a rune-literal-simplification quirk in comments; rephrase to avoid the sequence entirely.
- **D3** (`a048d71`): Replace the format gate's pipe with explicit exit-code capture. `gofmt -l . | grep -v ^\.worktrees/` masked gofmt's non-zero exit on parse errors (the pipe replaces gofmt's exit code with grep's, and `$(...)` swallows stderr), causing the gate to pass on broken Go files.
- **D5** (`78dc39b`): The post-`a048d71` form failed on parse errors anywhere in the tree, including under `.worktrees/`, defeating the `.worktrees/` exclusion. Filter at the file-enumeration level (`find -not -path "./.worktrees/*"`) rather than post-hoc on stdout, so `gofmt` never sees worktree files at all.
- **Regression test** (`78dc39b`): `internal/spawn/format_gate_test.go` reads the live `format:` command from `.no-mistakes.yaml` at runtime and asserts the cartesian product of {parse error, unformatted} × {main tree, `.worktrees/`} — 4 sub-tests that prevent recurrence of D3 or D5.

## Refs

- `Refs seungpyoson/claude-config#774` (defects D2, D3, D5)
- D5 was discovered while building the D3 regression test in this PR — see [comment 4414399769 on #774](https://github.com/seungpyoson/claude-config/issues/774#issuecomment-4414399769) for the full mechanism.
- This PR does not close #774. #774 will be closed manually after all three follow-up PRs merge with a diff-by-diff audit per `learnings-permanent.md` rule 10.

## Test plan

- [x] `go test -run TestFormatGate -v ./internal/spawn/` → 4/4 sub-tests pass
- [x] `go test ./internal/spawn/` → all green
- [x] `go test ./...` → all green
- [x] `go vet ./...` → exit 0
- [x] `gofmt -l internal/spawn/command.go` → no output (D2 ASCII-clean, gofmt-stable)
- [x] `find . -name '*.go' -not -path './.worktrees/*' -exec gofmt -l {} +` → no output (full repo clean under new gate)
- [ ] CI green
- [ ] No regression on `.worktrees/` exclusion semantics (covered by sub-test 4)

## Verification details

D2 (comment corruption): I verified `internal/spawn/command.go:64` is pure ASCII via `od -c` and confirmed `gofmt -l command.go` returns no output. The new comment phrasing avoids the `'\''` rune sequence inside comments that gofmt was rewriting to U+201D.

D3 (gofmt exit code): the regression test's `parse_error_in_main_tree_fails_the_gate` sub-test exits with code 1 — exactly the behavior the original gate was failing to provide.

D5 (worktree parse error): the regression test's `parse_error_confined_to_.worktrees/_does_NOT_fail_the_gate` sub-test exits 0, confirming `find` prunes worktrees before gofmt runs and parse errors confined there no longer leak through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
